### PR TITLE
feat(support): add R2 attachment helpers

### DIFF
--- a/__tests__/lib/support/r2.test.ts
+++ b/__tests__/lib/support/r2.test.ts
@@ -1,0 +1,63 @@
+import {
+  SUPPORT_R2_BUCKET,
+  buildSupportAttachmentKey,
+  createSupportR2SignedUrl,
+  detectAttachmentKind,
+  getSupportR2Config,
+  sniffSupportMimeType,
+  validateSupportAttachmentIntent,
+} from '@/lib/support/r2'
+
+describe('support R2 attachment helpers', () => {
+  const env = { R2_ACCOUNT_ID: 'account', R2_ACCESS_KEY_ID: 'access', R2_SECRET_ACCESS_KEY: 'secret' }
+
+  it('accepts allowed screenshots and builds safe private keys', () => {
+    const file = validateSupportAttachmentIntent({
+      filename: '../screen shot.png',
+      contentType: 'image/png',
+      byteSize: 1024,
+    })
+
+    expect(file).toEqual({
+      filename: 'screen-shot.png',
+      contentType: 'image/png',
+      byteSize: 1024,
+      kind: 'screenshot',
+    })
+    expect(buildSupportAttachmentKey('ticket-1', 'attachment-1', file.filename)).toBe(
+      'support/ticket-1/attachment-1/screen-shot.png'
+    )
+  })
+
+  it('rejects oversized files, unsupported MIME types, and too many videos', () => {
+    expect(() => validateSupportAttachmentIntent({ filename: 'huge.png', contentType: 'image/png', byteSize: 10 * 1024 * 1024 + 1 })).toThrow('Screenshots must be 10MB or smaller')
+    expect(() => validateSupportAttachmentIntent({ filename: 'notes.txt', contentType: 'text/plain', byteSize: 1024 })).toThrow('Unsupported attachment MIME type')
+    expect(() => detectAttachmentKind('video/mp4')).not.toThrow()
+  })
+
+  it('sniffs image and video magic bytes before finalization', () => {
+    expect(sniffSupportMimeType(new Uint8Array([0x89, 0x50, 0x4e, 0x47]), 'image/png')).toBe(true)
+    expect(sniffSupportMimeType(new Uint8Array([0xff, 0xd8, 0xff]), 'image/jpeg')).toBe(true)
+    expect(sniffSupportMimeType(new Uint8Array([0, 0, 0, 24, 0x66, 0x74, 0x79, 0x70]), 'video/mp4')).toBe(true)
+    expect(sniffSupportMimeType(new Uint8Array([0x3c, 0x68, 0x74, 0x6d, 0x6c]), 'image/png')).toBe(false)
+  })
+
+  it('uses server-only envs and keeps the support bucket private', () => {
+    expect(getSupportR2Config(env)).toMatchObject({
+      bucket: SUPPORT_R2_BUCKET,
+      endpoint: 'https://account.r2.cloudflarestorage.com',
+    })
+  })
+
+  it('creates deterministic SigV4 signatures for private R2 URLs', () => {
+    jest.useFakeTimers().setSystemTime(new Date('2026-06-09T00:00:00.000Z'))
+    const url = createSupportR2SignedUrl({
+      method: 'GET',
+      key: 'support/ticket-1/attachment-1/file.png',
+      expiresInSeconds: 60,
+      config: getSupportR2Config(env),
+    })
+    expect(url).toContain('X-Amz-Signature=4ad1e3f841acdcd836f153721b8be904c2a9661df7d9ff81431abe2502b963b5')
+    jest.useRealTimers()
+  })
+})

