### PR TITLE
chore(supabase): add staging baseline tooling

### DIFF
--- a/scripts/generate-staging-schema-baseline.mjs
+++ b/scripts/generate-staging-schema-baseline.mjs
@@ -1,0 +1,167 @@
+#!/usr/bin/env node
+
+import { mkdir } from 'node:fs/promises'
+import { spawn, spawnSync } from 'node:child_process'
+import { dirname, resolve } from 'node:path'
+import { pathToFileURL } from 'node:url'
+
+const STAGING_PROJECT_REF = 'ebwtdjtajclzciwipevw'
+const DEFAULT_OUTPUT_FILE = 'tmp/staging-baseline/staging-schema-baseline.review.sql'
+const DEFAULT_SCHEMAS = ['public', 'storage']
+
+export function parseSchemas(value) {
+  if (!value) {
+    return [...DEFAULT_SCHEMAS]
+  }
+
+  const schemas = value
+    .split(',')
+    .map((schema) => schema.trim())
+    .filter(Boolean)
+
+  if (schemas.length === 0) {
+    throw new Error('BASELINE_SCHEMAS must include at least one schema name.')
+  }
+
+  for (const schema of schemas) {
+    if (!/^[a-zA-Z_][a-zA-Z0-9_]*$/.test(schema)) {
+      throw new Error(`Invalid schema name in BASELINE_SCHEMAS: ${schema}`)
+    }
+  }
+
+  return schemas
+}
+
+export function validateSourceDatabaseUrl(sourceUrl) {
+  if (!sourceUrl) {
+    throw new Error('PRODUCTION_DATABASE_URL is required. Set it only in the controlled operator environment.')
+  }
+
+  const normalizedSourceUrl = sourceUrl.toLowerCase()
+
+  if (normalizedSourceUrl.includes(STAGING_PROJECT_REF)) {
+    throw new Error(`PRODUCTION_DATABASE_URL appears to target staging project ref ${STAGING_PROJECT_REF}. Refusing to continue.`)
+  }
+
+  if (/[<>{}]|\.\.\.|your_|placeholder|change-?me/.test(normalizedSourceUrl)) {
+    throw new Error('PRODUCTION_DATABASE_URL appears to contain a placeholder value. Refusing to continue.')
+  }
+
+  let parsed
+  try {
+    parsed = new URL(sourceUrl)
+  } catch (error) {
+    throw new Error(`PRODUCTION_DATABASE_URL must be a valid Postgres connection URL: ${error.message}`)
+  }
+
+  if (!['postgres:', 'postgresql:'].includes(parsed.protocol)) {
+    throw new Error('PRODUCTION_DATABASE_URL must use the postgres:// or postgresql:// protocol.')
+  }
+
+  const hostname = parsed.hostname.toLowerCase()
+  const databaseName = decodeURIComponent(parsed.pathname.replace(/^\//, '')).toLowerCase()
+
+  if (!hostname || ['undefined', 'null'].includes(hostname)) {
+    throw new Error('PRODUCTION_DATABASE_URL is missing a real database host. Refusing to continue.')
+  }
+
+  if (['localhost', '127.0.0.1', '::1'].includes(hostname)) {
+    throw new Error('PRODUCTION_DATABASE_URL points to a local database. Refusing to create a staging baseline from localhost.')
+  }
+
+  if (/\b(test|example|localhost)\b/.test(hostname) || /\b(test|example|template)\b/.test(databaseName)) {
+    throw new Error('PRODUCTION_DATABASE_URL appears to target a test/example database. Refusing to continue.')
+  }
+}
+
+export function buildPgEnvironment(sourceUrl) {
+  const parsed = new URL(sourceUrl)
+  const databaseName = decodeURIComponent(parsed.pathname.replace(/^\//, ''))
+
+  return {
+    PGHOST: parsed.hostname,
+    PGPORT: parsed.port || '5432',
+    PGUSER: decodeURIComponent(parsed.username),
+    PGPASSWORD: decodeURIComponent(parsed.password),
+    PGDATABASE: databaseName || 'postgres',
+  }
+}
+
+export function buildPgDumpArgs({ outputFile, schemas }) {
+  return [
+    '--schema-only',
+    '--no-owner',
+    '--no-comments',
+    '--no-publications',
+    '--no-subscriptions',
+    ...schemas.flatMap((schema) => [`--schema=${schema}`]),
+    `--file=${outputFile}`,
+  ]
+}
+
+function assertPgDumpAvailable() {
+  const result = spawnSync('pg_dump', ['--version'], { stdio: 'ignore' })
+
+  if (result.error) {
+    throw new Error([
+      'pg_dump is required on PATH but was not found.',
+      'Install PostgreSQL client tools in the controlled operator environment before running this generator.',
+      'macOS examples: `brew install libpq` then add libpq/bin to PATH, or `brew install postgresql@16`.',
+      'Do not run this script from the current restricted environment if pg_dump is unavailable.',
+    ].join('\n'))
+  }
+}
+
+function runPgDump({ args, sourceUrl }) {
+  return new Promise((resolveRun, rejectRun) => {
+    const child = spawn('pg_dump', args, {
+      env: {
+        ...process.env,
+        ...buildPgEnvironment(sourceUrl),
+      },
+      shell: false,
+      stdio: ['ignore', 'inherit', 'inherit'],
+    })
+
+    child.on('error', rejectRun)
+    child.on('close', (code) => {
+      if (code === 0) {
+        resolveRun()
+        return
+      }
+
+      rejectRun(new Error(`pg_dump exited with status ${code}. Review the error output above.`))
+    })
+  })
+}
+
+async function main() {
+  const sourceUrl = process.env.PRODUCTION_DATABASE_URL
+  const outputFile = resolve(process.env.BASELINE_OUTPUT_FILE || DEFAULT_OUTPUT_FILE)
+  const schemas = parseSchemas(process.env.BASELINE_SCHEMAS)
+
+  console.error('WARNING: This generator exports schema metadata only and does not apply anything to staging.')
+  console.error('WARNING: Review staging-schema-baseline.review.sql before any manual staging apply.')
+  console.error(`WARNING: Refusing known staging project ref ${STAGING_PROJECT_REF} as a source.`)
+
+  validateSourceDatabaseUrl(sourceUrl)
+  assertPgDumpAvailable()
+  await mkdir(dirname(outputFile), { recursive: true })
+
+  await runPgDump({
+    args: buildPgDumpArgs({ outputFile, schemas }),
+    sourceUrl,
+  })
+
+  console.error(`Generated review artifact: ${outputFile}`)
+  console.error('Next step: run the static review checklist in docs/supabase-staging-baseline.md before any staging apply.')
+}
+
+const invokedPath = process.argv[1] ? pathToFileURL(resolve(process.argv[1])).href : ''
+
+if (import.meta.url === invokedPath) {
+  main().catch((error) => {
+    console.error(error.message)
+    process.exit(1)
+  })
+}

--- a/scripts/generate-staging-schema-baseline.test.mjs
+++ b/scripts/generate-staging-schema-baseline.test.mjs
@@ -1,0 +1,115 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+
+import {
+  buildPgDumpArgs,
+  buildPgEnvironment,
+  parseSchemas,
+  validateSourceDatabaseUrl,
+} from './generate-staging-schema-baseline.mjs'
+
+test('buildPgDumpArgs creates a schema-only pg_dump command argument list', () => {
+  const args = buildPgDumpArgs({
+    outputFile: '/tmp/staging-schema-baseline.review.sql',
+    schemas: ['public', 'storage', 'private_schema'],
+  })
+
+  assert.deepEqual(args, [
+    '--schema-only',
+    '--no-owner',
+    '--no-comments',
+    '--no-publications',
+    '--no-subscriptions',
+    '--schema=public',
+    '--schema=storage',
+    '--schema=private_schema',
+    '--file=/tmp/staging-schema-baseline.review.sql',
+  ])
+})
+
+test('buildPgDumpArgs does not include the production database URL', () => {
+  const productionDatabaseUrl = 'postgresql://operator:secret@db.production-ref.supabase.co:5432/postgres'
+
+  const args = buildPgDumpArgs({
+    outputFile: '/tmp/staging-schema-baseline.review.sql',
+    schemas: ['public'],
+    sourceUrl: productionDatabaseUrl,
+  })
+
+  assert.equal(args.some((arg) => arg.includes(productionDatabaseUrl)), false)
+  assert.equal(args.some((arg) => arg.includes('postgresql://')), false)
+})
+
+test('buildPgEnvironment parses connection URL without using a local socket fallback', () => {
+  const env = buildPgEnvironment('postgresql://postgres.user%40ref:s5k8%2A2p%29nm%25%3FF2x@db.production-ref.supabase.co:5432/postgres')
+
+  assert.deepEqual(env, {
+    PGHOST: 'db.production-ref.supabase.co',
+    PGPORT: '5432',
+    PGUSER: 'postgres.user@ref',
+    PGPASSWORD: 's5k8*2p)nm%?F2x',
+    PGDATABASE: 'postgres',
+  })
+})
+
+test('validateSourceDatabaseUrl rejects missing production database URLs', () => {
+  assert.throws(() => validateSourceDatabaseUrl(''), /PRODUCTION_DATABASE_URL is required/)
+})
+
+test('validateSourceDatabaseUrl rejects the known staging ref', () => {
+  assert.throws(
+    () => validateSourceDatabaseUrl('postgresql://operator:secret@db.ebwtdjtajclzciwipevw.supabase.co:5432/postgres'),
+    /staging project ref/
+  )
+})
+
+test('validateSourceDatabaseUrl rejects localhost sources', () => {
+  assert.throws(
+    () => validateSourceDatabaseUrl('postgresql://postgres:postgres@localhost:5432/postgres'),
+    /local database/
+  )
+})
+
+test('validateSourceDatabaseUrl rejects missing or undefined hosts', () => {
+  assert.throws(
+    () => validateSourceDatabaseUrl('postgresql://postgres:postgres@undefined:5432/postgres'),
+    /missing a real database host/
+  )
+})
+
+test('validateSourceDatabaseUrl rejects placeholder values', () => {
+  assert.throws(
+    () => validateSourceDatabaseUrl('postgresql://operator:secret@db.<your-production-ref>.supabase.co:5432/postgres'),
+    /placeholder value/
+  )
+  assert.throws(
+    () => validateSourceDatabaseUrl('postgres://...'),
+    /placeholder value/
+  )
+})
+
+test('validateSourceDatabaseUrl rejects non-Postgres protocols', () => {
+  assert.throws(
+    () => validateSourceDatabaseUrl('https://operator:secret@db.production-ref.supabase.co:5432/postgres'),
+    /postgres:\/\/ or postgresql:\/\//
+  )
+})
+
+test('validateSourceDatabaseUrl rejects test and example targets', () => {
+  assert.throws(
+    () => validateSourceDatabaseUrl('postgresql://operator:secret@test.supabase.co:5432/postgres'),
+    /test\/example database/
+  )
+  assert.throws(
+    () => validateSourceDatabaseUrl('postgresql://operator:secret@db.production-ref.supabase.co:5432/example'),
+    /test\/example database/
+  )
+})
+
+test('parseSchemas defaults to public and storage', () => {
+  assert.deepEqual(parseSchemas(''), ['public', 'storage'])
+})
+
+test('parseSchemas rejects invalid schema names', () => {
+  assert.throws(() => parseSchemas('public, bad-schema'), /Invalid schema name/)
+})

--- a/scripts/normalize-staging-schema-baseline.mjs
+++ b/scripts/normalize-staging-schema-baseline.mjs
@@ -1,0 +1,242 @@
+#!/usr/bin/env node
+
+import { mkdir, readFile, writeFile } from 'node:fs/promises'
+import { dirname, resolve } from 'node:path'
+import { pathToFileURL } from 'node:url'
+
+const DEFAULT_INPUT_FILE = 'tmp/staging-baseline/staging-schema-baseline.review.sql'
+const DEFAULT_OUTPUT_FILE = 'tmp/staging-baseline/staging-schema-baseline.normalized.sql'
+const DEFAULT_PLATFORM_ACL_FILE = 'tmp/staging-baseline/staging-schema-baseline.platform-acls.review.sql'
+
+const NORMALIZED_HEADER = `-- Derived schema-only staging baseline for Global Connect.
+-- Source: tmp/staging-baseline/staging-schema-baseline.review.sql.
+-- This artifact intentionally excludes Supabase-managed storage internals and platform ACL/default privilege replay.
+-- Review this file manually before any staging apply. Do not execute it without explicit approval.
+
+`
+
+const PLATFORM_ACL_HEADER = `-- Platform ACL/default privilege statements isolated from the normalized staging baseline.
+-- Review manually if staging requires explicit privilege reconciliation.
+-- Do not blindly replay these statements.
+
+`
+
+function splitDumpSections(sql) {
+  const lines = sql.split(/(?<=\n)/)
+  const sections = []
+  let current = []
+
+  for (let index = 0; index < lines.length; index += 1) {
+    const line = lines[index]
+    const nextLine = lines[index + 1] ?? ''
+
+    if (line === '--\n' && nextLine.startsWith('-- Name: ') && current.length > 0) {
+      sections.push(current.join(''))
+      current = [line]
+      continue
+    }
+
+    current.push(line)
+  }
+
+  if (current.length > 0) {
+    sections.push(current.join(''))
+  }
+
+  return sections
+}
+
+function getSectionHeader(section) {
+  return section.match(/^-- Name: (?<name>.*); Type: (?<type>.*); Schema: (?<schema>.*); Owner: -$/m)?.groups ?? null
+}
+
+function isPublicSchemaCreation(section) {
+  const header = getSectionHeader(section)
+
+  return header?.name === 'public' && header.type === 'SCHEMA' && /\nCREATE SCHEMA public;\n/.test(section)
+}
+
+function isStorageManagedSection(section) {
+  const header = getSectionHeader(section)
+
+  if (!header) {
+    return false
+  }
+
+  if (header.schema === 'storage') {
+    return true
+  }
+
+  return header.type === 'SCHEMA' && header.name === 'storage'
+}
+
+function isAclSection(section) {
+  const header = getSectionHeader(section)
+
+  return header?.type === 'ACL' || header?.type === 'DEFAULT ACL'
+}
+
+function isFunctionSection(section) {
+  return getSectionHeader(section)?.type === 'FUNCTION'
+}
+
+function stripPsqlMetaCommands(section) {
+  if (isFunctionSection(section)) {
+    return { normalized: section, removedCount: 0 }
+  }
+
+  const lines = section.split(/(?<=\n)/)
+  const retainedLines = []
+  let removedCount = 0
+
+  for (const line of lines) {
+    if (/^\\\S+/.test(line)) {
+      removedCount += 1
+      continue
+    }
+
+    retainedLines.push(line)
+  }
+
+  return { normalized: retainedLines.join(''), removedCount }
+}
+
+function stripUnsupportedPgDumpSettings(section) {
+  if (isFunctionSection(section)) {
+    return section
+  }
+
+  return section
+    .split(/(?<=\n)/)
+    .filter((line) => !/^SET transaction_timeout = 0;\n?$/.test(line))
+    .join('')
+}
+
+function startsTopLevelAclStatement(line) {
+  return /^\s*(GRANT|REVOKE|ALTER DEFAULT PRIVILEGES)\b/.test(line)
+}
+
+function hasTopLevelAclStatement(section) {
+  return section.split('\n').some((line) => startsTopLevelAclStatement(line))
+}
+
+function splitStatements(section) {
+  const lines = section.split(/(?<=\n)/)
+  const headerLines = []
+  const statements = []
+  let statement = []
+  let insideStatements = false
+
+  for (const line of lines) {
+    if (!insideStatements && startsTopLevelAclStatement(line)) {
+      insideStatements = true
+    }
+
+    if (!insideStatements) {
+      headerLines.push(line)
+      continue
+    }
+
+    statement.push(line)
+
+    if (/;\s*$/.test(line)) {
+      statements.push(statement.join(''))
+      statement = []
+    }
+  }
+
+  if (statement.length > 0) {
+    statements.push(statement.join(''))
+  }
+
+  return { header: headerLines.join(''), statements }
+}
+
+function normalizeAclSection(section) {
+  if (isFunctionSection(section) || (!isAclSection(section) && !hasTopLevelAclStatement(section))) {
+    return { normalized: section, isolated: '' }
+  }
+
+  const { header, statements } = splitStatements(section)
+  const isolated = []
+
+  for (const statement of statements) {
+    isolated.push(statement)
+  }
+
+  return {
+    normalized: isAclSection(section) ? '' : header,
+    isolated: isolated.length > 0 ? `${header}${isolated.join('')}` : '',
+  }
+}
+
+export function normalizeBaseline(sql) {
+  const normalizedSections = []
+  const isolatedAclSections = []
+  const summary = {
+    removedPublicSchemaSections: 0,
+    removedStorageSections: 0,
+    isolatedPlatformAclSections: 0,
+    removedPsqlMetaCommands: 0,
+  }
+
+  for (const rawSection of splitDumpSections(sql)) {
+    const metaCommandResult = stripPsqlMetaCommands(rawSection)
+    const section = stripUnsupportedPgDumpSettings(metaCommandResult.normalized)
+
+    summary.removedPsqlMetaCommands += metaCommandResult.removedCount
+
+    if (isPublicSchemaCreation(section)) {
+      summary.removedPublicSchemaSections += 1
+      continue
+    }
+
+    if (isStorageManagedSection(section)) {
+      summary.removedStorageSections += 1
+      continue
+    }
+
+    const aclResult = normalizeAclSection(section)
+
+    if (aclResult.isolated) {
+      summary.isolatedPlatformAclSections += 1
+      isolatedAclSections.push(aclResult.isolated)
+    }
+
+    if (aclResult.normalized) {
+      normalizedSections.push(aclResult.normalized)
+    }
+  }
+
+  return {
+    normalizedSql: NORMALIZED_HEADER + normalizedSections.join(''),
+    platformAclSql: PLATFORM_ACL_HEADER + isolatedAclSections.join(''),
+    summary,
+  }
+}
+
+async function main() {
+  const inputFile = resolve(process.env.BASELINE_REVIEW_FILE || DEFAULT_INPUT_FILE)
+  const outputFile = resolve(process.env.BASELINE_NORMALIZED_FILE || DEFAULT_OUTPUT_FILE)
+  const platformAclFile = resolve(process.env.BASELINE_PLATFORM_ACL_FILE || DEFAULT_PLATFORM_ACL_FILE)
+
+  const reviewSql = await readFile(inputFile, 'utf8')
+  const { normalizedSql, platformAclSql, summary } = normalizeBaseline(reviewSql)
+
+  await mkdir(dirname(outputFile), { recursive: true })
+  await writeFile(outputFile, normalizedSql)
+  await writeFile(platformAclFile, platformAclSql)
+
+  console.error(`Normalized schema baseline written to ${outputFile}`)
+  console.error(`Platform ACL review file written to ${platformAclFile}`)
+  console.error(JSON.stringify(summary))
+}
+
+const invokedPath = process.argv[1] ? pathToFileURL(resolve(process.argv[1])).href : ''
+
+if (import.meta.url === invokedPath) {
+  main().catch((error) => {
+    console.error(error.message)
+    process.exit(1)
+  })
+}

--- a/scripts/normalize-staging-schema-baseline.test.mjs
+++ b/scripts/normalize-staging-schema-baseline.test.mjs
@@ -1,0 +1,112 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+
+import { normalizeBaseline } from './normalize-staging-schema-baseline.mjs'
+
+test('normalizeBaseline removes public schema creation and storage managed sections', () => {
+  const { normalizedSql, summary } = normalizeBaseline(`--
+-- Name: public; Type: SCHEMA; Schema: -; Owner: -
+--
+
+CREATE SCHEMA public;
+
+
+--
+-- Name: storage; Type: SCHEMA; Schema: -; Owner: -
+--
+
+CREATE SCHEMA storage;
+
+
+--
+-- Name: buckets; Type: TABLE; Schema: storage; Owner: -
+--
+
+CREATE TABLE storage.buckets (id text NOT NULL);
+
+
+--
+-- Name: app_table; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.app_table (id uuid NOT NULL);
+`)
+
+  assert.match(normalizedSql, /CREATE TABLE public\.app_table/)
+  assert.doesNotMatch(normalizedSql, /CREATE SCHEMA public;/)
+  assert.doesNotMatch(normalizedSql, /CREATE SCHEMA storage;/)
+  assert.doesNotMatch(normalizedSql, /CREATE TABLE storage\.buckets/)
+  assert.equal(summary.removedPublicSchemaSections, 1)
+  assert.equal(summary.removedStorageSections, 2)
+})
+
+test('normalizeBaseline isolates top-level ACL statements from normalized SQL', () => {
+  const { normalizedSql, platformAclSql, summary } = normalizeBaseline(`--
+  -- Name: TABLE app_table; Type: ACL; Schema: public; Owner: -
+  --
+
+REVOKE ALL ON FUNCTION public.do_work() FROM PUBLIC;
+GRANT SELECT ON TABLE public.app_table TO authenticated;
+GRANT SELECT ON TABLE public.app_table TO app_reader;
+ALTER DEFAULT PRIVILEGES FOR ROLE postgres IN SCHEMA public GRANT SELECT ON TABLES TO authenticated;
+`)
+
+  assert.doesNotMatch(normalizedSql, /REVOKE ALL/)
+  assert.doesNotMatch(normalizedSql, /TO authenticated;/)
+  assert.doesNotMatch(normalizedSql, /TO app_reader;/)
+  assert.doesNotMatch(normalizedSql, /ALTER DEFAULT PRIVILEGES/)
+  assert.match(platformAclSql, /REVOKE ALL ON FUNCTION public\.do_work\(\) FROM PUBLIC;/)
+  assert.match(platformAclSql, /TO authenticated;/)
+  assert.match(platformAclSql, /TO app_reader;/)
+  assert.match(platformAclSql, /ALTER DEFAULT PRIVILEGES/)
+  assert.equal(summary.isolatedPlatformAclSections, 1)
+})
+
+test('normalizeBaseline strips pg_dump psql metacommands outside function bodies', () => {
+  const { normalizedSql, summary } = normalizeBaseline(`\\restrict abc123
+--
+-- Name: app_table; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.app_table (id uuid NOT NULL);
+
+\\unrestrict abc123
+`)
+
+  assert.match(normalizedSql, /CREATE TABLE public\.app_table/)
+  assert.doesNotMatch(normalizedSql, /\\restrict/)
+  assert.doesNotMatch(normalizedSql, /\\unrestrict/)
+  assert.equal(summary.removedPsqlMetaCommands, 2)
+})
+
+test('normalizeBaseline strips unsupported pg_dump transaction_timeout setting', () => {
+  const { normalizedSql } = normalizeBaseline(`SET statement_timeout = 0;
+SET transaction_timeout = 0;
+--
+-- Name: app_table; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.app_table (id uuid NOT NULL);
+`)
+
+  assert.match(normalizedSql, /SET statement_timeout = 0;/)
+  assert.match(normalizedSql, /CREATE TABLE public\.app_table/)
+  assert.doesNotMatch(normalizedSql, /SET transaction_timeout = 0;/)
+})
+
+test('normalizeBaseline preserves INSERT statements inside function bodies', () => {
+  const { normalizedSql } = normalizeBaseline(`--
+-- Name: create_event(); Type: FUNCTION; Schema: public; Owner: -
+--
+
+CREATE FUNCTION public.create_event() RETURNS void
+    LANGUAGE plpgsql
+    AS $$
+BEGIN
+  INSERT INTO public.audit_log(action) VALUES ('created');
+END;
+$$;
+`)
+
+  assert.match(normalizedSql, /INSERT INTO public\.audit_log/)
+})


### PR DESCRIPTION
Closes #107

# Título del PR
chore(supabase): add staging baseline tooling

## Resumen
This PR adds local-only tooling to generate and normalize a schema-only staging baseline for the support ticket system rollout.

## Qué Incluye
- Schema-only baseline generator using `pg_dump` safety checks.
- Baseline normalizer that removes unsupported/platform-managed statements and isolates ACL review output.
- Unit tests for generator and normalizer guardrails.

## Motivación / Por Qué
The repository migrations are not a complete empty-database bootstrap. Staging needs a reviewed schema-only baseline before applying the support migration safely.

## Chain Context
Strategy: feature-branch-chain

```text
main
└── feat/support-ticket-system-tracker
    └── feat/support-ticket-schema
        └── chore/support-staging-guardrails
            └── chore/support-staging-baseline-tools 📍
                └── docs/support-staging-baseline
                    └── feat/support-r2-attachments
                        └── docs/support-ticket-sdd
```

Current PR boundary:
- Local staging baseline generator/normalizer tooling and tests only.

Out of scope:
- Applying SQL.
- Production mutation.
- Committing generated `tmp/` artifacts.

## Evidencia Visual (si aplica)
No aplica.

## Migraciones / Base de Datos
- [x] No aplica
- [ ] Sí (orden exacto):
```text
N/A
```
Notas:
- Tooling generates local artifacts only; it does not apply SQL.

## Impacto y Riesgos
- Adds operator tooling for staging baseline preparation.
- Generated SQL remains local under `tmp/` and is intentionally excluded from commits.

## Checklist Autor
- [x] Código formateado (Prettier/ESLint)
- [x] Sin `console.log` / debugger
- [x] Validaciones con zod para entradas nuevas
- [x] Estados loading/error/empty cubiertos
- [x] Tipos TypeScript correctos
- [x] Migraciones probadas local
- [x] Documentación actualizada (`docs/` o README)
- [x] Variables de entorno documentadas
- [x] Rebase con `main` limpio

## Checklist Revisor
- [ ] Propósito claro
- [ ] Nombres descriptivos
- [ ] Sin lógica duplicada evidente
- [ ] Manejo adecuado de errores
- [ ] Cambios acotados al alcance
- [ ] Sin secretos / datos sensibles

## Pruebas Manuales Realizadas
- Generator and normalizer tests passed during SDD verification.
- Normalized baseline was used successfully in Supabase staging.

## Pendientes / Follow-up
- Staging baseline runbook in the next chained PR.

## Notas Adicionales
This PR is tooling-only. It intentionally does not include generated baseline SQL output.
