### PR TITLE
fix: Corregir inicialización de campos latitud y longitud en formular…

### DIFF
--- a/components/forms/UserEditForm.tsx
+++ b/components/forms/UserEditForm.tsx
@@ -159,6 +159,8 @@ export function UserEditForm({ usuario, ocupaciones, profesiones, paises, estado
         estado_id: usuario.direccion.parroquia?.municipio?.estado?.id || "",
         municipio_id: usuario.direccion.parroquia?.municipio?.id || "",
         parroquia_id: usuario.direccion.parroquia?.id || "none",
+        lat: usuario.direccion.latitud ?? undefined,
+        lng: usuario.direccion.longitud ?? undefined,
       } : {
         calle: "",
         barrio: "",


### PR DESCRIPTION
…io de edición

### Problema:
Los campos de latitud y longitud en la página de edición de usuario aparecían vacíos, aunque el mapa sí mostraba la ubicación correcta guardada en la base de datos.

### Causa:
Los valores por defecto del formulario (defaultValues en react-hook-form) no incluían las propiedades  y  del objeto , por lo que estos campos no se inicializaban con los datos guardados.

### Solución:
- Agregado  y  a los defaultValues del formulario
- Los campos ahora se llenan correctamente con las coordenadas guardadas al cargar la página de edición

### Resultado:
✅ Los campos de latitud y longitud ahora muestran los valores correctos ✅ El mapa sigue funcionando correctamente
✅ La funcionalidad de actualización de coordenadas preservada

## Qué incluye

- Gestión de miembros de grupo con permisos en BD
- Detalle de grupo: botón “Añadir miembro”, cambiar rol y quitar miembro
- Endpoints API para buscar/agregar/actualizar/eliminar miembros
- Migraciones SQL para RPCs seguras y fix de permisos en detalle

## Migraciones a aplicar

- 20250906110000_permisos_gestion_miembros.sql
- 20250906111510_grupo_detalle_y_miembros.sql
- 20250906113000_miembros_update_delete.sql
- 20250906114500_fix_obtener_detalle_grupo_auth.sql

Aplicar con:

```
supabase db push
```

## Checklist de verificación

- [ ] Como admin, puedo ver el detalle del grupo
- [ ] Puedo buscar personas y agregarlas como miembros
- [ ] Puedo cambiar el rol del miembro (Líder/Colíder/Miembro)
- [ ] Puedo quitar a un miembro, con confirmación
- [ ] El botón “Añadir miembro” solo aparece si tengo permisos

## Pruebas rápidas (opcional)

Con la app corriendo y un GROUP_ID válido:

```
BASE_URL=http://localhost:3000 GROUP_ID=<uuid> node scripts/smoke-members-api.mjs
```