--- a/lib/support/r2.ts
+++ b/lib/support/r2.ts
@@ -1,0 +1,124 @@
+import { createHash, createHmac, randomUUID } from 'crypto'
+
+export const SUPPORT_R2_BUCKET = 'global-connect-support'
+export const SUPPORT_UPLOAD_URL_TTL_SECONDS = 300
+export const SUPPORT_DOWNLOAD_URL_TTL_SECONDS = 60
+export const SUPPORT_SCREENSHOT_MAX_BYTES = 10 * 1024 * 1024
+export const SUPPORT_VIDEO_MAX_BYTES = 100 * 1024 * 1024
+export const SUPPORT_TICKET_MAX_BYTES = 150 * 1024 * 1024
+export const SUPPORT_MAX_SCREENSHOTS = 5
+export const SUPPORT_MAX_VIDEOS = 1
+
+const SCREENSHOT_TYPES = new Set(['image/png', 'image/jpeg', 'image/webp'])
+const VIDEO_TYPES = new Set(['video/mp4', 'video/webm', 'video/quicktime'])
+
+export type SupportAttachmentKind = 'screenshot' | 'video'
+
+export type SupportAttachmentIntentInput = {
+  filename: string
+  contentType: string
+  byteSize: number
+}
+
+export type SupportAttachmentIntent = SupportAttachmentIntentInput & {
+  filename: string
+  kind: SupportAttachmentKind
+}
+
+export type SupportR2Config = {
+  accountId: string
+  accessKeyId: string
+  secretAccessKey: string
+  bucket: typeof SUPPORT_R2_BUCKET
+  endpoint: string
+}
+
+export function getSupportR2Config(env: NodeJS.ProcessEnv | Record<string, string | undefined> = process.env): SupportR2Config {
+  const accountId = env.R2_ACCOUNT_ID
+  const accessKeyId = env.R2_ACCESS_KEY_ID
+  const secretAccessKey = env.R2_SECRET_ACCESS_KEY
+  if (!accountId || !accessKeyId || !secretAccessKey) throw new Error('Missing R2 support attachment environment variables')
+  return { accountId, accessKeyId, secretAccessKey, bucket: SUPPORT_R2_BUCKET, endpoint: `https://${accountId}.r2.cloudflarestorage.com` }
+}
+
+export function detectAttachmentKind(contentType: string): SupportAttachmentKind {
+  if (SCREENSHOT_TYPES.has(contentType)) return 'screenshot'
+  if (VIDEO_TYPES.has(contentType)) return 'video'
+  throw new Error('Unsupported attachment MIME type')
+}
+
+export function validateSupportAttachmentIntent(input: SupportAttachmentIntentInput): SupportAttachmentIntent {
+  const kind = detectAttachmentKind(input.contentType)
+  if (!Number.isInteger(input.byteSize) || input.byteSize <= 0) throw new Error('Attachment size must be positive')
+  if (kind === 'screenshot' && input.byteSize > SUPPORT_SCREENSHOT_MAX_BYTES) throw new Error('Screenshots must be 10MB or smaller')
+  if (kind === 'video' && input.byteSize > SUPPORT_VIDEO_MAX_BYTES) throw new Error('Videos must be 100MB or smaller')
+  return { ...input, filename: sanitizeFilename(input.filename), kind }
+}
+
+export function enforceSupportAttachmentBatch(files: SupportAttachmentIntent[], existing: { kind: string; byte_size: number; status: string }[]) {
+  const active = existing.filter((file) => file.status !== 'deleted' && file.status !== 'rejected')
+  const screenshots = active.filter((file) => file.kind === 'screenshot').length + files.filter((file) => file.kind === 'screenshot').length
+  const videos = active.filter((file) => file.kind === 'video').length + files.filter((file) => file.kind === 'video').length
+  const totalBytes = active.reduce((sum, file) => sum + file.byte_size, 0) + files.reduce((sum, file) => sum + file.byteSize, 0)
+  if (screenshots > SUPPORT_MAX_SCREENSHOTS) throw new Error('A ticket can include up to 5 screenshots')
+  if (videos > SUPPORT_MAX_VIDEOS) throw new Error('A ticket can include up to 1 video')
+  if (totalBytes > SUPPORT_TICKET_MAX_BYTES) throw new Error('A ticket can include up to 150MB of attachments')
+}
+
+export function buildSupportAttachmentKey(ticketId: string, attachmentId: string, filename: string) {
+  return `support/${ticketId}/${attachmentId}/${sanitizeFilename(filename)}`
+}
+
+export function createSupportAttachmentId() {
+  return randomUUID()
+}
+
+export function sniffSupportMimeType(bytes: Uint8Array, expectedContentType: string) {
+  if (expectedContentType === 'image/png') return startsWith(bytes, [0x89, 0x50, 0x4e, 0x47])
+  if (expectedContentType === 'image/jpeg') return startsWith(bytes, [0xff, 0xd8, 0xff])
+  if (expectedContentType === 'image/webp') return startsWith(bytes.slice(0, 12), [0x52, 0x49, 0x46, 0x46]) && String.fromCharCode(...bytes.slice(8, 12)) === 'WEBP'
+  if (expectedContentType === 'video/mp4' || expectedContentType === 'video/quicktime') return String.fromCharCode(...bytes.slice(4, 8)) === 'ftyp'
+  if (expectedContentType === 'video/webm') return startsWith(bytes, [0x1a, 0x45, 0xdf, 0xa3])
+  return false
+}
+
+export function createSupportR2SignedUrl(input: { method: 'PUT' | 'GET' | 'HEAD' | 'DELETE'; key: string; expiresInSeconds: number; contentType?: string; config?: SupportR2Config }) {
+  const config = input.config ?? getSupportR2Config()
+  const now = new Date()
+  const date = now.toISOString().slice(0, 10).replace(/-/g, '')
+  const amzDate = `${date}T${now.toISOString().slice(11, 19).replace(/:/g, '')}Z`
+  const host = `${config.bucket}.${config.accountId}.r2.cloudflarestorage.com`
+  const credential = `${config.accessKeyId}/${date}/auto/s3/aws4_request`
+  const signedHeaders = 'host'
+  const path = `/${encodeURIComponent(input.key).replace(/%2F/g, '/')}`
+  const params = new URLSearchParams({
+    'X-Amz-Algorithm': 'AWS4-HMAC-SHA256',
+    'X-Amz-Credential': credential,
+    'X-Amz-Date': amzDate,
+    'X-Amz-Expires': String(input.expiresInSeconds),
+    'X-Amz-SignedHeaders': signedHeaders,
+  })
+  const canonicalRequest = [input.method, path, params.toString(), `host:${host}\n`, signedHeaders, 'UNSIGNED-PAYLOAD'].join('\n')
+  const stringToSign = ['AWS4-HMAC-SHA256', amzDate, `${date}/auto/s3/aws4_request`, sha256(canonicalRequest)].join('\n')
+  const signingKey = hmac(hmac(hmac(hmac(`AWS4${config.secretAccessKey}`, date), 'auto'), 's3'), 'aws4_request')
+  const signature = hmac(signingKey, stringToSign).toString('hex')
+  params.set('X-Amz-Signature', signature)
+  return `https://${host}${path}?${params.toString()}`
+}
+
+function sanitizeFilename(filename: string) {
+  const name = filename.split(/[\\/]/).pop()?.trim() || 'attachment'
+  return name.toLowerCase().replace(/[^a-z0-9._-]+/g, '-').replace(/^-+|-+$/g, '') || 'attachment'
+}
+
+function startsWith(bytes: Uint8Array, signature: number[]) {
+  return signature.every((byte, index) => bytes[index] === byte)
+}
+
+function sha256(value: string) {
+  return createHash('sha256').update(value).digest('hex')
+}
+
+function hmac(key: string | Buffer, value: string) {
+  return createHmac('sha256', key).update(value).digest()
+}


