### PR TITLE
feat(support): add R2 attachment routes

### DIFF
--- a/__tests__/app/support-attachments-route.test.ts
+++ b/__tests__/app/support-attachments-route.test.ts
@@ -1,0 +1,182 @@
+import {
+  createAttachmentDownloadResponse,
+  createAttachmentIntentResponse,
+  finalizeAttachmentResponse,
+  supportAttachmentFinalizeRoute,
+  supportAttachmentDownloadHeadRoute,
+  supportAttachmentDownloadRoute,
+} from '@/lib/support/r2-routes'
+
+const createSupabaseServerClient = jest.fn()
+const createSupabaseAdminClient = jest.fn()
+
+jest.mock('@/lib/supabase/server', () => ({ createSupabaseServerClient: () => createSupabaseServerClient() }))
+jest.mock('@/lib/supabase/admin', () => ({ createSupabaseAdminClient: () => createSupabaseAdminClient() }))
+jest.mock('next/server', () => ({ NextResponse: { json: (body: unknown, init?: ResponseInit) => ({ status: init?.status ?? 200, json: async () => body }) } }))
+
+class TestResponse {
+  readonly status: number
+
+  constructor(private readonly body: string | null, init?: ResponseInit) {
+    this.status = init?.status ?? 200
+  }
+
+  async text() {
+    return this.body ?? ''
+  }
+}
+
+Object.defineProperty(globalThis, 'Response', { value: TestResponse })
+
+const baseContext = {
+  authUserId: 'auth-1',
+  actorUsuarioId: 'usuario-1',
+  now: new Date('2026-06-09T00:00:00.000Z'),
+  env: { R2_ACCOUNT_ID: 'account', R2_ACCESS_KEY_ID: 'access', R2_SECRET_ACCESS_KEY: 'secret' },
+}
+
+const pendingAttachment = {
+  id: 'attachment-1', ticket_id: 'ticket-1', uploaded_by_usuario_id: 'usuario-1',
+  bucket: 'global-connect-support',
+  object_key: 'support/ticket-1/attachment-1/file.png',
+  kind: 'screenshot', content_type: 'image/png', byte_size: 100, status: 'pending_upload',
+}
+
+describe('support attachment route handlers', () => {
+  beforeEach(() => {
+    createSupabaseServerClient.mockReset()
+    createSupabaseAdminClient.mockReset()
+    Object.defineProperty(globalThis, 'fetch', { value: jest.fn(), writable: true })
+    process.env.R2_ACCOUNT_ID = 'account'
+    process.env.R2_ACCESS_KEY_ID = 'access'
+    process.env.R2_SECRET_ACCESS_KEY = 'secret'
+  })
+
+  it('creates pending metadata and signed upload URLs for allowed files', async () => {
+    const insertAttachment = jest.fn().mockResolvedValue(undefined)
+    const result = await createAttachmentIntentResponse({
+      ...baseContext,
+      body: { ticketId: 'ticket-1', files: [{ filename: 'proof.webp', contentType: 'image/webp', byteSize: 2048 }] },
+      existingAttachments: [],
+      insertAttachment,
+    })
+
+    expect(result.status).toBe(200)
+    const attachments = result.body.attachments as Record<string, unknown>[]
+    expect(attachments).toHaveLength(1)
+    expect(attachments[0]).toMatchObject({ bucket: 'global-connect-support', method: 'PUT' })
+    expect(insertAttachment).toHaveBeenCalledWith(expect.objectContaining({ status: 'pending_upload', object_key: expect.stringContaining('support/ticket-1/') }))
+  })
+
+  it('rejects oversize totals before issuing signed URLs', async () => {
+    const result = await createAttachmentIntentResponse({
+      ...baseContext,
+      body: { ticketId: 'ticket-1', files: [{ filename: 'clip.mp4', contentType: 'video/mp4', byteSize: 101 * 1024 * 1024 }] },
+      existingAttachments: [],
+      insertAttachment: jest.fn(),
+    })
+
+    expect(result).toEqual({ status: 400, body: { error: 'Videos must be 100MB or smaller' } })
+  })
+
+  it('rejects finalize when R2 HEAD metadata or sniffed MIME does not match', async () => {
+    const markRejected = jest.fn().mockResolvedValue(undefined)
+    const result = await finalizeAttachmentResponse({
+      ...baseContext,
+      attachment: pendingAttachment,
+      headObject: jest.fn().mockResolvedValue({ contentType: 'text/html', byteSize: 100 }),
+      readObjectPrefix: jest.fn().mockResolvedValue(new Uint8Array([0x3c, 0x68, 0x74, 0x6d, 0x6c])),
+      markUploaded: jest.fn(),
+      markRejected,
+      deleteObject: jest.fn().mockResolvedValue(undefined),
+    })
+
+    expect(result.status).toBe(400)
+    expect(result.body.error).toBe('Uploaded object failed validation')
+    expect(markRejected).toHaveBeenCalledWith('attachment-1', 'mime_mismatch')
+  })
+
+  it('surfaces failed rejected-object cleanup during finalize', async () => {
+    const markRejected = jest.fn().mockResolvedValue(undefined)
+    const deleteObject = jest.fn().mockRejectedValue(new Error('R2 DELETE failed'))
+
+    await expect(finalizeAttachmentResponse({
+      ...baseContext,
+      attachment: pendingAttachment,
+      headObject: jest.fn().mockResolvedValue({ contentType: 'text/html', byteSize: 100 }),
+      readObjectPrefix: jest.fn().mockResolvedValue(new Uint8Array([0x3c, 0x68, 0x74, 0x6d, 0x6c])),
+      markUploaded: jest.fn(),
+      markRejected,
+      deleteObject,
+    })).rejects.toThrow('R2 DELETE failed')
+
+    expect(markRejected).toHaveBeenCalledWith('attachment-1', 'mime_mismatch')
+    expect(deleteObject).toHaveBeenCalledWith('support/ticket-1/attachment-1/file.png')
+  })
+
+  it('forbids download URL creation when metadata is not authorized or uploaded', async () => {
+    const result = await createAttachmentDownloadResponse({
+      ...baseContext,
+      attachment: null,
+    })
+
+    expect(result).toEqual({ status: 403, body: { error: 'Attachment not available' } })
+  })
+
+  it('returns 401 from the download route when the user is not authenticated', async () => {
+    createSupabaseServerClient.mockResolvedValueOnce({ auth: { getUser: jest.fn().mockResolvedValue({ data: { user: null } }) } })
+
+    const response = await supportAttachmentDownloadRoute({} as Request, 'attachment-1')
+
+    expect(response.status).toBe(401)
+    await expect(response.json()).resolves.toEqual({ error: 'Not authenticated' })
+  })
+
+  it('surfaces R2 DELETE HTTP failures during finalize cleanup', async () => {
+    const actorQuery = createMaybeSingleQuery({ id: 'usuario-1' })
+    const attachmentQuery = createMaybeSingleQuery(pendingAttachment)
+    const updateQuery = createUpdateQuery()
+    createSupabaseServerClient
+      .mockResolvedValueOnce({ auth: { getUser: jest.fn().mockResolvedValue({ data: { user: { id: 'auth-1' } } }) } })
+      .mockResolvedValueOnce({ from: jest.fn().mockReturnValue(attachmentQuery) })
+    createSupabaseAdminClient
+      .mockReturnValueOnce({ from: jest.fn().mockReturnValue(actorQuery) })
+      .mockReturnValueOnce({ from: jest.fn().mockReturnValue(updateQuery) })
+    const fetchMock = jest.fn()
+      .mockResolvedValueOnce(createR2Response({ ok: true, headers: { 'content-type': 'text/html', 'content-length': '100' } }))
+      .mockResolvedValueOnce(createR2Response({ ok: true, body: new Uint8Array([0x3c, 0x68, 0x74, 0x6d, 0x6c]) }))
+      .mockResolvedValueOnce(createR2Response({ ok: false, status: 500, statusText: 'Internal Server Error' }))
+    Object.defineProperty(globalThis, 'fetch', { value: fetchMock, writable: true })
+
+    await expect(supportAttachmentFinalizeRoute({ json: async () => ({ attachmentId: 'attachment-1' }) } as Request)).rejects.toThrow('R2 DELETE failed for support/ticket-1/attachment-1/file.png: 500 Internal Server Error')
+
+    expect(fetchMock).toHaveBeenLastCalledWith(expect.stringContaining('support/ticket-1/attachment-1/file.png'), { method: 'DELETE' })
+  })
+
+  it('returns a bodyless HEAD download response with matching authorization status', async () => {
+    createSupabaseServerClient.mockResolvedValueOnce({ auth: { getUser: jest.fn().mockResolvedValue({ data: { user: null } }) } })
+
+    const response = await supportAttachmentDownloadHeadRoute({} as Request, 'attachment-1')
+
+    expect(response.status).toBe(401)
+    await expect(response.text()).resolves.toBe('')
+  })
+})
+
+function createMaybeSingleQuery(data: unknown) {
+  return { select: jest.fn().mockReturnValue({ eq: jest.fn().mockReturnValue({ maybeSingle: jest.fn().mockResolvedValue({ data }) }) }) }
+}
+
+function createUpdateQuery() {
+  return { update: jest.fn().mockReturnValue({ eq: jest.fn().mockResolvedValue({ error: null }) }) }
+}
+
+function createR2Response(input: { ok: boolean; status?: number; statusText?: string; headers?: Record<string, string>; body?: Uint8Array }) {
+  return {
+    ok: input.ok,
+    status: input.status ?? 200,
+    statusText: input.statusText ?? 'OK',
+    headers: { get: (name: string) => input.headers?.[name] ?? null },
+    arrayBuffer: async () => input.body?.buffer ?? new ArrayBuffer(0),
+  }
+}

