### PR TITLE
feat: Agregar coordenadas específicas para municipio Iribarren

### DIFF
--- a/components/forms/UserEditForm.tsx
+++ b/components/forms/UserEditForm.tsx
@@ -269,6 +269,16 @@ export function UserEditForm({ usuario, ocupaciones, profesiones, paises, estado
     const estadoNombre = estados.find(e => e.id === estadoId)?.nombre
     const municipioNombre = municipios.find(m => m.id === municipioId)?.nombre
 
+    // Coordenadas específicas para municipio Iribarren
+    if (municipioNombre?.toLowerCase() === 'iribarren') {
+      const iribarrenLat = 10.078726345593038
+      const iribarrenLng = -69.28487917698043
+      setMapCenter({ lat: iribarrenLat, lng: iribarrenLng })
+      setValue("direccion.lat", iribarrenLat, { shouldValidate: true, shouldDirty: true })
+      setValue("direccion.lng", iribarrenLng, { shouldValidate: true, shouldDirty: true })
+      return
+    }
+
     // Construir dirección solo si hay al menos municipio, estado o país
     const partes = [municipioNombre, estadoNombre, paisNombre].filter(Boolean)
     const direccionStr = partes.join(", ")


### PR DESCRIPTION
### Funcionalidad implementada:
- Cuando se selecciona el municipio 'Iribarren', el mapa se centra automáticamente en las coordenadas específicas
- Latitud: 10.078726345593038
- Longitud: -69.28487917698043
- Los campos de latitud y longitud se actualizan automáticamente
- Prioridad sobre geocodificación automática para este municipio específico

### Cambios técnicos:
- Agregada validación específica para municipio Iribarren en UserEditForm.tsx
- Coordenadas hardcodeadas para mayor precisión
- Actualización inmediata del centro del mapa y campos del formulario

## Qué incluye

- Gestión de miembros de grupo con permisos en BD
- Detalle de grupo: botón “Añadir miembro”, cambiar rol y quitar miembro
- Endpoints API para buscar/agregar/actualizar/eliminar miembros
- Migraciones SQL para RPCs seguras y fix de permisos en detalle

## Migraciones a aplicar

- 20250906110000_permisos_gestion_miembros.sql
- 20250906111510_grupo_detalle_y_miembros.sql
- 20250906113000_miembros_update_delete.sql
- 20250906114500_fix_obtener_detalle_grupo_auth.sql

Aplicar con:

```
supabase db push
```

## Checklist de verificación

- [ ] Como admin, puedo ver el detalle del grupo
- [ ] Puedo buscar personas y agregarlas como miembros
- [ ] Puedo cambiar el rol del miembro (Líder/Colíder/Miembro)
- [ ] Puedo quitar a un miembro, con confirmación
- [ ] El botón “Añadir miembro” solo aparece si tengo permisos

## Pruebas rápidas (opcional)

Con la app corriendo y un GROUP_ID válido:

```
BASE_URL=http://localhost:3000 GROUP_ID=<uuid> node scripts/smoke-members-api.mjs
```