### PR DESCRIPTION
Closes #107

# Título del PR
feat(support): add R2 attachment helpers

## Resumen
This PR adds private Cloudflare R2 support helpers for attachment validation, object key generation, environment validation, and signed URL generation.

## Qué Incluye
- R2 attachment validation helpers.
- Deterministic private object key builder.
- Environment/config validation for private support bucket access.
- Unit tests for limits, MIME handling, keys, envs, and signing.

## Motivación / Por Qué
Support attachments must remain private and validated before API routes expose upload/download flows.

## Chain Context
Strategy: feature-branch-chain

```text
main
└── feat/support-ticket-system-tracker
    └── feat/support-ticket-schema
        └── chore/support-staging-guardrails
            └── chore/support-staging-baseline-tools
                └── docs/support-staging-baseline
                    └── feat/support-r2-helpers 📍
                        └── feat/support-r2-attachment-routes
                            └── docs/support-ticket-sdd
```

Current PR boundary:
- R2 helper logic and unit tests only.

Out of scope:
- Attachment API routes.
- Reporter UI.
- Staff console.
- Notifications.

## Evidencia Visual (si aplica)
No aplica.

## Migraciones / Base de Datos
- [x] No aplica
- [ ] Sí (orden exacto):
```text
N/A
```

## Impacto y Riesgos
- Introduces private R2 helper primitives. No credentials are exposed to client code.

## Checklist Autor
- [x] Código formateado (Prettier/ESLint)
- [x] Sin `console.log` / debugger
- [x] Validaciones con zod para entradas nuevas
- [x] Estados loading/error/empty cubiertos
- [x] Tipos TypeScript correctos
- [x] Migraciones probadas local
- [x] Documentación actualizada (`docs/` o README)
- [x] Variables de entorno documentadas
- [x] Rebase con `main` limpio

## Checklist Revisor
- [ ] Propósito claro
- [ ] Nombres descriptivos
- [ ] Sin lógica duplicada evidente
- [ ] Manejo adecuado de errores
- [ ] Cambios acotados al alcance
- [ ] Sin secretos / datos sensibles

## Pruebas Manuales Realizadas
- Phase 2 support tests passed during SDD validation: 4 suites, 25 tests.
- `pnpm exec tsc --noEmit` passed.

## Pendientes / Follow-up
- Attachment API routes in the next chained PR.

## Notas Adicionales
This PR intentionally contains helpers only so route behavior can be reviewed separately.