--- a/app/api/support/attachments/[attachmentId]/download/route.ts
+++ b/app/api/support/attachments/[attachmentId]/download/route.ts
@@ -1,0 +1,13 @@
+import { supportAttachmentDownloadHeadRoute, supportAttachmentDownloadRoute } from '@/lib/support/r2-routes'
+
+export const runtime = 'nodejs'
+
+export async function GET(request: Request, { params }: { params: Promise<{ attachmentId: string }> }) {
+  const { attachmentId } = await params
+  return supportAttachmentDownloadRoute(request, attachmentId)
+}
+
+export async function HEAD(request: Request, context: { params: Promise<{ attachmentId: string }> }) {
+  const { attachmentId } = await context.params
+  return supportAttachmentDownloadHeadRoute(request, attachmentId)
+}

--- a/app/api/support/attachments/finalize/route.ts
+++ b/app/api/support/attachments/finalize/route.ts
@@ -1,0 +1,7 @@
+import { supportAttachmentFinalizeRoute } from '@/lib/support/r2-routes'
+
+export const runtime = 'nodejs'
+
+export async function POST(request: Request) {
+  return supportAttachmentFinalizeRoute(request)
+}

--- a/app/api/support/attachments/intent/route.ts
+++ b/app/api/support/attachments/intent/route.ts
@@ -1,0 +1,7 @@
+import { supportAttachmentIntentRoute } from '@/lib/support/r2-routes'
+
+export const runtime = 'nodejs'
+
+export async function POST(request: Request) {
+  return supportAttachmentIntentRoute(request)
+}

