### PR TITLE
fix(permisos): revoca ejecución anon de edición

### DIFF
--- a/docs/desarrollo/produccion-puede-editar-usuario.md
+++ b/docs/desarrollo/produccion-puede-editar-usuario.md
@@ -25,6 +25,7 @@ Este documento define cómo aplicar el ajuste de permisos de edición de usuario
    - `public.es_director_general_de_grupo(uuid, uuid)`.
 5. Revisar la migración y confirmar que contiene solamente:
    - `CREATE OR REPLACE FUNCTION`
+   - `REVOKE EXECUTE ON FUNCTION ... FROM anon`
    - `REVOKE ALL ON FUNCTION`
    - `GRANT EXECUTE ON FUNCTION`
 
@@ -67,3 +68,4 @@ La aplicación se considera segura cuando:
 - [ ] Los smoke tests devuelven los `true/false` esperados.
 - [ ] El formulario de edición aparece solo para usuarios autorizados.
 - [ ] Las acciones de edición siguen bloqueando usuarios no autorizados.
+- [ ] `anon` no tiene permiso `EXECUTE` sobre `public.puede_editar_usuario(uuid, uuid)`.

--- a/supabase/migrations/20260327_001_puede_editar_usuario.sql
+++ b/supabase/migrations/20260327_001_puede_editar_usuario.sql
@@ -113,5 +113,6 @@ END;
 $$;
 
 -- Permisos de ejecución explícitos
+REVOKE EXECUTE ON FUNCTION public.puede_editar_usuario(uuid, uuid) FROM anon;
 REVOKE ALL ON FUNCTION public.puede_editar_usuario(uuid, uuid) FROM PUBLIC;
 GRANT EXECUTE ON FUNCTION public.puede_editar_usuario(uuid, uuid) TO authenticated;

--- a/supabase/migrations/20260516023854_revoke_anon_puede_editar_usuario.sql
+++ b/supabase/migrations/20260516023854_revoke_anon_puede_editar_usuario.sql
@@ -1,0 +1,9 @@
+-- ==========================================================================
+-- Migración: Revocar ejecución anónima de puede_editar_usuario
+-- Contexto: producción tenía un GRANT explícito previo para anon. Revocar
+-- PUBLIC no elimina permisos explícitos asignados al rol anon.
+-- ==========================================================================
+
+REVOKE EXECUTE ON FUNCTION public.puede_editar_usuario(uuid, uuid) FROM anon;
+REVOKE ALL ON FUNCTION public.puede_editar_usuario(uuid, uuid) FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION public.puede_editar_usuario(uuid, uuid) TO authenticated;

--- a/supabase/safety/20260327_puede_editar_usuario_preflight.sql
+++ b/supabase/safety/20260327_puede_editar_usuario_preflight.sql
@@ -45,6 +45,7 @@ from current_function;
 --
 -- Permitido en esta migración:
 -- - CREATE OR REPLACE FUNCTION public.puede_editar_usuario(...)
+-- - REVOKE EXECUTE ON FUNCTION public.puede_editar_usuario(uuid, uuid) FROM anon
 -- - REVOKE ALL ON FUNCTION public.puede_editar_usuario(uuid, uuid) FROM PUBLIC
 -- - GRANT EXECUTE ON FUNCTION public.puede_editar_usuario(uuid, uuid) TO authenticated
 --


### PR DESCRIPTION
Closes #91

## Resumen
Follow-up de seguridad para trazar en repo el revoke aplicado en producción: `anon` no debe poder ejecutar `public.puede_editar_usuario(uuid, uuid)`.

## Qué Incluye
- Agrega migración local `20260516023854_revoke_anon_puede_editar_usuario.sql`, alineada con la migración aplicada en producción vía MCP.
- Actualiza la migración original para revocar explícitamente `anon` en futuras instalaciones/entornos.
- Actualiza documentación y preflight para incluir la verificación de `anon` sin `EXECUTE`.

## Motivación / Por Qué
Después de aplicar la migración en producción, la verificación mostró que `anon` conservaba un grant explícito previo. `REVOKE ... FROM PUBLIC` no elimina grants explícitos del rol `anon`, así que el revoke debe quedar documentado y versionado.

## Evidencia Visual (si aplica)
| Antes | Después |
|-------|---------|
| No aplica | No aplica |

## Migraciones / Base de Datos
- [ ] No aplica
- [x] Sí (orden exacto):
```text
20260516023854_revoke_anon_puede_editar_usuario.sql
```
Notas:
- Producción ya tiene esta migración aplicada vía MCP.
- SQL no modifica datos; solo ajusta grants de función.

## Impacto y Riesgos
- No hay cambios de datos.
- Reduce superficie de exposición: `anon` pierde ejecución de la función de permisos.
- `authenticated` conserva ejecución.

## Checklist Autor
- [x] Código formateado (Prettier/ESLint)
- [x] Sin `console.log` / debugger
- [x] Validaciones con zod para entradas nuevas
- [x] Estados loading/error/empty cubiertos
- [x] Tipos TypeScript correctos
- [x] Migraciones probadas local
- [x] Documentación actualizada (`docs/` o README)
- [x] Variables de entorno documentadas
- [x] Rebase con `main` limpio

## Checklist Revisor
- [ ] Propósito claro
- [ ] Nombres descriptivos
- [ ] Sin lógica duplicada evidente
- [ ] Manejo adecuado de errores
- [ ] Cambios acotados al alcance
- [ ] Sin secretos / datos sensibles

## Pruebas Manuales Realizadas
- [x] Verificado en producción vía MCP: `anon_can_execute = false`, `authenticated_can_execute = true`, `service_role_can_execute = true`.

## Pendientes / Follow-up (opcional)
- Ninguno para este follow-up.

## Notas Adicionales
Este PR existe para mantener el repo alineado con la corrección de grants ya aplicada en producción.