### PR TITLE
Revert "Fix/UI improvements sep 2025"

### DIFF
--- a/app/api/grupos/[id]/miembros/[usuarioId]/route.ts
+++ b/app/api/grupos/[id]/miembros/[usuarioId]/route.ts
@@ -5,7 +5,7 @@ export async function PATCH(req: NextRequest, { params }: { params: Promise<{ id
   try {
   const { id: grupoId, usuarioId } = await params;
     const body = await req.json();
-  const rol: "Líder" | "Colíder" | "Miembro" = body?.rol; // UI muestra 'Aprendiz'
+    const rol: "Líder" | "Colíder" | "Miembro" = body?.rol;
     if (!rol) return NextResponse.json({ error: "rol requerido" }, { status: 400 });
 
     const supabase = await createSupabaseServerClient();

--- a/app/api/grupos/[id]/miembros/route.ts
+++ b/app/api/grupos/[id]/miembros/route.ts
@@ -6,7 +6,7 @@ export async function POST(req: NextRequest, { params }: { params: Promise<{ id:
     const { id: grupoId } = await params;
     const body = await req.json();
     const usuarioId: string = body?.usuarioId;
-  const rol: "Líder" | "Colíder" | "Miembro" = body?.rol || "Miembro"; // UI muestra 'Aprendiz'
+    const rol: "Líder" | "Colíder" | "Miembro" = body?.rol || "Miembro";
     const incluirConyuge: boolean = body?.incluirConyuge || false;
     
     if (!usuarioId) return NextResponse.json({ error: "usuarioId requerido" }, { status: 400 });

--- a/app/dashboard/grupos/[id]/GrupoDetailClient.tsx
+++ b/app/dashboard/grupos/[id]/GrupoDetailClient.tsx
@@ -223,11 +223,11 @@ export default function GrupoDetailClient({ grupo, id }: GrupoDetailClientProps)
                 </Link>
               )}
               
-              {grupo.puede_editar_ui && (
-                <Link href={`/dashboard/grupos/${id}/edit`} className="col-span-1">
-                  <BotonSistema variante="outline" className="w-full h-10 text-sm" data-testid="btn-editar-grupo">
+              {grupo.puede_editar_ui && (grupo.rol_en_grupo?.toLowerCase() !== 'miembro') && (
+                <Link href={`/dashboard/grupos/${id}/edit`}>
+                  <BotonSistema variante="outline" className="w-full h-10 text-sm">
                     <Edit className="w-4 h-4" />
-                    <span className="ml-2 hidden sm:inline">Editar Grupo</span>
+                    <span className="ml-2 hidden sm:inline">Editar</span>
                     <span className="ml-2 sm:hidden">Editar</span>
                   </BotonSistema>
                 </Link>
@@ -322,7 +322,7 @@ export default function GrupoDetailClient({ grupo, id }: GrupoDetailClientProps)
                           </SelectTrigger>
                           <SelectContent>
                             <SelectItem value="Líder">Líder</SelectItem>
-                            <SelectItem value="Colíder">Aprendiz</SelectItem>
+                            <SelectItem value="Colíder">Colíder</SelectItem>
                             <SelectItem value="Miembro">Miembro</SelectItem>
                           </SelectContent>
                         </Select>
@@ -339,7 +339,7 @@ export default function GrupoDetailClient({ grupo, id }: GrupoDetailClientProps)
                       </>
                     ) : (
                       <BadgeSistema variante="default" tamaño="sm">
-                        {miembro.rol === 'Colíder' ? 'Aprendiz' : miembro.rol}
+                        {miembro.rol}
                       </BadgeSistema>
                     )}
                   </div>
@@ -382,7 +382,7 @@ export default function GrupoDetailClient({ grupo, id }: GrupoDetailClientProps)
                         </SelectTrigger>
                         <SelectContent>
                           <SelectItem value="Líder">Líder</SelectItem>
-                          <SelectItem value="Colíder">Aprendiz</SelectItem>
+                          <SelectItem value="Colíder">Colíder</SelectItem>
                           <SelectItem value="Miembro">Miembro</SelectItem>
                         </SelectContent>
                       </Select>

--- a/app/dashboard/grupos/create/page.tsx
+++ b/app/dashboard/grupos/create/page.tsx
@@ -25,7 +25,7 @@ export default async function CreateGroupPage() {
 
   // Si no es admin/pastor/director-general ni director-etapa, redirigir a listado
   if (!esAdminOPastorODG && !esDirectorEtapa) {
-  // Usuarios Líder / Aprendiz / Miembro no pueden crear
+    // Usuarios Líder / Colíder / Miembro no pueden crear
     return (
       <div className="p-6 text-sm text-red-600">No tienes permisos para crear grupos.</div>
     )

--- a/components/forms/GroupEditForm.tsx
+++ b/components/forms/GroupEditForm.tsx
@@ -88,7 +88,7 @@ export default function GroupEditForm({
   });
 
   const dias = [
-    "Lunes","Miércoles","Jueves","Viernes","Sábado"
+    "Lunes","Martes","Miércoles","Jueves","Viernes","Sábado","Domingo"
   ];
   const horas = [
     "05:00 AM","05:30 AM","06:00 AM","06:30 AM","07:00 AM","07:30 AM",

--- a/components/grupos/GroupAudit.client.tsx
+++ b/components/grupos/GroupAudit.client.tsx
@@ -71,11 +71,6 @@ export default function GroupAudit({ grupoId }: { grupoId: string }) {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [grupoId, action, actor, desde, hasta]);
 
-  const rolLabel = (rol: string | null | undefined) => {
-    if (!rol) return rol;
-    return rol === 'Colíder' ? 'Aprendiz' : rol;
-  };
-
   function renderDiff(it: AuditItem) {
     const oldRol = it.old_data?.rol ?? null;
     const newRol = it.new_data?.rol ?? null;
@@ -85,11 +80,11 @@ export default function GroupAudit({ grupoId }: { grupoId: string }) {
           <span className="font-medium text-gray-700">Cambio de rol:</span>
           <div className="flex items-center gap-2 mt-1">
             <BadgeSistema variante={oldRol ? "info" : "default"}>
-              {oldRol ? rolLabel(oldRol) : "Sin rol"}
+              {oldRol ?? "Sin rol"}
             </BadgeSistema>
             <span className="text-gray-400">→</span>
             <BadgeSistema variante={newRol ? "success" : "default"}>
-              {newRol ? rolLabel(newRol) : "Sin rol"}
+              {newRol ?? "Sin rol"}
             </BadgeSistema>
           </div>
         </div>
@@ -108,8 +103,8 @@ export default function GroupAudit({ grupoId }: { grupoId: string }) {
       it.actor_nombre || "",
       it.usuario_nombre || it.usuario_id,
       it.usuario_email || "",
-      rolLabel(it.old_data?.rol ?? "") || "",
-      rolLabel(it.new_data?.rol ?? "") || "",
+      it.old_data?.rol ?? "",
+      it.new_data?.rol ?? "",
     ]);
     const csv = [headers.join(','), ...rows.map(r => r.map(v => `"${String(v).replace(/"/g,'""')}"`).join(','))].join('\n');
     const blob = new Blob([csv], { type: 'text/csv;charset=utf-8;' });
@@ -146,7 +141,7 @@ export default function GroupAudit({ grupoId }: { grupoId: string }) {
               onClick={() => load(0)}
               variante="primario"
               tamaño="md"
-              disabled={loading}
+              deshabilitado={loading}
               className="w-full sm:w-auto"
             >
               <Filter className="w-4 h-4 mr-2" />
@@ -286,7 +281,7 @@ export default function GroupAudit({ grupoId }: { grupoId: string }) {
             onClick={() => load(page + 1)}
             variante={canLoadMore ? "primario" : "outline"}
             tamaño="md"
-            disabled={loading || !canLoadMore}
+            deshabilitado={loading || !canLoadMore}
             className="w-full sm:w-auto"
           >
             {loading ? "Cargando..." : canLoadMore ? "Cargar más" : "No hay más"}

--- a/components/grupos/GroupAuditPreview.client.tsx
+++ b/components/grupos/GroupAuditPreview.client.tsx
@@ -56,10 +56,7 @@ export default function GroupAuditPreview({ grupoId }: { grupoId: string }) {
     if (oldRol || newRol) {
       return (
         <div className="text-xs text-gray-600">
-          {"Rol: "}
-          <span className="font-medium">{oldRol === 'Colíder' ? 'Aprendiz' : (oldRol ?? "-")}</span>
-          {" → "}
-          <span className="font-medium">{newRol === 'Colíder' ? 'Aprendiz' : (newRol ?? "-")}</span>
+          Rol: <span className="font-medium">{oldRol ?? "-"}</span> → <span className="font-medium">{newRol ?? "-"}</span>
         </div>
       );
     }

--- a/components/modals/AddMemberModal.tsx
+++ b/components/modals/AddMemberModal.tsx
@@ -25,9 +25,9 @@ interface Props {
 
 const roles: Array<{ value: "Líder" | "Colíder" | "Miembro"; label: string }> = [
   { value: "Líder", label: "Líder" },
-  { value: "Colíder", label: "Aprendiz" },
+  { value: "Colíder", label: "Colíder" },
   { value: "Miembro", label: "Miembro" },
-]
+];
 
 export default function AddMemberModal({ isOpen, onClose, grupoId, segmentoNombre }: Props) {
   const [query, setQuery] = useState("");

--- a/components/modals/ConfirmationModal.tsx
+++ b/components/modals/ConfirmationModal.tsx
@@ -3,7 +3,6 @@
 import { AlertTriangle, Loader2 } from "lucide-react"
 import { Button } from "@/components/ui/button"
 import React from "react"
-import { createPortal } from "react-dom"
 
 // Usa un div con estilos glassmorphism en vez de GlassCard si no existe el componente
 export function GlassCard({ className = "", children }: { className?: string; children: React.ReactNode }) {
@@ -27,9 +26,6 @@ interface ConfirmationModalProps {
   title: string
   message: string
   isLoading?: boolean
-  confirmLabel?: string
-  // Si se pasa, el botón de confirmar será un submit de este formulario (server action)
-  confirmFormAction?: (formData: FormData) => Promise<void> | void
 }
 
 export function ConfirmationModal({
@@ -39,16 +35,14 @@ export function ConfirmationModal({
   title,
   message,
   isLoading = false,
-  confirmLabel = "Confirmar Borrado",
-  confirmFormAction,
 }: ConfirmationModalProps) {
   if (!isOpen) return null
 
-  const content = (
-    <div className="fixed inset-0 z-50 grid place-items-center bg-black/40 backdrop-blur-sm overflow-y-auto">
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/40 backdrop-blur-sm">
       <div className="absolute inset-0 bg-white/20 backdrop-blur-[6px] pointer-events-none" />
-      <div className="relative z-10 w-full max-w-sm md:max-w-md mx-4 my-8">
-        <GlassCard className="p-6 md:p-8 flex flex-col items-center gap-6">
+      <div className="relative z-10 w-full max-w-md mx-auto">
+        <GlassCard className="p-8 flex flex-col items-center gap-6">
           <AlertTriangle className="w-12 h-12 text-orange-500 mb-2" />
           <h2 className="text-xl font-bold text-gray-800 text-center">{title}</h2>
           <p className="text-gray-600 text-center">{message}</p>
@@ -62,39 +56,19 @@ export function ConfirmationModal({
             >
               Cancelar
             </Button>
-            {confirmFormAction ? (
-              <form action={confirmFormAction} className="flex-1">
-                <Button
-                  type="submit"
-                  variant="destructive"
-                  className="w-full flex items-center justify-center"
-                  disabled={isLoading}
-                >
-                  {isLoading && <Loader2 className="w-4 h-4 mr-2 animate-spin" />}
-                  {confirmLabel}
-                </Button>
-              </form>
-            ) : (
-              <Button
-                type="button"
-                variant="destructive"
-                className="flex-1 flex items-center justify-center"
-                onClick={onConfirm}
-                disabled={isLoading}
-              >
-                {isLoading && <Loader2 className="w-4 h-4 mr-2 animate-spin" />}
-                {confirmLabel}
-              </Button>
-            )}
+            <Button
+              type="button"
+              variant="destructive"
+              className="flex-1 flex items-center justify-center"
+              onClick={onConfirm}
+              disabled={isLoading}
+            >
+              {isLoading && <Loader2 className="w-4 h-4 mr-2 animate-spin" />}
+              Confirmar Borrado
+            </Button>
           </div>
         </GlassCard>
       </div>
     </div>
   )
-
-  // Portalizar al body para evitar contenedores con position/overflow que impidan el centrado (especialmente en móvil)
-  if (typeof document !== "undefined") {
-    return createPortal(content, document.body)
-  }
-  return content
 }

--- a/components/ui/header-movil.tsx
+++ b/components/ui/header-movil.tsx
@@ -1,13 +1,11 @@
 "use client"
 
-import React, { useState } from 'react'
+import React from 'react'
 import Link from 'next/link'
 import { logout } from "@/lib/actions/auth.actions"
 import { LogOut, User } from 'lucide-react'
-import { ConfirmationModal } from '@/components/modals/ConfirmationModal'
 
 export function HeaderMovil() {
-  const [confirmLogoutOpen, setConfirmLogoutOpen] = useState(false)
   return (
     <div className="md:hidden fixed top-0 left-0 right-0 z-40 bg-white/95 backdrop-blur-xl border-b border-gray-200/50 shadow-sm">
       <div className="flex items-center justify-between px-4 py-3 safe-area-pt">
@@ -29,24 +27,16 @@ export function HeaderMovil() {
           </Link>
           
           {/* Botón de logout */}
-          <button
-            type="button"
-            onClick={() => setConfirmLogoutOpen(true)}
-            className="p-2 rounded-lg text-gray-600 hover:text-orange-600 hover:bg-orange-50/50 transition-all duration-200"
-          >
-            <LogOut className="w-5 h-5" />
-          </button>
+          <form action={logout}>
+            <button
+              type="submit"
+              className="p-2 rounded-lg text-gray-600 hover:text-orange-600 hover:bg-orange-50/50 transition-all duration-200"
+            >
+              <LogOut className="w-5 h-5" />
+            </button>
+          </form>
         </div>
       </div>
-      <ConfirmationModal
-        isOpen={confirmLogoutOpen}
-        onClose={() => setConfirmLogoutOpen(false)}
-        onConfirm={() => setConfirmLogoutOpen(false)}
-        title="Cerrar sesión"
-        message="¿Seguro que deseas cerrar tu sesión?"
-        confirmLabel="Sí, cerrar sesión"
-        confirmFormAction={logout}
-      />
     </div>
   )
 }

--- a/components/ui/sidebar-moderna.tsx
+++ b/components/ui/sidebar-moderna.tsx
@@ -17,8 +17,6 @@ import {
   User
 } from 'lucide-react'
 import { BadgeSistema } from './sistema-diseno'
-import { logout } from '@/lib/actions/auth.actions'
-import { ConfirmationModal } from '@/components/modals/ConfirmationModal'
 import { UserAvatar } from './UserAvatar'
 import { useCurrentUser } from '@/hooks/useCurrentUser'
 
@@ -77,7 +75,6 @@ const menuItems: MenuItem[] = [
 export function SidebarModerna({ className }: SidebarModernaProps) {
   const [isCollapsed, setIsCollapsed] = useState(false)
   const [isMobile, setIsMobile] = useState(false)
-  const [confirmLogoutOpen, setConfirmLogoutOpen] = useState(false)
   const pathname = usePathname()
   const { usuario, roles, loading } = useCurrentUser()
 
@@ -321,9 +318,6 @@ export function SidebarModerna({ className }: SidebarModernaProps) {
 
           {/* Cerrar Sesión */}
           <button
-            type="button"
-            aria-label="Cerrar sesión"
-            onClick={() => setConfirmLogoutOpen(true)}
             className={cn(
               "flex items-center gap-3 px-3 py-2.5 rounded-lg transition-all duration-200 group relative w-full text-left",
               "text-gray-700 hover:bg-red-50 hover:text-red-700",
@@ -350,17 +344,6 @@ export function SidebarModerna({ className }: SidebarModernaProps) {
         </div>
       </div>
 
-      {/* Modal de confirmación de logout */}
-      <ConfirmationModal
-        isOpen={confirmLogoutOpen}
-        onClose={() => setConfirmLogoutOpen(false)}
-        onConfirm={() => setConfirmLogoutOpen(false)}
-        title="Cerrar sesión"
-        message="¿Seguro que deseas cerrar tu sesión?"
-        confirmLabel="Sí, cerrar sesión"
-        confirmFormAction={logout}
-      />
-
     </>
   )
 }
@@ -377,10 +360,4 @@ export function useSidebarModerna() {
   }, [])
 
   return { isCollapsed }
-}
-
-// Modal de confirmación de logout (portaled en el body)
-export function SidebarLogoutConfirm() {
-  const [open, setOpen] = useState(false)
-  return null
 }


### PR DESCRIPTION
Qué apliqué
reponer historial en detalles de grupo (preview y enlace a /auditoria); arreglar AuditViewer imports

En [GrupoDetailClient.tsx](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html):
El botón “Historial” ahora lleva a /dashboard/grupos/[id]/auditoria y se rotula “Auditoría”.
El preview [GroupAuditPreview](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html) vuelve a mostrarse para todos excepto rol “miembro” (si es null o distinto de “miembro”, se muestra).
[AuditViewer.client.tsx](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html) ya tenía imports correctos; quedó listo para la página de auditoría.
La página [page.tsx](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html) ya existe y usa [AuditViewer](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html).