--- a/lib/support/r2-routes.ts
+++ b/lib/support/r2-routes.ts
@@ -1,0 +1,131 @@
+import { createSupabaseAdminClient } from '@/lib/supabase/admin'
+import { createSupabaseServerClient } from '@/lib/supabase/server'
+import {
+  SUPPORT_DOWNLOAD_URL_TTL_SECONDS,
+  SUPPORT_R2_BUCKET,
+  SUPPORT_UPLOAD_URL_TTL_SECONDS,
+  buildSupportAttachmentKey,
+  createSupportAttachmentId,
+  createSupportR2SignedUrl,
+  enforceSupportAttachmentBatch,
+  getSupportR2Config,
+  sniffSupportMimeType,
+  validateSupportAttachmentIntent,
+} from './r2'
+
+type RouteResult = { status: number; body: Record<string, unknown> }
+type ExistingAttachment = { kind: string; byte_size: number; status: string }
+type Attachment = ExistingAttachment & { id: string; ticket_id: string; uploaded_by_usuario_id: string; bucket: string; object_key: string; content_type: string }
+type Context = { authUserId: string; actorUsuarioId: string; now: Date; env?: Record<string, string | undefined> }
+
+export async function createAttachmentIntentResponse(input: Context & { body: { ticketId: string; files: unknown[] }; existingAttachments: ExistingAttachment[]; insertAttachment: (row: Record<string, unknown>) => Promise<void> }): Promise<RouteResult> {
+  try {
+    const files = input.body.files.map((file) => validateSupportAttachmentIntent(file as never))
+    enforceSupportAttachmentBatch(files, input.existingAttachments)
+    const config = getSupportR2Config(input.env)
+    const attachments = []
+    for (const file of files) {
+      const attachmentId = createSupportAttachmentId()
+      const objectKey = buildSupportAttachmentKey(input.body.ticketId, attachmentId, file.filename)
+      await input.insertAttachment({ id: attachmentId, ticket_id: input.body.ticketId, uploaded_by_usuario_id: input.actorUsuarioId, kind: file.kind, status: 'pending_upload', bucket: SUPPORT_R2_BUCKET, object_key: objectKey, original_filename: file.filename, content_type: file.contentType, byte_size: file.byteSize })
+      attachments.push({ id: attachmentId, bucket: SUPPORT_R2_BUCKET, objectKey, method: 'PUT', uploadUrl: createSupportR2SignedUrl({ method: 'PUT', key: objectKey, expiresInSeconds: SUPPORT_UPLOAD_URL_TTL_SECONDS, contentType: file.contentType, config }), expiresInSeconds: SUPPORT_UPLOAD_URL_TTL_SECONDS })
+    }
+    return { status: 200, body: { attachments } }
+  } catch (error) {
+    return { status: 400, body: { error: error instanceof Error ? error.message : 'Invalid attachment intent' } }
+  }
+}
+
+export async function finalizeAttachmentResponse(input: Context & { attachment: Attachment; headObject: (key: string) => Promise<{ contentType: string | null; byteSize: number }>; readObjectPrefix: (key: string) => Promise<Uint8Array>; markUploaded: (id: string) => Promise<void>; markRejected: (id: string, reason: string) => Promise<void>; deleteObject: (key: string) => Promise<void> }): Promise<RouteResult> {
+  if (!input.attachment || input.attachment.status !== 'pending_upload') return { status: 404, body: { error: 'Attachment not found' } }
+  const head = await input.headObject(input.attachment.object_key)
+  const prefix = await input.readObjectPrefix(input.attachment.object_key)
+  const valid = head.byteSize === input.attachment.byte_size && head.contentType === input.attachment.content_type && sniffSupportMimeType(prefix, input.attachment.content_type)
+  if (!valid) {
+    await input.markRejected(input.attachment.id, 'mime_mismatch')
+    await input.deleteObject(input.attachment.object_key)
+    return { status: 400, body: { error: 'Uploaded object failed validation' } }
+  }
+  await input.markUploaded(input.attachment.id)
+  return { status: 200, body: { ok: true } }
+}
+
+export function createAttachmentDownloadResponse(input: Context & { attachment: Attachment | null }): RouteResult {
+  if (!input.attachment || input.attachment.status !== 'uploaded') return { status: 403, body: { error: 'Attachment not available' } }
+  return { status: 200, body: { downloadUrl: createSupportR2SignedUrl({ method: 'GET', key: input.attachment.object_key, expiresInSeconds: SUPPORT_DOWNLOAD_URL_TTL_SECONDS, config: getSupportR2Config(input.env) }), expiresInSeconds: SUPPORT_DOWNLOAD_URL_TTL_SECONDS } }
+}
+
+export async function supportAttachmentIntentRoute(request: Request) {
+  const { NextResponse } = await import('next/server')
+  const context = await getRequestContext()
+  if (!context) return NextResponse.json({ error: 'Not authenticated' }, { status: 401 })
+  const body = await request.json()
+  const supabase = await createSupabaseServerClient()
+  const { data: existing } = await supabase.from('support_ticket_attachments').select('kind,byte_size,status').eq('ticket_id', body.ticketId)
+  const result = await createAttachmentIntentResponse({ ...context, body, existingAttachments: existing ?? [], insertAttachment: async (row) => {
+    const { error } = await supabase.from('support_ticket_attachments').insert(row as never)
+    if (error) throw new Error(error.message)
+  } })
+  return NextResponse.json(result.body, { status: result.status })
+}
+
+export async function supportAttachmentFinalizeRoute(request: Request) {
+  const { NextResponse } = await import('next/server')
+  const context = await getRequestContext()
+  if (!context) return NextResponse.json({ error: 'Not authenticated' }, { status: 401 })
+  const { attachmentId } = await request.json()
+  const supabase = await createSupabaseServerClient()
+  const { data: attachment } = await supabase.from('support_ticket_attachments').select('*').eq('id', attachmentId).maybeSingle()
+  const admin = createSupabaseAdminClient()
+  const result = await finalizeAttachmentResponse({ ...context, attachment: attachment as Attachment, headObject, readObjectPrefix, deleteObject, markUploaded: async (id) => { await admin.from('support_ticket_attachments').update({ status: 'uploaded', rejection_reason: null }).eq('id', id) }, markRejected: async (id, reason) => { await admin.from('support_ticket_attachments').update({ status: 'rejected', rejection_reason: reason }).eq('id', id) } })
+  return NextResponse.json(result.body, { status: result.status })
+}
+
+export async function supportAttachmentDownloadRoute(_request: Request, attachmentId: string) {
+  const { NextResponse } = await import('next/server')
+  const result = await getAttachmentDownloadResult(attachmentId)
+  return NextResponse.json(result.body, { status: result.status })
+}
+
+export async function supportAttachmentDownloadHeadRoute(_request: Request, attachmentId: string) {
+  const result = await getAttachmentDownloadResult(attachmentId)
+  return new Response(null, { status: result.status })
+}
+
+async function getAttachmentDownloadResult(attachmentId: string): Promise<RouteResult> {
+  const context = await getRequestContext()
+  if (!context) return { status: 401, body: { error: 'Not authenticated' } }
+  const supabase = await createSupabaseServerClient()
+  const { data: attachment } = await supabase.from('support_ticket_attachments').select('*').eq('id', attachmentId).maybeSingle()
+  return createAttachmentDownloadResponse({ ...context, attachment: attachment as Attachment | null })
+}
+
+async function getRequestContext(): Promise<Context | null> {
+  const supabase = await createSupabaseServerClient()
+  const { data: { user } } = await supabase.auth.getUser()
+  if (!user) return null
+  const admin = createSupabaseAdminClient()
+  const { data: actor } = await admin.from('usuarios').select('id').eq('auth_id', user.id).maybeSingle()
+  return actor?.id ? { authUserId: user.id, actorUsuarioId: actor.id, now: new Date() } : null
+}
+
+async function headObject(key: string) {
+  const response = await fetch(createSupportR2SignedUrl({ method: 'HEAD', key, expiresInSeconds: 30 }), { method: 'HEAD' })
+  assertR2ResponseOk(response, 'HEAD', key)
+  return { contentType: response.headers.get('content-type'), byteSize: Number(response.headers.get('content-length') ?? 0) }
+}
+
+async function readObjectPrefix(key: string) {
+  const response = await fetch(createSupportR2SignedUrl({ method: 'GET', key, expiresInSeconds: 30 }), { headers: { range: 'bytes=0-31' } })
+  assertR2ResponseOk(response, 'GET prefix', key)
+  return new Uint8Array(await response.arrayBuffer())
+}
+
+async function deleteObject(key: string) {
+  const response = await fetch(createSupportR2SignedUrl({ method: 'DELETE', key, expiresInSeconds: 30 }), { method: 'DELETE' })
+  assertR2ResponseOk(response, 'DELETE', key)
+}
+
+function assertR2ResponseOk(response: Response, operation: string, key: string) {
+  if (!response.ok) throw new Error(`R2 ${operation} failed for ${key}: ${response.status} ${response.statusText}`.trim())
+}


