### PR TITLE
chore(supabase): regenerate support database types

### DIFF
--- a/lib/supabase/database.types.ts
+++ b/lib/supabase/database.types.ts
@@ -10,7 +10,7 @@ export type Database = {
   // Allows to automatically instantiate createClient with right options
   // instead of createClient<Database, { PostgrestVersion: 'XX' }>(URL, KEY)
   __InternalSupabase: {
-    PostgrestVersion: "12.2.12 (cd3cf9e)"
+    PostgrestVersion: "14.5"
   }
   public: {
     Tables: {
@@ -2383,6 +2383,500 @@ export type Database = {
           },
         ]
       }
+      support_ticket_attachments: {
+        Row: {
+          bucket: string
+          byte_size: number
+          checksum_sha256: string | null
+          content_type: string
+          created_at: string
+          id: string
+          kind: string
+          object_key: string
+          original_filename: string
+          rejection_reason: string | null
+          retention_expires_at: string | null
+          status: string
+          ticket_id: string
+          updated_at: string
+          uploaded_by_usuario_id: string
+        }
+        Insert: {
+          bucket?: string
+          byte_size: number
+          checksum_sha256?: string | null
+          content_type: string
+          created_at?: string
+          id?: string
+          kind: string
+          object_key: string
+          original_filename: string
+          rejection_reason?: string | null
+          retention_expires_at?: string | null
+          status?: string
+          ticket_id: string
+          updated_at?: string
+          uploaded_by_usuario_id: string
+        }
+        Update: {
+          bucket?: string
+          byte_size?: number
+          checksum_sha256?: string | null
+          content_type?: string
+          created_at?: string
+          id?: string
+          kind?: string
+          object_key?: string
+          original_filename?: string
+          rejection_reason?: string | null
+          retention_expires_at?: string | null
+          status?: string
+          ticket_id?: string
+          updated_at?: string
+          uploaded_by_usuario_id?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "support_ticket_attachments_ticket_id_fkey"
+            columns: ["ticket_id"]
+            isOneToOne: false
+            referencedRelation: "support_tickets"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "support_ticket_attachments_uploaded_by_usuario_id_fkey"
+            columns: ["uploaded_by_usuario_id"]
+            isOneToOne: false
+            referencedRelation: "usuarios"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "support_ticket_attachments_uploaded_by_usuario_id_fkey"
+            columns: ["uploaded_by_usuario_id"]
+            isOneToOne: false
+            referencedRelation: "v_casas_anfitrionas_disponibles"
+            referencedColumns: ["anfitrion_id"]
+          },
+          {
+            foreignKeyName: "support_ticket_attachments_uploaded_by_usuario_id_fkey"
+            columns: ["uploaded_by_usuario_id"]
+            isOneToOne: false
+            referencedRelation: "v_casas_anfitrionas_disponibles"
+            referencedColumns: ["co_anfitrion_id"]
+          },
+          {
+            foreignKeyName: "support_ticket_attachments_uploaded_by_usuario_id_fkey"
+            columns: ["uploaded_by_usuario_id"]
+            isOneToOne: false
+            referencedRelation: "v_lideres_con_pareja"
+            referencedColumns: ["pareja_id"]
+          },
+          {
+            foreignKeyName: "support_ticket_attachments_uploaded_by_usuario_id_fkey"
+            columns: ["uploaded_by_usuario_id"]
+            isOneToOne: false
+            referencedRelation: "v_solicitudes_pendientes"
+            referencedColumns: ["miembro_id"]
+          },
+        ]
+      }
+      support_ticket_events: {
+        Row: {
+          action: string
+          actor_usuario_id: string | null
+          created_at: string
+          id: string
+          idempotency_key: string | null
+          metadata: Json
+          target_id: string | null
+          target_type: string
+          ticket_id: string
+        }
+        Insert: {
+          action: string
+          actor_usuario_id?: string | null
+          created_at?: string
+          id?: string
+          idempotency_key?: string | null
+          metadata?: Json
+          target_id?: string | null
+          target_type: string
+          ticket_id: string
+        }
+        Update: {
+          action?: string
+          actor_usuario_id?: string | null
+          created_at?: string
+          id?: string
+          idempotency_key?: string | null
+          metadata?: Json
+          target_id?: string | null
+          target_type?: string
+          ticket_id?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "support_ticket_events_actor_usuario_id_fkey"
+            columns: ["actor_usuario_id"]
+            isOneToOne: false
+            referencedRelation: "usuarios"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "support_ticket_events_actor_usuario_id_fkey"
+            columns: ["actor_usuario_id"]
+            isOneToOne: false
+            referencedRelation: "v_casas_anfitrionas_disponibles"
+            referencedColumns: ["anfitrion_id"]
+          },
+          {
+            foreignKeyName: "support_ticket_events_actor_usuario_id_fkey"
+            columns: ["actor_usuario_id"]
+            isOneToOne: false
+            referencedRelation: "v_casas_anfitrionas_disponibles"
+            referencedColumns: ["co_anfitrion_id"]
+          },
+          {
+            foreignKeyName: "support_ticket_events_actor_usuario_id_fkey"
+            columns: ["actor_usuario_id"]
+            isOneToOne: false
+            referencedRelation: "v_lideres_con_pareja"
+            referencedColumns: ["pareja_id"]
+          },
+          {
+            foreignKeyName: "support_ticket_events_actor_usuario_id_fkey"
+            columns: ["actor_usuario_id"]
+            isOneToOne: false
+            referencedRelation: "v_solicitudes_pendientes"
+            referencedColumns: ["miembro_id"]
+          },
+          {
+            foreignKeyName: "support_ticket_events_ticket_id_fkey"
+            columns: ["ticket_id"]
+            isOneToOne: false
+            referencedRelation: "support_tickets"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+      support_ticket_messages: {
+        Row: {
+          author_usuario_id: string
+          body: string
+          created_at: string
+          id: string
+          is_internal: boolean
+          ticket_id: string
+        }
+        Insert: {
+          author_usuario_id: string
+          body: string
+          created_at?: string
+          id?: string
+          is_internal?: boolean
+          ticket_id: string
+        }
+        Update: {
+          author_usuario_id?: string
+          body?: string
+          created_at?: string
+          id?: string
+          is_internal?: boolean
+          ticket_id?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "support_ticket_messages_author_usuario_id_fkey"
+            columns: ["author_usuario_id"]
+            isOneToOne: false
+            referencedRelation: "usuarios"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "support_ticket_messages_author_usuario_id_fkey"
+            columns: ["author_usuario_id"]
+            isOneToOne: false
+            referencedRelation: "v_casas_anfitrionas_disponibles"
+            referencedColumns: ["anfitrion_id"]
+          },
+          {
+            foreignKeyName: "support_ticket_messages_author_usuario_id_fkey"
+            columns: ["author_usuario_id"]
+            isOneToOne: false
+            referencedRelation: "v_casas_anfitrionas_disponibles"
+            referencedColumns: ["co_anfitrion_id"]
+          },
+          {
+            foreignKeyName: "support_ticket_messages_author_usuario_id_fkey"
+            columns: ["author_usuario_id"]
+            isOneToOne: false
+            referencedRelation: "v_lideres_con_pareja"
+            referencedColumns: ["pareja_id"]
+          },
+          {
+            foreignKeyName: "support_ticket_messages_author_usuario_id_fkey"
+            columns: ["author_usuario_id"]
+            isOneToOne: false
+            referencedRelation: "v_solicitudes_pendientes"
+            referencedColumns: ["miembro_id"]
+          },
+          {
+            foreignKeyName: "support_ticket_messages_ticket_id_fkey"
+            columns: ["ticket_id"]
+            isOneToOne: false
+            referencedRelation: "support_tickets"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+      support_tickets: {
+        Row: {
+          app_build_version: string | null
+          assignee_usuario_id: string | null
+          browser_name: string | null
+          campus_id: string | null
+          category: string
+          closed_at: string | null
+          created_at: string
+          current_route: string | null
+          description: string
+          diagnostics_consent: boolean
+          id: string
+          os_name: string | null
+          reporter_usuario_id: string
+          search_vector: unknown
+          sentry_event_id: string | null
+          severity: string
+          status: string
+          ticket_number: number
+          title: string
+          updated_at: string
+          viewport: string | null
+        }
+        Insert: {
+          app_build_version?: string | null
+          assignee_usuario_id?: string | null
+          browser_name?: string | null
+          campus_id?: string | null
+          category: string
+          closed_at?: string | null
+          created_at?: string
+          current_route?: string | null
+          description: string
+          diagnostics_consent?: boolean
+          id?: string
+          os_name?: string | null
+          reporter_usuario_id: string
+          search_vector?: unknown
+          sentry_event_id?: string | null
+          severity?: string
+          status?: string
+          ticket_number?: number
+          title: string
+          updated_at?: string
+          viewport?: string | null
+        }
+        Update: {
+          app_build_version?: string | null
+          assignee_usuario_id?: string | null
+          browser_name?: string | null
+          campus_id?: string | null
+          category?: string
+          closed_at?: string | null
+          created_at?: string
+          current_route?: string | null
+          description?: string
+          diagnostics_consent?: boolean
+          id?: string
+          os_name?: string | null
+          reporter_usuario_id?: string
+          search_vector?: unknown
+          sentry_event_id?: string | null
+          severity?: string
+          status?: string
+          ticket_number?: number
+          title?: string
+          updated_at?: string
+          viewport?: string | null
+        }
+        Relationships: [
+          {
+            foreignKeyName: "support_tickets_assignee_usuario_id_fkey"
+            columns: ["assignee_usuario_id"]
+            isOneToOne: false
+            referencedRelation: "usuarios"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "support_tickets_assignee_usuario_id_fkey"
+            columns: ["assignee_usuario_id"]
+            isOneToOne: false
+            referencedRelation: "v_casas_anfitrionas_disponibles"
+            referencedColumns: ["anfitrion_id"]
+          },
+          {
+            foreignKeyName: "support_tickets_assignee_usuario_id_fkey"
+            columns: ["assignee_usuario_id"]
+            isOneToOne: false
+            referencedRelation: "v_casas_anfitrionas_disponibles"
+            referencedColumns: ["co_anfitrion_id"]
+          },
+          {
+            foreignKeyName: "support_tickets_assignee_usuario_id_fkey"
+            columns: ["assignee_usuario_id"]
+            isOneToOne: false
+            referencedRelation: "v_lideres_con_pareja"
+            referencedColumns: ["pareja_id"]
+          },
+          {
+            foreignKeyName: "support_tickets_assignee_usuario_id_fkey"
+            columns: ["assignee_usuario_id"]
+            isOneToOne: false
+            referencedRelation: "v_solicitudes_pendientes"
+            referencedColumns: ["miembro_id"]
+          },
+          {
+            foreignKeyName: "support_tickets_campus_id_fkey"
+            columns: ["campus_id"]
+            isOneToOne: false
+            referencedRelation: "campus"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "support_tickets_reporter_usuario_id_fkey"
+            columns: ["reporter_usuario_id"]
+            isOneToOne: false
+            referencedRelation: "usuarios"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "support_tickets_reporter_usuario_id_fkey"
+            columns: ["reporter_usuario_id"]
+            isOneToOne: false
+            referencedRelation: "v_casas_anfitrionas_disponibles"
+            referencedColumns: ["anfitrion_id"]
+          },
+          {
+            foreignKeyName: "support_tickets_reporter_usuario_id_fkey"
+            columns: ["reporter_usuario_id"]
+            isOneToOne: false
+            referencedRelation: "v_casas_anfitrionas_disponibles"
+            referencedColumns: ["co_anfitrion_id"]
+          },
+          {
+            foreignKeyName: "support_tickets_reporter_usuario_id_fkey"
+            columns: ["reporter_usuario_id"]
+            isOneToOne: false
+            referencedRelation: "v_lideres_con_pareja"
+            referencedColumns: ["pareja_id"]
+          },
+          {
+            foreignKeyName: "support_tickets_reporter_usuario_id_fkey"
+            columns: ["reporter_usuario_id"]
+            isOneToOne: false
+            referencedRelation: "v_solicitudes_pendientes"
+            referencedColumns: ["miembro_id"]
+          },
+        ]
+      }
+      support_user_capabilities: {
+        Row: {
+          capability: string
+          granted_at: string
+          granted_by_usuario_id: string | null
+          id: string
+          revoked_at: string | null
+          usuario_id: string
+        }
+        Insert: {
+          capability: string
+          granted_at?: string
+          granted_by_usuario_id?: string | null
+          id?: string
+          revoked_at?: string | null
+          usuario_id: string
+        }
+        Update: {
+          capability?: string
+          granted_at?: string
+          granted_by_usuario_id?: string | null
+          id?: string
+          revoked_at?: string | null
+          usuario_id?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "support_user_capabilities_granted_by_usuario_id_fkey"
+            columns: ["granted_by_usuario_id"]
+            isOneToOne: false
+            referencedRelation: "usuarios"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "support_user_capabilities_granted_by_usuario_id_fkey"
+            columns: ["granted_by_usuario_id"]
+            isOneToOne: false
+            referencedRelation: "v_casas_anfitrionas_disponibles"
+            referencedColumns: ["anfitrion_id"]
+          },
+          {
+            foreignKeyName: "support_user_capabilities_granted_by_usuario_id_fkey"
+            columns: ["granted_by_usuario_id"]
+            isOneToOne: false
+            referencedRelation: "v_casas_anfitrionas_disponibles"
+            referencedColumns: ["co_anfitrion_id"]
+          },
+          {
+            foreignKeyName: "support_user_capabilities_granted_by_usuario_id_fkey"
+            columns: ["granted_by_usuario_id"]
+            isOneToOne: false
+            referencedRelation: "v_lideres_con_pareja"
+            referencedColumns: ["pareja_id"]
+          },
+          {
+            foreignKeyName: "support_user_capabilities_granted_by_usuario_id_fkey"
+            columns: ["granted_by_usuario_id"]
+            isOneToOne: false
+            referencedRelation: "v_solicitudes_pendientes"
+            referencedColumns: ["miembro_id"]
+          },
+          {
+            foreignKeyName: "support_user_capabilities_usuario_id_fkey"
+            columns: ["usuario_id"]
+            isOneToOne: false
+            referencedRelation: "usuarios"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "support_user_capabilities_usuario_id_fkey"
+            columns: ["usuario_id"]
+            isOneToOne: false
+            referencedRelation: "v_casas_anfitrionas_disponibles"
+            referencedColumns: ["anfitrion_id"]
+          },
+          {
+            foreignKeyName: "support_user_capabilities_usuario_id_fkey"
+            columns: ["usuario_id"]
+            isOneToOne: false
+            referencedRelation: "v_casas_anfitrionas_disponibles"
+            referencedColumns: ["co_anfitrion_id"]
+          },
+          {
+            foreignKeyName: "support_user_capabilities_usuario_id_fkey"
+            columns: ["usuario_id"]
+            isOneToOne: false
+            referencedRelation: "v_lideres_con_pareja"
+            referencedColumns: ["pareja_id"]
+          },
+          {
+            foreignKeyName: "support_user_capabilities_usuario_id_fkey"
+            columns: ["usuario_id"]
+            isOneToOne: false
+            referencedRelation: "v_solicitudes_pendientes"
+            referencedColumns: ["miembro_id"]
+          },
+        ]
+      }
       temporadas: {
         Row: {
           activa: boolean
@@ -3665,11 +4159,9 @@ export type Database = {
         Args: {
           p_activo?: boolean
           p_auth_id: string
-          p_campus_id?: string
           p_eliminado?: boolean
           p_estado_temporal?: string
           p_limit?: number
-          p_localidad_id?: string
           p_municipio_id?: string
           p_offset?: number
           p_parroquia_id?: string
@@ -3699,21 +4191,37 @@ export type Database = {
           total_count: number
         }[]
       }
-      obtener_kpis_grupos_para_usuario: {
-        Args: { p_auth_id: string; p_campus_id?: string }
-        Returns: {
-          desviacion_miembros: number
-          fecha_ultima_actualizacion: string
-          pct_aprobados: number
-          pct_con_lider: number
-          pct_sin_director: number
-          promedio_miembros: number
-          total_aprobados: number
-          total_con_lider: number
-          total_grupos: number
-          total_sin_director: number
-        }[]
-      }
+      obtener_kpis_grupos_para_usuario:
+        | {
+            Args: { p_auth_id: string }
+            Returns: {
+              desviacion_miembros: number
+              fecha_ultima_actualizacion: string
+              pct_aprobados: number
+              pct_con_lider: number
+              pct_sin_director: number
+              promedio_miembros: number
+              total_aprobados: number
+              total_con_lider: number
+              total_grupos: number
+              total_sin_director: number
+            }[]
+          }
+        | {
+            Args: { p_auth_id: string; p_campus_id?: string }
+            Returns: {
+              desviacion_miembros: number
+              fecha_ultima_actualizacion: string
+              pct_aprobados: number
+              pct_con_lider: number
+              pct_sin_director: number
+              promedio_miembros: number
+              total_aprobados: number
+              total_con_lider: number
+              total_grupos: number
+              total_sin_director: number
+            }[]
+          }
       obtener_miembros_en_riesgo: { Args: { p_auth_id: string }; Returns: Json }
       obtener_ranking_asistencia_grupo: {
         Args: {


### PR DESCRIPTION
Closes #107

# Título del PR
chore(supabase): regenerate support database types

## Resumen
This PR regenerates `lib/supabase/database.types.ts` from Supabase staging after applying the support ticket schema.

## Qué Incluye
- Generated Supabase TypeScript types for the new `support_*` tables.
- Staging-generated drift captured by the type generator.

## Motivación / Por Qué
The support schema must be reflected in application types before actions/routes/UI consume the new tables safely.

## Chain Context
Strategy: feature-branch-chain

```text
main
└── feat/support-ticket-system-tracker
    └── feat/support-ticket-schema
        └── chore/support-database-types 📍
            └── chore/support-staging-guardrails
                └── chore/support-staging-baseline-tools
                    └── docs/support-staging-baseline
                        └── feat/support-r2-helpers
                            └── feat/support-r2-attachment-routes
                                └── docs/support-ticket-sdd
```

Current PR boundary:
- Generated Supabase database types only.

Out of scope:
- Schema/RLS migration logic.
- Staging baseline tooling.
- R2 attachment routes.
- Reporter UI.

## Evidencia Visual (si aplica)
No aplica.

## Migraciones / Base de Datos
- [x] No aplica
- [ ] Sí (orden exacto):
```text
N/A
```
Notas:
- Types were generated from Supabase staging after the schema-only baseline and support migration were applied.

## Impacto y Riesgos
- `database.types.ts` includes generated staging schema drift beyond support tables (`PostgrestVersion`/RPC signatures). Review this as generated output tied to staging regeneration.
- No production database mutation was performed.

## Checklist Autor
- [x] Código formateado (Prettier/ESLint)
- [x] Sin `console.log` / debugger
- [x] Validaciones con zod para entradas nuevas
- [x] Estados loading/error/empty cubiertos
- [x] Tipos TypeScript correctos
- [x] Migraciones probadas local/staging
- [x] Documentación actualizada (`docs/` o README)
- [x] Variables de entorno documentadas
- [x] Rebase con `main` limpio

## Checklist Revisor
- [ ] Propósito claro
- [ ] Nombres descriptivos
- [ ] Sin lógica duplicada evidente
- [ ] Manejo adecuado de errores
- [ ] Cambios acotados al alcance
- [ ] Sin secretos / datos sensibles

## Pruebas Manuales Realizadas
- Static support tests passed as part of the support suite.
- Live staging RLS tests: 12 passed, 0 failed, 0 skipped.
- Typecheck previously passed with these generated types: `pnpm exec tsc --noEmit`.

## Pendientes / Follow-up
- Staging guardrails and baseline tooling in the next chained PRs.

## Notas Adicionales
This PR exists to keep generated type drift out of the schema/RLS review.
