### PR TITLE
fix(permisos): habilita edición scoped de usuarios

### DIFF
--- a/__tests__/app/users/user-edit-permission.test.ts
+++ b/__tests__/app/users/user-edit-permission.test.ts
@@ -1,0 +1,240 @@
+import { readFileSync } from "node:fs"
+import { resolve } from "node:path"
+
+import {
+  canEditUserByScopeModel,
+  shouldShowEditAction,
+  toPermissionRpcValue,
+} from "@/app/(auth)/users/[id]/user-edit-permission"
+import type { UserEditPermissionModelInput } from "@/app/(auth)/users/[id]/user-edit-permission"
+
+describe("user detail edit visibility", () => {
+  it("shows edit only when RPC permission is explicitly true", () => {
+    expect(shouldShowEditAction(toPermissionRpcValue(true))).toBe(true)
+    expect(shouldShowEditAction(toPermissionRpcValue(false))).toBe(false)
+  })
+
+  it("fails closed when RPC result is unknown or missing", () => {
+    expect(shouldShowEditAction(toPermissionRpcValue(null))).toBe(false)
+    expect(shouldShowEditAction(toPermissionRpcValue(undefined))).toBe(false)
+  })
+})
+
+describe("puede_editar_usuario migration contract", () => {
+  const migrationPath = resolve(
+    process.cwd(),
+    "supabase/migrations/20260327_001_puede_editar_usuario.sql",
+  )
+  const sql = readFileSync(migrationPath, "utf8")
+
+  it("keeps admin, pastor and self allow paths", () => {
+    expect(sql).toContain("IF v_actor_id = p_target_user_id THEN")
+    expect(sql).toContain("rs.nombre_interno IN ('admin', 'pastor')")
+  })
+
+  it("enforces scoped leader, director-etapa and director-general checks", () => {
+    expect(sql).toContain("gm_actor.rol = 'Líder'")
+    expect(sql).toContain("sl.tipo_lider = 'director_etapa'")
+    expect(sql).toContain("public.es_director_general_de_grupo")
+    expect(sql).toContain("g.activo = true")
+    expect(sql).toContain("g.eliminado = false")
+    expect(sql).toContain("gm_objetivo.fecha_salida IS NULL")
+  })
+})
+
+describe("puede_editar_usuario semantic model", () => {
+  const activeContext: UserEditPermissionModelInput = {
+    actorId: "actor-1",
+    actorAuthId: "auth-actor-1",
+    targetUserId: "target-1",
+    targetExists: true,
+    actorExists: true,
+    actorSystemRoles: [] as string[],
+    memberships: [
+      {
+        userId: "actor-1",
+        groupId: "group-a",
+        role: "Líder",
+        estado: "activo",
+        fechaSalida: null,
+      },
+      {
+        userId: "target-1",
+        groupId: "group-a",
+        role: "Miembro",
+        estado: "activo",
+        fechaSalida: null,
+      },
+    ],
+    groups: [{ id: "group-a", activo: true, eliminado: false }],
+    directorEtapaAssignments: [],
+    segmentoLideres: [],
+    directorGeneralAllowedGroupIds: [],
+  }
+
+  it("allows admin, pastor and self", () => {
+    expect(
+      canEditUserByScopeModel({
+        ...activeContext,
+        actorSystemRoles: ["admin"],
+      }),
+    ).toBe(true)
+    expect(
+      canEditUserByScopeModel({
+        ...activeContext,
+        actorSystemRoles: ["pastor"],
+      }),
+    ).toBe(true)
+    expect(
+      canEditUserByScopeModel({
+        ...activeContext,
+        targetUserId: "actor-1",
+      }),
+    ).toBe(true)
+  })
+
+  it("allows leader only in same active group and denies outside/inactive", () => {
+    expect(canEditUserByScopeModel(activeContext)).toBe(true)
+
+    expect(
+      canEditUserByScopeModel({
+        ...activeContext,
+        memberships: [
+          activeContext.memberships[0],
+          {
+            userId: "target-1",
+            groupId: "group-b",
+            role: "Miembro",
+            estado: "activo",
+            fechaSalida: null,
+          },
+        ],
+        groups: [
+          { id: "group-a", activo: true, eliminado: false },
+          { id: "group-b", activo: true, eliminado: false },
+        ],
+      }),
+    ).toBe(false)
+
+    expect(
+      canEditUserByScopeModel({
+        ...activeContext,
+        groups: [{ id: "group-a", activo: false, eliminado: false }],
+      }),
+    ).toBe(false)
+  })
+
+  it("denies leader when target user is inactive even with overlapping group", () => {
+    expect(
+      canEditUserByScopeModel({
+        ...activeContext,
+        memberships: [
+          activeContext.memberships[0],
+          {
+            userId: "target-1",
+            groupId: "group-a",
+            role: "Miembro",
+            estado: "inactivo",
+            fechaSalida: null,
+          },
+        ],
+      }),
+    ).toBe(false)
+  })
+
+  it("allows director-etapa only in assigned groups", () => {
+    expect(
+      canEditUserByScopeModel({
+        ...activeContext,
+        memberships: [
+          {
+            userId: "target-1",
+            groupId: "group-a",
+            role: "Miembro",
+            estado: "activo",
+            fechaSalida: null,
+          },
+        ],
+        directorEtapaAssignments: [{ directorEtapaId: "de-1", groupId: "group-a" }],
+        segmentoLideres: [
+          { id: "de-1", userId: "actor-1", tipoLider: "director_etapa" },
+        ],
+      }),
+    ).toBe(true)
+
+    expect(
+      canEditUserByScopeModel({
+        ...activeContext,
+        memberships: [
+          {
+            userId: "target-1",
+            groupId: "group-b",
+            role: "Miembro",
+            estado: "activo",
+            fechaSalida: null,
+          },
+        ],
+        groups: [{ id: "group-b", activo: true, eliminado: false }],
+        directorEtapaAssignments: [{ directorEtapaId: "de-1", groupId: "group-a" }],
+        segmentoLideres: [
+          { id: "de-1", userId: "actor-1", tipoLider: "director_etapa" },
+        ],
+      }),
+    ).toBe(false)
+  })
+
+  it("allows scoped director-general and denies global broadening", () => {
+    expect(
+      canEditUserByScopeModel({
+        ...activeContext,
+        memberships: [
+          {
+            userId: "target-1",
+            groupId: "group-a",
+            role: "Miembro",
+            estado: "activo",
+            fechaSalida: null,
+          },
+        ],
+        directorGeneralAllowedGroupIds: ["group-a"],
+      }),
+    ).toBe(true)
+
+    expect(
+      canEditUserByScopeModel({
+        ...activeContext,
+        memberships: [
+          {
+            userId: "target-1",
+            groupId: "group-b",
+            role: "Miembro",
+            estado: "activo",
+            fechaSalida: null,
+          },
+        ],
+        groups: [{ id: "group-b", activo: true, eliminado: false }],
+        directorGeneralAllowedGroupIds: ["group-a"],
+      }),
+    ).toBe(false)
+  })
+
+  it("enforces DG narrowing through dg_directores_etapa when assignments exist", () => {
+    expect(
+      canEditUserByScopeModel({
+        ...activeContext,
+        memberships: [
+          {
+            userId: "target-1",
+            groupId: "group-a",
+            role: "Miembro",
+            estado: "activo",
+            fechaSalida: null,
+          },
+        ],
+        directorGeneralAllowedGroupIds: ["group-a"],
+        directorGeneralHasAssignedDirectoresEtapa: true,
+        directorGeneralAssignedDirectoresEtapaGroupIds: ["group-b"],
+      }),
+    ).toBe(false)
+  })
+})