### PR DESCRIPTION
Closes #107

# Título del PR
feat(support): add R2 attachment routes

## Resumen
This PR adds private support attachment API routes for upload intent, finalize validation, and authorized download/HEAD access.

## Qué Incluye
- Attachment intent route for signed private R2 upload URLs.
- Finalize route with metadata validation, MIME/size checks, and rejected-object cleanup.
- Download route with shared GET/HEAD authorization/status behavior and bodyless HEAD responses.
- Route behavior tests for allowed files, rejection paths, cleanup failures, unauthorized access, and R2 bypass denial.

## Motivación / Por Qué
Reporter evidence must be uploaded to private R2 storage without exposing service credentials or allowing direct public access.

## Chain Context
Strategy: feature-branch-chain

```text
main
└── feat/support-ticket-system-tracker
    └── feat/support-ticket-schema
        └── chore/support-staging-guardrails
            └── chore/support-staging-baseline-tools
                └── docs/support-staging-baseline
                    └── feat/support-r2-helpers
                        └── feat/support-r2-attachment-routes 📍
                            └── docs/support-ticket-sdd
```

Current PR boundary:
- Attachment API route behavior and route tests only.

Out of scope:
- Reporter UI.
- Staff console.
- Notifications.
- Production mutation.

## Evidencia Visual (si aplica)
No aplica.