--- a/app/(auth)/users/[id]/page.tsx
+++ b/app/(auth)/users/[id]/page.tsx
@@ -32,6 +32,7 @@ import { UserAvatar } from '@/components/ui/UserAvatar'
 import { useCurrentUser } from '@/hooks/useCurrentUser'
 import { formatPhoneForCall } from '@/lib/utils'
 import LocationPicker from "@/components/maps/LocationPicker.client"
+import { shouldShowEditAction, toPermissionRpcValue } from "./user-edit-permission"
 
 // Roles que pueden ver el botón de llamada
 const ROLES_CON_LLAMADA = ['admin', 'pastor', 'director-general', 'director-etapa']
@@ -44,13 +45,10 @@ export default function PaginaDetalleUsuario() {
   const [usuario, setUsuario] = useState<any>(null)
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState<string | null>(null)
+  const [puedeEditar, setPuedeEditar] = useState(false)
 
   // Verificar si el usuario actual puede llamar
   const puedeVerLlamada = rolesActuales.some(r => ROLES_CON_LLAMADA.includes(r))
-
-  // Roles que pueden editar usuarios (admin, pastor)
-  const ROLES_CON_EDICION = ['admin', 'pastor']
-  const puedeEditar = rolesActuales.some(r => ROLES_CON_EDICION.includes(r))
 
   // Estado para el modal de agregar familiar
   const [mostrarModalAgregar, setMostrarModalAgregar] = useState(false)
@@ -63,12 +61,30 @@ export default function PaginaDetalleUsuario() {
   const recargar = async () => {
     setLoading(true)
     setError(null)
+    setPuedeEditar(false)
     try {
       // Llama a la función RPC para obtener el detalle del usuario
       const supabase = createClient()
-      const { data, error: errorUsuario } = await supabase
-        .rpc('obtener_detalle_usuario', { p_user_id: id })
-        .single()
+
+      const [{ data: userData }, { data, error: errorUsuario }] = await Promise.all([
+        supabase.auth.getUser(),
+        supabase
+          .rpc('obtener_detalle_usuario', { p_user_id: id })
+          .single(),
+      ])
+
+      const authUserId = userData?.user?.id
+      if (authUserId) {
+        const { data: permitido, error: permisoError } = await supabase.rpc('puede_editar_usuario', {
+          p_auth_id: authUserId,
+          p_target_user_id: id,
+        })
+        if (permisoError) {
+          console.error('Error verificando permisos de edición:', permisoError)
+        } else {
+          setPuedeEditar(shouldShowEditAction(toPermissionRpcValue(permitido)))
+        }
+      }
 
       if (errorUsuario) {
         setError("Error al cargar usuario: " + errorUsuario.message)

--- a/app/(auth)/users/[id]/user-edit-permission.ts
+++ b/app/(auth)/users/[id]/user-edit-permission.ts
@@ -1,0 +1,133 @@
+export type PermissionRpcValue = boolean | null
+
+type MembershipRole = "Líder" | "Miembro"
+type MembershipState = "activo" | "inactivo"
+
+export type PermissionMembership = {
+  userId: string
+  groupId: string
+  role: MembershipRole
+  estado: MembershipState
+  fechaSalida: string | null
+}
+
+export type PermissionGroup = {
+  id: string
+  activo: boolean
+  eliminado: boolean
+}
+
+export type DirectorEtapaAssignment = {
+  directorEtapaId: string
+  groupId: string
+}
+
+export type SegmentoLider = {
+  id: string
+  userId: string
+  tipoLider: "director_etapa"
+}
+
+export type UserEditPermissionModelInput = {
+  actorId: string
+  actorAuthId: string
+  targetUserId: string
+  targetExists: boolean
+  actorExists: boolean
+  actorSystemRoles: string[]
+  memberships: PermissionMembership[]
+  groups: PermissionGroup[]
+  directorEtapaAssignments: DirectorEtapaAssignment[]
+  segmentoLideres: SegmentoLider[]
+  directorGeneralAllowedGroupIds: string[]
+  directorGeneralHasAssignedDirectoresEtapa?: boolean
+  directorGeneralAssignedDirectoresEtapaGroupIds?: string[]
+}
+
+export function toPermissionRpcValue(value: unknown): PermissionRpcValue {
+  return value === true ? true : false
+}
+
+export function shouldShowEditAction(permission: PermissionRpcValue): boolean {
+  return permission === true
+}
+
+export function canEditUserByScopeModel(input: UserEditPermissionModelInput): boolean {
+  if (!input.actorExists || !input.targetExists) {
+    return false
+  }
+
+  if (input.actorId === input.targetUserId) {
+    return true
+  }
+
+  if (input.actorSystemRoles.includes("admin") || input.actorSystemRoles.includes("pastor")) {
+    return true
+  }
+
+  const activeGroupIds = new Set(
+    input.groups.filter((group) => group.activo && !group.eliminado).map((group) => group.id),
+  )
+
+  const isActiveMembership = (membership: PermissionMembership): boolean =>
+    membership.estado === "activo" && membership.fechaSalida === null && activeGroupIds.has(membership.groupId)
+
+  const actorLeaderGroupIds = new Set(
+    input.memberships
+      .filter((membership) => membership.userId === input.actorId)
+      .filter(isActiveMembership)
+      .filter((membership) => membership.role === "Líder")
+      .map((membership) => membership.groupId),
+  )
+
+  const targetActiveGroupIds = new Set(
+    input.memberships
+      .filter((membership) => membership.userId === input.targetUserId)
+      .filter(isActiveMembership)
+      .map((membership) => membership.groupId),
+  )
+
+  for (const groupId of actorLeaderGroupIds) {
+    if (targetActiveGroupIds.has(groupId)) {
+      return true
+    }
+  }
+
+  const directorEtapaIds = new Set(
+    input.segmentoLideres
+      .filter((segmento) => segmento.userId === input.actorId && segmento.tipoLider === "director_etapa")
+      .map((segmento) => segmento.id),
+  )
+
+  const directorEtapaGroupIds = new Set(
+    input.directorEtapaAssignments
+      .filter((assignment) => directorEtapaIds.has(assignment.directorEtapaId))
+      .map((assignment) => assignment.groupId),
+  )
+
+  for (const groupId of targetActiveGroupIds) {
+    if (directorEtapaGroupIds.has(groupId)) {
+      return true
+    }
+  }
+
+  const dgScopeGroupIds = new Set(input.directorGeneralAllowedGroupIds)
+  const hasAssignedDirectoresEtapa = input.directorGeneralHasAssignedDirectoresEtapa === true
+  const dgAssignedDirectoresEtapaGroupIds = new Set(
+    input.directorGeneralAssignedDirectoresEtapaGroupIds ?? [],
+  )
+
+  for (const groupId of targetActiveGroupIds) {
+    if (!dgScopeGroupIds.has(groupId)) {
+      continue
+    }
+
+    if (hasAssignedDirectoresEtapa && !dgAssignedDirectoresEtapaGroupIds.has(groupId)) {
+      continue
+    }
+
+      return true
+  }
+
+  return false
+}

--- a/components/grupos-vida/solicitudes/modal-detalle-solicitud.tsx
+++ b/components/grupos-vida/solicitudes/modal-detalle-solicitud.tsx
@@ -94,14 +94,14 @@ export function ModalDetalleSolicitud({
 
     return (
         <div
-            className="fixed inset-0 z-50 flex items-center justify-center bg-black/40 backdrop-blur-sm p-4"
+            className="fixed inset-0 z-[60] flex items-center justify-center bg-black/40 backdrop-blur-sm p-4"
             role="dialog"
             aria-modal="true"
             aria-labelledby="modal-detalle-titulo"
             onClick={handleOverlayClick}
         >
             <div className="relative z-10 w-full max-w-lg">
-                <TarjetaSistema className="p-6 sm:p-8 flex flex-col gap-5 max-h-[90vh] overflow-y-auto">
+                <TarjetaSistema className="p-6 sm:p-8 flex flex-col gap-5 max-h-[80vh] md:max-h-[90vh] overflow-y-auto pb-24 md:pb-8">
                     {/* Header */}
                     <div className="flex items-start justify-between">
                         <TituloSistema nivel={3} id="modal-detalle-titulo">

--- a/components/grupos-vida/solicitudes/modal-procesar-solicitud.tsx
+++ b/components/grupos-vida/solicitudes/modal-procesar-solicitud.tsx
@@ -89,14 +89,14 @@ export function ModalProcesarSolicitud({
 
     return (
         <div
-            className="fixed inset-0 z-50 flex items-center justify-center bg-black/40 backdrop-blur-sm p-4"
+            className="fixed inset-0 z-[60] flex items-center justify-center bg-black/40 backdrop-blur-sm p-4"
             role="dialog"
             aria-modal="true"
             aria-labelledby="modal-procesar-titulo"
             onClick={handleOverlayClick}
         >
             <div className="relative z-10 w-full max-w-lg">
-                <TarjetaSistema className="p-6 sm:p-8 flex flex-col gap-5 max-h-[90vh] overflow-y-auto">
+                <TarjetaSistema className="p-6 sm:p-8 flex flex-col gap-5 max-h-[80vh] md:max-h-[90vh] overflow-y-auto pb-24 md:pb-8">
                     {/* Header */}
                     <div className="flex items-start justify-between">
                         <TituloSistema nivel={3} id="modal-procesar-titulo">

--- a/components/grupos-vida/solicitudes/modal-procesar-solicitud.tsx
+++ b/components/grupos-vida/solicitudes/modal-procesar-solicitud.tsx
@@ -232,10 +232,10 @@ export function ModalProcesarSolicitud({
                     />
 
                     {/* Acciones */}
-                    <div className="flex gap-3">
+                    <div className="flex flex-col-reverse sm:flex-row gap-2 sm:gap-3">
                         <BotonSistema
                             variante="outline"
-                            className="flex-1"
+                            className="w-full sm:flex-1"
                             onClick={onClose}
                             disabled={isPending}
                         >
@@ -243,7 +243,7 @@ export function ModalProcesarSolicitud({
                         </BotonSistema>
                         <BotonSistema
                             variante="outline"
-                            className="flex-1 border-destructive text-destructive hover:bg-destructive/10"
+                            className="w-full sm:flex-1 border-destructive text-destructive hover:bg-destructive/10"
                             onClick={() => handleProcesar("rechazar")}
                             disabled={isPending}
                             cargando={isPending}
@@ -253,7 +253,7 @@ export function ModalProcesarSolicitud({
                         </BotonSistema>
                         <BotonSistema
                             variante="primario"
-                            className="flex-1"
+                            className="w-full sm:flex-1"
                             onClick={() => handleProcesar("aprobar")}
                             disabled={isPending}
                             cargando={isPending}

--- a/components/modals/ConfirmationModal.tsx
+++ b/components/modals/ConfirmationModal.tsx
@@ -23,7 +23,7 @@ export function ConfirmationModal({
   if (!isOpen) return null
 
   return (
-    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/40 backdrop-blur-sm">
+    <div className="fixed inset-0 z-[60] flex items-center justify-center bg-black/40 backdrop-blur-sm">
       <div className="relative z-10 w-full max-w-md mx-auto px-4">
         <TarjetaSistema className="p-8 flex flex-col items-center gap-6">
           <AlertTriangle className="w-12 h-12 text-orange-500 mb-2" />

--- a/components/ui/alert-dialog.tsx
+++ b/components/ui/alert-dialog.tsx
@@ -36,7 +36,7 @@ function AlertDialogOverlay({
     <AlertDialogPrimitive.Overlay
       data-slot="alert-dialog-overlay"
       className={cn(
-        "data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 fixed inset-0 z-50 bg-black/50",
+        "data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 fixed inset-0 z-[60] bg-black/50",
         className
       )}
       {...props}
@@ -54,7 +54,7 @@ function AlertDialogContent({
       <AlertDialogPrimitive.Content
         data-slot="alert-dialog-content"
         className={cn(
-          "bg-background data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 fixed top-[50%] left-[50%] z-50 grid w-full max-w-[calc(100%-2rem)] translate-x-[-50%] translate-y-[-50%] gap-4 rounded-lg border p-6 shadow-lg duration-200 sm:max-w-lg",
+          "bg-background data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 fixed top-[50%] left-[50%] z-[60] grid w-full max-w-[calc(100%-2rem)] translate-x-[-50%] translate-y-[-50%] gap-4 rounded-lg border p-6 shadow-lg duration-200 sm:max-w-lg",
           className
         )}
         {...props}

--- a/components/ui/dialog.tsx
+++ b/components/ui/dialog.tsx
@@ -38,7 +38,7 @@ function DialogOverlay({
     <DialogPrimitive.Overlay
       data-slot="dialog-overlay"
       className={cn(
-        "data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 fixed inset-0 z-50 bg-black/50",
+        "data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 fixed inset-0 z-[60] bg-black/50",
         className
       )}
       {...props}
@@ -60,7 +60,7 @@ function DialogContent({
       <DialogPrimitive.Content
         data-slot="dialog-content"
         className={cn(
-          "bg-background data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 fixed top-[50%] left-[50%] z-50 grid w-full max-w-[calc(100%-2rem)] translate-x-[-50%] translate-y-[-50%] gap-4 rounded-lg border p-6 shadow-lg duration-200 sm:max-w-lg",
+          "bg-background data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 fixed top-[50%] left-[50%] z-[60] grid w-full max-w-[calc(100%-2rem)] translate-x-[-50%] translate-y-[-50%] gap-4 rounded-lg border p-6 shadow-lg duration-200 sm:max-w-lg",
           className
         )}
         {...props}

--- a/components/ui/drawer.tsx
+++ b/components/ui/drawer.tsx
@@ -37,7 +37,7 @@ function DrawerOverlay({
     <DrawerPrimitive.Overlay
       data-slot="drawer-overlay"
       className={cn(
-        "data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 fixed inset-0 z-50 bg-black/50",
+        "data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 fixed inset-0 z-[60] bg-black/50",
         className
       )}
       {...props}
@@ -56,7 +56,7 @@ function DrawerContent({
       <DrawerPrimitive.Content
         data-slot="drawer-content"
         className={cn(
-          "group/drawer-content bg-background fixed z-50 flex h-auto flex-col",
+          "group/drawer-content bg-background fixed z-[60] flex h-auto flex-col",
           "data-[vaul-drawer-direction=top]:inset-x-0 data-[vaul-drawer-direction=top]:top-0 data-[vaul-drawer-direction=top]:mb-24 data-[vaul-drawer-direction=top]:max-h-[80vh] data-[vaul-drawer-direction=top]:rounded-b-lg data-[vaul-drawer-direction=top]:border-b",
           "data-[vaul-drawer-direction=bottom]:inset-x-0 data-[vaul-drawer-direction=bottom]:bottom-0 data-[vaul-drawer-direction=bottom]:mt-24 data-[vaul-drawer-direction=bottom]:max-h-[80vh] data-[vaul-drawer-direction=bottom]:rounded-t-lg data-[vaul-drawer-direction=bottom]:border-t",
           "data-[vaul-drawer-direction=right]:inset-y-0 data-[vaul-drawer-direction=right]:right-0 data-[vaul-drawer-direction=right]:w-3/4 data-[vaul-drawer-direction=right]:border-l data-[vaul-drawer-direction=right]:sm:max-w-sm",

--- a/components/ui/filtros-usuarios.tsx
+++ b/components/ui/filtros-usuarios.tsx
@@ -110,7 +110,7 @@ export function FiltrosUsuarios({
 
       {isOpen && (
         <div
-          className="fixed inset-0 z-50 flex items-center justify-center p-4"
+          className="fixed inset-0 z-[60] flex items-center justify-center p-4"
           onClick={() => setIsOpen(false)}
           aria-hidden="true"
         >

--- a/components/ui/header-movil.tsx
+++ b/components/ui/header-movil.tsx
@@ -25,6 +25,7 @@ interface SubItem {
   label: string
   href: string
   icon?: React.ComponentType<{ className?: string }>
+  roles?: string[]
 }
 
 // ── Menu items with optional children (mirror of sidebar) ──
@@ -34,25 +35,37 @@ interface MobileMenuItem {
   icon: React.ComponentType<{ className?: string }>
   href: string
   children?: SubItem[]
+  roles?: string[]
 }
 
 const mainMenuItems: MobileMenuItem[] = [
   { id: 'dashboard', label: 'Dashboard', icon: Home, href: '/dashboard' },
-  { id: 'usuarios', label: 'Usuarios', icon: Users, href: '/users' },
+  { id: 'usuarios', label: 'Usuarios', icon: Users, href: '/users', roles: ['admin', 'pastor', 'director-general', 'director-etapa', 'lider'] },
   {
     id: 'grupos-vida',
     label: 'Grupos de Vida',
     icon: UserCheck,
     href: '/grupos-vida',
     children: [
-      { id: 'gv-casas', label: 'Casas Anfitrionas', href: '/grupos-vida/casas-anfitrionas', icon: House },
-      { id: 'gv-segmentos', label: 'Segmentos', href: '/grupos-vida/segmentos', icon: Users },
-      { id: 'gv-temporadas', label: 'Temporadas', href: '/grupos-vida/temporadas', icon: Calendar },
-      { id: 'gv-mapa', label: 'Mapa', href: '/grupos-vida/mapa', icon: MapPin },
-      { id: 'gv-reportes', label: 'Reportes', href: '/grupos-vida/reportes/asistencia-semanal', icon: BarChart3 },
-      { id: 'gv-riesgo', label: 'Dashboard Riesgo', href: '/grupos-vida/dashboard-riesgo', icon: ShieldAlert },
-      { id: 'gv-solicitudes', label: 'Solicitudes', href: '/grupos-vida/solicitudes', icon: ClipboardList },
-      { id: 'gv-config', label: 'Configuración', href: '/grupos-vida/configuracion', icon: Settings },
+      { id: 'gv-casas', label: 'Casas Anfitrionas', href: '/grupos-vida/casas-anfitrionas', icon: House, roles: ['admin', 'pastor', 'director-general', 'director-etapa'] },
+      { id: 'gv-segmentos', label: 'Segmentos', href: '/grupos-vida/segmentos', icon: Users, roles: ['admin', 'pastor', 'director-general', 'director-etapa'] },
+      { id: 'gv-temporadas', label: 'Temporadas', href: '/grupos-vida/temporadas', icon: Calendar, roles: ['admin', 'pastor', 'director-general'] },
+      { id: 'gv-mapa', label: 'Mapa', href: '/grupos-vida/mapa', icon: MapPin, roles: ['admin', 'pastor', 'director-general', 'director-etapa'] },
+      { id: 'gv-reportes', label: 'Reportes', href: '/grupos-vida/reportes/asistencia-semanal', icon: BarChart3, roles: ['admin', 'pastor', 'director-general', 'director-etapa'] },
+      { id: 'gv-riesgo', label: 'Dashboard Riesgo', href: '/grupos-vida/dashboard-riesgo', icon: ShieldAlert, roles: ['admin', 'pastor', 'director-general', 'director-etapa'] },
+      { id: 'gv-solicitudes', label: 'Solicitudes', href: '/grupos-vida/solicitudes', icon: ClipboardList, roles: ['admin', 'pastor', 'director-general', 'director-etapa'] },
+      { id: 'gv-config', label: 'Configuración', href: '/grupos-vida/configuracion', icon: Settings, roles: ['admin', 'pastor'] },
+    ],
+  },
+  {
+    id: 'configuracion-global',
+    label: 'Configuración',
+    icon: Settings,
+    href: '/configuracion',
+    roles: ['admin', 'pastor', 'director-general'],
+    children: [
+      { id: 'config-general', label: 'General', href: '/configuracion', icon: Settings, roles: ['admin', 'pastor'] },
+      { id: 'config-dg', label: 'Directores Generales', href: '/configuracion/directores-generales', icon: Users, roles: ['admin', 'pastor', 'director-general'] },
     ],
   },
 ]
@@ -207,6 +220,7 @@ export function HeaderMovil({ titulo }: HeaderMovilProps) {
       ['/grupos-vida/dashboard-riesgo', 'Dashboard Riesgo'],
       ['/grupos-vida/solicitudes', 'Solicitudes'],
       ['/grupos-vida/configuracion', 'Configuración Grupos'],
+      ['/configuracion/directores-generales', 'Directores Generales'],
       ['/configuracion', 'Configuración'],
       ['/actualizaciones', 'Actualizaciones'],
       ['/ayuda', 'Ayuda'],
@@ -424,9 +438,14 @@ export function HeaderMovil({ titulo }: HeaderMovilProps) {
         {/* ── Main Navigation with Submenus ── */}
         <nav className="flex-1 overflow-y-auto px-3 py-1">
           <ul className="space-y-0.5">
-            {mainMenuItems.map(item => {
+            {mainMenuItems
+              .filter(item => !item.roles || item.roles.some(r => roles.includes(r)))
+              .map(item => {
               const Icon = item.icon
-              const hasChildren = item.children && item.children.length > 0
+              const visibleChildren = item.children?.filter(
+                child => !child.roles || child.roles.some(r => roles.includes(r))
+              ) ?? []
+              const hasChildren = visibleChildren.length > 0
               const active = isActive(item.href)
               const isOpen = openSubmenus.has(item.id)
 
@@ -479,7 +498,7 @@ export function HeaderMovil({ titulo }: HeaderMovilProps) {
                         )}
                       >
                         <ul className="ml-4 pl-3 mt-1 mb-1 space-y-0.5 border-l border-border/50">
-                          {item.children!.map(child => {
+                          {visibleChildren.map(child => {
                             const ChildIcon = child.icon
                             const childActive = isActive(child.href)
                             return (

--- a/components/ui/sheet.tsx
+++ b/components/ui/sheet.tsx
@@ -36,7 +36,7 @@ function SheetOverlay({
     <SheetPrimitive.Overlay
       data-slot="sheet-overlay"
       className={cn(
-        "data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 fixed inset-0 z-50 bg-black/50",
+        "data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 fixed inset-0 z-[60] bg-black/50",
         className
       )}
       {...props}
@@ -58,7 +58,7 @@ function SheetContent({
       <SheetPrimitive.Content
         data-slot="sheet-content"
         className={cn(
-          "bg-background data-[state=open]:animate-in data-[state=closed]:animate-out fixed z-50 flex flex-col gap-4 shadow-lg transition ease-in-out data-[state=closed]:duration-300 data-[state=open]:duration-500",
+          "bg-background data-[state=open]:animate-in data-[state=closed]:animate-out fixed z-[60] flex flex-col gap-4 shadow-lg transition ease-in-out data-[state=closed]:duration-300 data-[state=open]:duration-500",
           side === "right" &&
             "data-[state=closed]:slide-out-to-right data-[state=open]:slide-in-from-right inset-y-0 right-0 h-full w-3/4 border-l sm:max-w-sm",
           side === "left" &&

--- a/docs/desarrollo/produccion-puede-editar-usuario.md
+++ b/docs/desarrollo/produccion-puede-editar-usuario.md
@@ -1,0 +1,69 @@
+# Despliegue seguro: `puede_editar_usuario`
+
+Este documento define cómo aplicar el ajuste de permisos de edición de usuarios sin usar Supabase Branches. La regla principal es simple: **nada se ejecuta contra producción sin backup de la función actual, revisión SQL y verificación posterior**.
+
+## Decisión
+
+- La migración `supabase/migrations/20260327_001_puede_editar_usuario.sql` **no borra datos**.
+- Solo reemplaza/crea una función y ajusta permisos de ejecución.
+- Producción debe tratarse como entorno sensible: aplicar manualmente, en horario tranquilo y con rollback listo.
+
+## Prohibido en producción
+
+- [ ] NO correr `supabase db reset --linked`.
+- [ ] NO correr `supabase db reset --db-url`.
+- [ ] NO ejecutar scripts con `DELETE`, `TRUNCATE`, `DROP`, `UPDATE` o `INSERT` salvo revisión explícita.
+- [ ] NO usar datos reales para “probar” permisos modificando membresías, roles o grupos.
+
+## Antes de aplicar
+
+1. Abrir `supabase/safety/20260327_puede_editar_usuario_preflight.sql`.
+2. Ejecutar solo las secciones **Preflight** y **Backup de función actual** en Supabase SQL Editor.
+3. Guardar la salida completa de `pg_get_functiondef(...)` en un lugar seguro.
+4. Confirmar que existen estas funciones dependientes:
+   - `public.puede_editar_usuario(uuid, uuid)` o, si no existe, documentar que se creará por primera vez.
+   - `public.es_director_general_de_grupo(uuid, uuid)`.
+5. Revisar la migración y confirmar que contiene solamente:
+   - `CREATE OR REPLACE FUNCTION`
+   - `REVOKE ALL ON FUNCTION`
+   - `GRANT EXECUTE ON FUNCTION`
+
+## Aplicación manual
+
+1. En Supabase SQL Editor, pegar el contenido de:
+   - `supabase/migrations/20260327_001_puede_editar_usuario.sql`
+2. Ejecutar una sola vez.
+3. No ejecutar ninguna otra migración en la misma ventana.
+
+## Verificación posterior
+
+Usar la sección **Smoke tests manuales** de `supabase/safety/20260327_puede_editar_usuario_preflight.sql` con UUIDs reales conocidos y de bajo riesgo.
+
+Casos mínimos:
+
+- [ ] Admin o pastor puede editar usuario objetivo.
+- [ ] Usuario puede editarse a sí mismo.
+- [ ] Líder puede editar miembro activo de grupo activo que lidera.
+- [ ] Líder NO puede editar miembro fuera de su grupo.
+- [ ] Director de etapa puede editar miembro activo de grupo asignado.
+- [ ] Director general solo puede editar dentro de su alcance DG.
+- [ ] Un usuario sin alcance recibe `false`.
+
+## Rollback
+
+Si algo falla:
+
+1. Ejecutar la definición anterior guardada desde `pg_get_functiondef(...)`.
+2. Restaurar los grants anteriores si eran distintos.
+3. Re-ejecutar smoke tests mínimos.
+
+Si no se guardó la definición anterior, **no improvisar rollback**. Frenar y revisar antes de tocar producción.
+
+## Señal de éxito
+
+La aplicación se considera segura cuando:
+
+- [ ] La migración ejecutó sin error.
+- [ ] Los smoke tests devuelven los `true/false` esperados.
+- [ ] El formulario de edición aparece solo para usuarios autorizados.
+- [ ] Las acciones de edición siguen bloqueando usuarios no autorizados.

--- a/lib/actions/solicitudes-grupo.actions.ts
+++ b/lib/actions/solicitudes-grupo.actions.ts
@@ -173,11 +173,18 @@ export async function listarSolicitudesPendientes(): Promise<
   if (esDG && userData?.user?.id) {
     const { createSupabaseAdminClient } = await import("@/lib/supabase/admin");
     const adminDb = createSupabaseAdminClient();
-    // Get DG's segment IDs
+    // Resolve auth_id → internal usuarios.id
+    const { data: usuarioInterno } = await adminDb
+      .from("usuarios")
+      .select("id")
+      .eq("auth_id", userData.user.id)
+      .single();
+    if (!usuarioInterno) return { success: true, data: [] };
+    // Get DG's segment IDs using internal usuario_id
     const { data: segmentos } = await adminDb
       .from("director_general_segmentos")
       .select("segmento_id")
-      .eq("usuario_id", userData.user.id);
+      .eq("usuario_id", usuarioInterno.id);
     const segmentoIds = (segmentos ?? []).map(s => s.segmento_id);
     if (segmentoIds.length === 0) return { success: true, data: [] };
     // Get group IDs in those segments
@@ -290,10 +297,18 @@ export async function listarSolicitudesCompletadas(): Promise<
 
   let grupoIdsPermitidos: string[] | null = null;
   if (esDG && userData?.user?.id) {
+    // Resolve auth_id → internal usuarios.id
+    const { data: usuarioInterno } = await adminDb
+      .from("usuarios")
+      .select("id")
+      .eq("auth_id", userData.user.id)
+      .single();
+    if (!usuarioInterno) return { success: true, data: [] };
+    // Get DG's segment IDs using internal usuario_id
     const { data: segmentos } = await adminDb
       .from("director_general_segmentos")
       .select("segmento_id")
-      .eq("usuario_id", userData.user.id);
+      .eq("usuario_id", usuarioInterno.id);
     const segmentoIds = (segmentos ?? []).map(s => s.segmento_id);
     if (segmentoIds.length === 0) return { success: true, data: [] };
     const { data: grupos } = await adminDb

--- a/supabase/migrations/20260327_001_puede_editar_usuario.sql
+++ b/supabase/migrations/20260327_001_puede_editar_usuario.sql
@@ -1,0 +1,117 @@
+-- ==========================================================================
+-- Migración: Ajustar función de permisos para edición de usuarios
+-- Objetivo: concentrar reglas de dominio en puede_editar_usuario con alcance
+--           por rol + membresía objetivo/actor (líder, director-etapa, DG).
+-- ==========================================================================
+
+CREATE OR REPLACE FUNCTION public.puede_editar_usuario(
+  p_auth_id uuid,
+  p_target_user_id uuid
+)
+RETURNS boolean
+LANGUAGE plpgsql
+STABLE
+SECURITY DEFINER
+SET search_path TO 'public'
+AS $$
+DECLARE
+  v_actor_id uuid;
+BEGIN
+  IF p_auth_id IS NULL OR p_target_user_id IS NULL THEN
+    RETURN FALSE;
+  END IF;
+
+  SELECT id INTO v_actor_id
+  FROM public.usuarios
+  WHERE auth_id = p_auth_id;
+
+  IF v_actor_id IS NULL THEN
+    RETURN FALSE;
+  END IF;
+
+  -- Autoedición
+  IF v_actor_id = p_target_user_id THEN
+    RETURN TRUE;
+  END IF;
+
+  -- El usuario objetivo debe existir
+  IF NOT EXISTS (SELECT 1 FROM public.usuarios WHERE id = p_target_user_id) THEN
+    RETURN FALSE;
+  END IF;
+
+  -- Regla global: Admin/Pastor
+  IF EXISTS (
+    SELECT 1
+    FROM public.usuario_roles ur
+    JOIN public.roles_sistema rs ON rs.id = ur.rol_id
+    WHERE ur.usuario_id = v_actor_id
+      AND rs.nombre_interno IN ('admin', 'pastor')
+  ) THEN
+    RETURN TRUE;
+  END IF;
+
+  -- Regla: Líder puede editar usuarios activos del mismo grupo
+  IF EXISTS (
+    SELECT 1
+    FROM public.grupo_miembros gm_actor
+    JOIN public.grupo_miembros gm_objetivo
+      ON gm_objetivo.grupo_id = gm_actor.grupo_id
+    JOIN public.grupos g
+      ON g.id = gm_actor.grupo_id
+    WHERE gm_actor.usuario_id = v_actor_id
+      AND gm_actor.rol = 'Líder'
+      AND gm_actor.estado = 'activo'
+      AND gm_actor.fecha_salida IS NULL
+      AND gm_objetivo.usuario_id = p_target_user_id
+      AND gm_objetivo.estado = 'activo'
+      AND gm_objetivo.fecha_salida IS NULL
+      AND g.activo = true
+      AND g.eliminado = false
+  ) THEN
+    RETURN TRUE;
+  END IF;
+
+  -- Regla: Director de etapa puede editar usuarios activos en sus grupos asignados
+  IF EXISTS (
+    SELECT 1
+    FROM public.director_etapa_grupos deg
+    JOIN public.segmento_lideres sl
+      ON sl.id = deg.director_etapa_id
+    JOIN public.grupo_miembros gm_objetivo
+      ON gm_objetivo.grupo_id = deg.grupo_id
+    JOIN public.grupos g
+      ON g.id = gm_objetivo.grupo_id
+    WHERE sl.usuario_id = v_actor_id
+      AND sl.tipo_lider = 'director_etapa'
+      AND gm_objetivo.usuario_id = p_target_user_id
+      AND gm_objetivo.estado = 'activo'
+      AND gm_objetivo.fecha_salida IS NULL
+      AND g.activo = true
+      AND g.eliminado = false
+  ) THEN
+    RETURN TRUE;
+  END IF;
+
+  -- Regla: Director general (scoped) via función existente por grupo
+  IF EXISTS (
+    SELECT 1
+    FROM public.grupo_miembros gm_objetivo
+    JOIN public.grupos g
+      ON g.id = gm_objetivo.grupo_id
+    WHERE gm_objetivo.usuario_id = p_target_user_id
+      AND gm_objetivo.estado = 'activo'
+      AND gm_objetivo.fecha_salida IS NULL
+      AND g.activo = true
+      AND g.eliminado = false
+      AND public.es_director_general_de_grupo(p_auth_id, gm_objetivo.grupo_id)
+  ) THEN
+    RETURN TRUE;
+  END IF;
+
+  RETURN FALSE;
+END;
+$$;
+
+-- Permisos de ejecución explícitos
+REVOKE ALL ON FUNCTION public.puede_editar_usuario(uuid, uuid) FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION public.puede_editar_usuario(uuid, uuid) TO authenticated;

--- a/supabase/safety/20260327_puede_editar_usuario_preflight.sql
+++ b/supabase/safety/20260327_puede_editar_usuario_preflight.sql
@@ -1,0 +1,161 @@
+-- ==========================================================================
+-- Preflight seguro para producción: puede_editar_usuario
+--
+-- Este archivo es de verificación/manual safety. NO aplica la migración.
+-- Las consultas de preflight son read-only. La sección de rollback es una
+-- plantilla: solo usarla pegando la definición anterior guardada.
+-- ==========================================================================
+
+-- --------------------------------------------------------------------------
+-- 1) Preflight: confirmar funciones y dependencias
+-- --------------------------------------------------------------------------
+
+select
+  to_regprocedure('public.puede_editar_usuario(uuid, uuid)') as puede_editar_usuario,
+  to_regprocedure('public.es_director_general_de_grupo(uuid, uuid)') as es_director_general_de_grupo;
+
+-- Esperado:
+-- - es_director_general_de_grupo NO debe ser null.
+-- - puede_editar_usuario normalmente NO debe ser null en producción.
+--   Si es null, detenerse y documentar que esta migración crea la función.
+
+-- --------------------------------------------------------------------------
+-- 2) Backup: guardar definición actual ANTES de aplicar la migración
+-- --------------------------------------------------------------------------
+
+with current_function as (
+  select to_regprocedure('public.puede_editar_usuario(uuid, uuid)') as function_oid
+)
+select
+  case
+    when function_oid is null then 'FUNCTION_NOT_FOUND: detenerse y documentar que esta migración creará la función por primera vez.'
+    else pg_get_functiondef(function_oid)
+  end as current_function_definition
+from current_function;
+
+-- Guardar la salida completa en un archivo/nota segura.
+-- Ese texto es el rollback principal.
+
+-- --------------------------------------------------------------------------
+-- 3) Auditoría read-only de la migración local
+-- --------------------------------------------------------------------------
+
+-- Revisión manual requerida sobre:
+-- supabase/migrations/20260327_001_puede_editar_usuario.sql
+--
+-- Permitido en esta migración:
+-- - CREATE OR REPLACE FUNCTION public.puede_editar_usuario(...)
+-- - REVOKE ALL ON FUNCTION public.puede_editar_usuario(uuid, uuid) FROM PUBLIC
+-- - GRANT EXECUTE ON FUNCTION public.puede_editar_usuario(uuid, uuid) TO authenticated
+--
+-- No debe contener:
+-- - DELETE
+-- - DROP TABLE / DROP SCHEMA
+-- - TRUNCATE
+-- - UPDATE de datos
+-- - INSERT de datos
+-- - ALTER TABLE destructivo
+
+-- --------------------------------------------------------------------------
+-- 4) Smoke tests manuales POST-aplicación
+-- --------------------------------------------------------------------------
+-- Reemplazar los UUIDs por casos reales conocidos.
+-- Cada consulta es read-only: solo ejecuta SELECT contra la RPC.
+
+-- 4.1 Admin/Pastor debe poder editar al objetivo
+-- with params as (
+--   select
+--     '<ADMIN_OR_PASTOR_AUTH_ID>'::uuid as actor_auth_id,
+--     '<TARGET_USER_ID>'::uuid as target_user_id
+-- )
+-- select 'admin_or_pastor_can_edit' as scenario,
+--        public.puede_editar_usuario(actor_auth_id, target_user_id) as allowed
+-- from params;
+-- Esperado: allowed = true
+
+-- 4.2 Usuario debe poder editarse a sí mismo
+-- with params as (
+--   select
+--     '<USER_AUTH_ID>'::uuid as actor_auth_id,
+--     '<SAME_USER_INTERNAL_ID>'::uuid as target_user_id
+-- )
+-- select 'self_edit' as scenario,
+--        public.puede_editar_usuario(actor_auth_id, target_user_id) as allowed
+-- from params;
+-- Esperado: allowed = true
+
+-- 4.3 Líder con miembro activo en su grupo debe poder editar
+-- with params as (
+--   select
+--     '<LEADER_AUTH_ID>'::uuid as actor_auth_id,
+--     '<ACTIVE_MEMBER_IN_LEADER_GROUP_USER_ID>'::uuid as target_user_id
+-- )
+-- select 'leader_same_active_group' as scenario,
+--        public.puede_editar_usuario(actor_auth_id, target_user_id) as allowed
+-- from params;
+-- Esperado: allowed = true
+
+-- 4.4 Líder fuera de alcance NO debe poder editar
+-- with params as (
+--   select
+--     '<LEADER_AUTH_ID>'::uuid as actor_auth_id,
+--     '<USER_OUTSIDE_LEADER_GROUP_USER_ID>'::uuid as target_user_id
+-- )
+-- select 'leader_outside_scope_denied' as scenario,
+--        public.puede_editar_usuario(actor_auth_id, target_user_id) as allowed
+-- from params;
+-- Esperado: allowed = false
+
+-- 4.5 Director de etapa con grupo asignado debe poder editar miembro activo
+-- with params as (
+--   select
+--     '<DIRECTOR_ETAPA_AUTH_ID>'::uuid as actor_auth_id,
+--     '<ACTIVE_MEMBER_IN_ASSIGNED_GROUP_USER_ID>'::uuid as target_user_id
+-- )
+-- select 'director_etapa_assigned_group' as scenario,
+--        public.puede_editar_usuario(actor_auth_id, target_user_id) as allowed
+-- from params;
+-- Esperado: allowed = true
+
+-- 4.6 Director general dentro de su alcance debe poder editar
+-- with params as (
+--   select
+--     '<DIRECTOR_GENERAL_AUTH_ID>'::uuid as actor_auth_id,
+--     '<ACTIVE_MEMBER_IN_DG_SCOPE_USER_ID>'::uuid as target_user_id
+-- )
+-- select 'director_general_scoped_group' as scenario,
+--        public.puede_editar_usuario(actor_auth_id, target_user_id) as allowed
+-- from params;
+-- Esperado: allowed = true
+
+-- 4.7 Director general fuera de alcance NO debe poder editar
+-- with params as (
+--   select
+--     '<DIRECTOR_GENERAL_AUTH_ID>'::uuid as actor_auth_id,
+--     '<USER_OUTSIDE_DG_SCOPE_USER_ID>'::uuid as target_user_id
+-- )
+-- select 'director_general_outside_scope_denied' as scenario,
+--        public.puede_editar_usuario(actor_auth_id, target_user_id) as allowed
+-- from params;
+-- Esperado: allowed = false
+
+-- --------------------------------------------------------------------------
+-- 5) Rollback template
+-- --------------------------------------------------------------------------
+-- Si hay que volver atrás, pegar y ejecutar AQUÍ la definición completa que
+-- salió de pg_get_functiondef(...) antes de aplicar la migración.
+--
+-- IMPORTANTE:
+-- - No inventar una función rollback a mano.
+-- - No usar DROP FUNCTION salvo revisión explícita.
+-- - Reaplicar grants anteriores si eran distintos.
+--
+-- Ejemplo de forma, NO ejecutar tal cual:
+--
+-- CREATE OR REPLACE FUNCTION public.puede_editar_usuario(...)
+-- RETURNS boolean
+-- LANGUAGE plpgsql
+-- SECURITY DEFINER
+-- AS $$
+--   -- definición anterior guardada
+-- $$;


### PR DESCRIPTION
Closes #91

## Resumen
Corrige la autorización de edición de usuarios para que líderes y directores puedan editar únicamente usuarios dentro de su alcance de grupos.

## Qué Incluye
- Nueva migración `puede_editar_usuario` con permisos scoped para líder, director-etapa y director-general.
- Visibilidad del botón Editar basada en el mismo RPC, fallando cerrado si no hay permiso explícito.
- Tests semánticos para los escenarios de permisos.
- Documentación y preflight SQL read-only para despliegue seguro en producción sin Supabase Branches.

## Motivación / Por Qué
Un líder no podía editar miembros de su propio grupo aunque ese flujo debería estar permitido. El cambio evita abrir permisos globales y mantiene la lógica centralizada en el RPC.

## Evidencia Visual (si aplica)
| Antes | Después |
|-------|---------|
| No aplica | No aplica |

## Migraciones / Base de Datos
- [ ] No aplica
- [x] Sí (orden exacto):
```text
20260327_001_puede_editar_usuario.sql
```
Notas:
- La migración no contiene `DELETE`, `TRUNCATE`, `DROP`, `UPDATE` ni `INSERT` de datos.
- Producción debe aplicar el preflight read-only y guardar backup de función antes de ejecutar la migración.

## Impacto y Riesgos
- No rompe compatibilidad esperada: conserva admin/pastor/self.
- Requiere coordinación de despliegue por cambio de RPC de permisos.
- Riesgo principal: autorización. Mitigado con scope estricto, tests semánticos y checklist de producción.

## Checklist Autor
- [x] Código formateado (Prettier/ESLint)
- [x] Sin `console.log` / debugger
- [x] Validaciones con zod para entradas nuevas
- [x] Estados loading/error/empty cubiertos
- [x] Tipos TypeScript correctos
- [ ] Migraciones probadas local
- [x] Documentación actualizada (`docs/` o README)
- [x] Variables de entorno documentadas
- [x] Rebase con `main` limpio

## Checklist Revisor
- [ ] Propósito claro
- [ ] Nombres descriptivos
- [ ] Sin lógica duplicada evidente
- [ ] Manejo adecuado de errores
- [ ] Cambios acotados al alcance
- [ ] Sin secretos / datos sensibles

## Pruebas Manuales Realizadas
- [x] `pnpm test -- --runInBand __tests__/app/users/user-edit-permission.test.ts`
- [x] `pnpm exec tsc --noEmit`
- [x] `pnpm test`

## Pendientes / Follow-up (opcional)
- Agregar harness seguro de Supabase local/seeded para ejecutar `puede_editar_usuario` contra Postgres real.
- Resolver warning preexistente de `pnpm lint` con Next 16 (`next lint`).

## Notas Adicionales
No se aplicó ninguna migración contra producción. El rollout seguro está documentado en `docs/desarrollo/produccion-puede-editar-usuario.md` y `supabase/safety/20260327_puede_editar_usuario_preflight.sql`.