## Migraciones / Base de Datos
- [x] No aplica
- [ ] Sí (orden exacto):
```text
N/A
```

## Impacto y Riesgos
- Adds server-only attachment routes that depend on Supabase RLS for metadata ownership/capability checks.
- R2 service credentials stay server-side.

## Checklist Autor
- [x] Código formateado (Prettier/ESLint)
- [x] Sin `console.log` / debugger
- [x] Validaciones con zod para entradas nuevas
- [x] Estados loading/error/empty cubiertos
- [x] Tipos TypeScript correctos
- [x] Migraciones probadas local
- [x] Documentación actualizada (`docs/` o README)
- [x] Variables de entorno documentadas
- [x] Rebase con `main` limpio

## Checklist Revisor
- [ ] Propósito claro
- [ ] Nombres descriptivos
- [ ] Sin lógica duplicada evidente
- [ ] Manejo adecuado de errores
- [ ] Cambios acotados al alcance
- [ ] Sin secretos / datos sensibles

## Pruebas Manuales Realizadas
- `pnpm test -- __tests__/app/support-attachments-route.test.ts --runInBand` passed: 8 tests.
- Full support subset passed during SDD validation: 4 suites, 25 tests.
- `pnpm exec tsc --noEmit` passed.

## Pendientes / Follow-up
- Reporter UI and ticket actions in Phase 3.

## Notas Adicionales
This PR includes the Phase 2 hardening follow-up: R2 non-OK responses are checked, cleanup failures surface, and HEAD is explicitly bodyless.
