### PR TITLE
feat(support): add reporter ticket actions

### DIFF
--- a/__tests__/app/support-pages.test.tsx
+++ b/__tests__/app/support-pages.test.tsx
@@ -1,0 +1,62 @@
+import { render, screen } from '@testing-library/react'
+
+import AyudaPage from '@/app/(auth)/ayuda/page'
+import ReportarPage from '@/app/(auth)/ayuda/reportar/page'
+import TicketsPage from '@/app/(auth)/ayuda/tickets/page'
+import TicketDetailPage from '@/app/(auth)/ayuda/tickets/[id]/page'
+
+jest.mock('@/lib/actions/support.actions', () => ({
+  createSupportTicket: jest.fn(),
+  createSupportTicketMessage: jest.fn(),
+  getSupportTicketDetail: jest.fn().mockResolvedValue({
+    success: true,
+    ticket: {
+      id: 'ticket-1',
+      ticketNumber: 42,
+      title: 'Map bug',
+      description: 'The group map does not load.',
+      status: 'received',
+      category: 'bug',
+      severity: 'normal',
+      createdAt: '2026-06-09T00:00:00Z',
+      updatedAt: '2026-06-09T00:00:00Z',
+      evidence: { currentRoute: '/dashboard', browserName: 'Chrome', osName: 'macOS', viewport: '1440x900', appBuildVersion: null, sentryEventId: null, diagnosticsConsent: true },
+      messages: [{ id: 'message-1', body: 'Public reply', createdAt: '2026-06-09T00:01:00Z' }],
+    },
+  }),
+  listSupportTickets: jest.fn().mockResolvedValue({ success: true, tickets: [{ id: 'ticket-1', ticketNumber: 42, title: 'Map bug', status: 'received', category: 'bug', severity: 'normal', createdAt: '2026-06-09T00:00:00Z', updatedAt: '2026-06-09T00:00:00Z' }] }),
+}))
+jest.mock('@/hooks/useCurrentUser', () => ({ useCurrentUser: () => ({ usuario: null, roles: ['miembro'], loading: false }) }))
+jest.mock('@/hooks/useBranding', () => ({ useBranding: () => ({ logoLightUrl: null, logoDarkUrl: null }) }))
+jest.mock('@/hooks/use-notificaciones', () => ({ useNotificaciones: () => ({ info: jest.fn() }) }))
+
+describe('reporter support pages', () => {
+  it('renders the /ayuda home with report and history links', async () => {
+    render(await AyudaPage())
+
+    expect(screen.getByRole('link', { name: /Report a problem/i })).toHaveAttribute('href', '/ayuda/reportar')
+    expect(screen.getByRole('link', { name: /View my tickets/i })).toHaveAttribute('href', '/ayuda/tickets')
+  })
+
+  it('renders the report form with safe evidence fields', async () => {
+    render(await ReportarPage())
+
+    expect(screen.getByLabelText(/Title/i)).toHaveAttribute('name', 'title')
+    expect(screen.getByLabelText(/Allow safe diagnostics/i)).toHaveAttribute('name', 'diagnosticsConsent')
+    expect(document.querySelector('[name="cookies"]')).not.toBeInTheDocument()
+  })
+
+  it('renders the reporter ticket history', async () => {
+    render(await TicketsPage())
+
+    expect(screen.getByRole('link', { name: /#42 Map bug/i })).toHaveAttribute('href', '/ayuda/tickets/ticket-1')
+  })
+
+  it('renders reporter-visible ticket details and reply form', async () => {
+    render(await TicketDetailPage({ params: Promise.resolve({ id: 'ticket-1' }) }))
+
+    expect(screen.getByText('The group map does not load.')).toBeInTheDocument()
+    expect(screen.getByText('Public reply')).toBeInTheDocument()
+    expect(screen.getByLabelText(/Reply/i)).toHaveAttribute('name', 'body')
+  })
+})

--- a/__tests__/components/support-navigation.test.tsx
+++ b/__tests__/components/support-navigation.test.tsx
@@ -1,0 +1,28 @@
+import { render, screen } from '@testing-library/react'
+
+import { MenuInferiorMovil } from '@/components/ui/menu-inferior-movil'
+import { SidebarModerna } from '@/components/ui/sidebar-moderna'
+
+jest.mock('next/navigation', () => ({
+  usePathname: () => '/dashboard',
+  useRouter: () => ({ push: jest.fn() }),
+}))
+jest.mock('@/hooks/useCurrentUser', () => ({ useCurrentUser: () => ({ usuario: null, roles: ['miembro'], loading: false }) }))
+jest.mock('@/hooks/useBranding', () => ({ useBranding: () => ({ logoLightUrl: null, logoDarkUrl: null }) }))
+jest.mock('@/hooks/use-notificaciones', () => ({ useNotificaciones: () => ({ info: jest.fn() }) }))
+jest.mock('@/hooks/useCampus', () => ({ useCampus: () => ({ campusActivo: null, localidadActiva: null, campusDisponibles: [], localidadesDisponibles: [], campusId: null, localidadId: null, esSuperadmin: false, loading: false, seleccionarCampus: jest.fn(), seleccionarLocalidad: jest.fn() }) }))
+jest.mock('@/lib/actions/auth.actions', () => ({ logout: jest.fn() }))
+
+describe('support navigation links', () => {
+  it('renders the mobile bottom Ayuda item as a real /ayuda link', () => {
+    render(<MenuInferiorMovil />)
+
+    expect(screen.getByLabelText('Navegar a Ayuda')).toHaveAttribute('href', '/ayuda')
+  })
+
+  it('renders the desktop sidebar Ayuda footer item as a real /ayuda link', () => {
+    render(<SidebarModerna />)
+
+    expect(screen.getByRole('link', { name: 'Ayuda' })).toHaveAttribute('href', '/ayuda')
+  })
+})

--- a/__tests__/lib/actions/support.actions.test.ts
+++ b/__tests__/lib/actions/support.actions.test.ts
@@ -1,0 +1,178 @@
+import {
+  createSupportTicket,
+  createSupportTicketMessage,
+  getSupportTicketDetail,
+  listSupportTickets,
+  sanitizeSupportEvidence,
+} from '@/lib/actions/support.actions'
+
+const createSupabaseServerClient = jest.fn()
+const revalidatePath = jest.fn()
+
+jest.mock('@/lib/supabase/server', () => ({ createSupabaseServerClient: () => createSupabaseServerClient() }))
+jest.mock('next/cache', () => ({ revalidatePath: (path: string) => revalidatePath(path) }))
+
+describe('support reporter actions', () => {
+  beforeEach(() => {
+    createSupabaseServerClient.mockReset()
+    revalidatePath.mockReset()
+  })
+
+  it('sanitizes evidence to the reporter-safe allowlist', () => {
+    expect(sanitizeSupportEvidence({
+      currentRoute: '/dashboard?token=secret#section',
+      browserName: 'Chrome',
+      osName: 'macOS',
+      viewport: '1440x900',
+      appBuildVersion: 'build-123',
+      sentryEventId: 'event-1',
+      diagnosticsConsent: true,
+      cookies: 'private',
+      localStorage: 'private',
+      rawSentryPayload: { secret: true },
+    })).toEqual({
+      current_route: '/dashboard',
+      browser_name: 'Chrome',
+      os_name: 'macOS',
+      viewport: '1440x900',
+      app_build_version: 'build-123',
+      sentry_event_id: 'event-1',
+      diagnostics_consent: true,
+    })
+  })
+
+  it('does not persist diagnostic fields without reporter consent', () => {
+    expect(sanitizeSupportEvidence({
+      currentRoute: '/dashboard#token-secret',
+      browserName: 'Chrome',
+      osName: 'macOS',
+      viewport: '1440x900',
+      appBuildVersion: 'build-123',
+      sentryEventId: 'event-1',
+      diagnosticsConsent: 'false',
+    })).toEqual({
+      current_route: '/dashboard',
+      browser_name: null,
+      os_name: null,
+      viewport: null,
+      app_build_version: null,
+      sentry_event_id: null,
+      diagnostics_consent: false,
+    })
+  })
+
+  it('rejects anonymous ticket creation before inserting', async () => {
+    const insert = jest.fn()
+    createSupabaseServerClient.mockResolvedValue({
+      auth: { getUser: jest.fn().mockResolvedValue({ data: { user: null } }) },
+      from: jest.fn().mockReturnValue({ insert }),
+    })
+
+    const result = await createSupportTicket(createTicketFormData())
+
+    expect(result).toEqual({ success: false, error: 'Not authenticated' })
+    expect(insert).not.toHaveBeenCalled()
+  })
+
+  it('creates a received ticket for the authenticated reporter', async () => {
+    const insert = jest.fn().mockReturnValue({ select: jest.fn().mockReturnValue({ single: jest.fn().mockResolvedValue({ data: { id: 'ticket-1', ticket_number: 42 }, error: null }) }) })
+    createSupabaseServerClient.mockResolvedValue({
+      auth: { getUser: jest.fn().mockResolvedValue({ data: { user: { id: 'auth-1' } } }) },
+      from: createFromMock({ usuarioId: 'usuario-1', insert }),
+    })
+
+    const result = await createSupportTicket(createTicketFormData())
+
+    expect(result).toEqual({ success: true, ticketId: 'ticket-1', ticketNumber: 42 })
+    expect(insert).toHaveBeenCalledWith(expect.objectContaining({
+      reporter_usuario_id: 'usuario-1',
+      status: 'received',
+      title: 'Cannot open group map',
+      diagnostics_consent: true,
+    }))
+    expect(insert.mock.calls[0][0]).not.toHaveProperty('cookies')
+    expect(revalidatePath).toHaveBeenCalledWith('/ayuda/tickets')
+  })
+
+  it('lists only public reporter fields from RLS-filtered tickets', async () => {
+    createSupabaseServerClient.mockResolvedValue({
+      auth: { getUser: jest.fn().mockResolvedValue({ data: { user: { id: 'auth-1' } } }) },
+      from: jest.fn().mockReturnValue({ select: jest.fn().mockReturnValue({ order: jest.fn().mockResolvedValue({ data: [{ id: 'ticket-1', ticket_number: 42, title: 'Map bug', status: 'received', category: 'bug', severity: 'normal', created_at: '2026-06-09T00:00:00Z', updated_at: '2026-06-09T00:00:00Z', description: 'private detail' }], error: null }) }) }),
+    })
+
+    await expect(listSupportTickets()).resolves.toEqual({ success: true, tickets: [{ id: 'ticket-1', ticketNumber: 42, title: 'Map bug', status: 'received', category: 'bug', severity: 'normal', createdAt: '2026-06-09T00:00:00Z', updatedAt: '2026-06-09T00:00:00Z' }] })
+  })
+
+  it('returns ticket detail with public messages and no internal evidence', async () => {
+    const ticketQuery = { select: jest.fn().mockReturnValue({ eq: jest.fn().mockReturnValue({ maybeSingle: jest.fn().mockResolvedValue({ data: { id: 'ticket-1', ticket_number: 42, title: 'Map bug', description: 'Steps', status: 'received', category: 'bug', severity: 'normal', current_route: '/dashboard', browser_name: 'Chrome', os_name: 'macOS', viewport: '1440x900', app_build_version: 'build-123', sentry_event_id: 'event-1', diagnostics_consent: true, created_at: '2026-06-09T00:00:00Z', updated_at: '2026-06-09T00:00:00Z' }, error: null }) }) }) }
+    const messagesFilter = { eq: jest.fn(), order: jest.fn().mockResolvedValue({ data: [{ id: 'message-1', body: 'Public reply', is_internal: false, created_at: '2026-06-09T00:01:00Z' }], error: null }) }
+    messagesFilter.eq.mockReturnValue(messagesFilter)
+    const messagesQuery = { select: jest.fn().mockReturnValue(messagesFilter) }
+    createSupabaseServerClient.mockResolvedValue({
+      auth: { getUser: jest.fn().mockResolvedValue({ data: { user: { id: 'auth-1' } } }) },
+      from: jest.fn((table) => table === 'support_tickets' ? ticketQuery : messagesQuery),
+    })
+
+    const result = await getSupportTicketDetail('ticket-1')
+
+    expect(result.success).toBe(true)
+    expect(result.ticket?.messages).toEqual([{ id: 'message-1', body: 'Public reply', createdAt: '2026-06-09T00:01:00Z' }])
+    expect(result.ticket).not.toHaveProperty('rawSentryPayload')
+    expect(messagesFilter.eq).toHaveBeenCalledWith('ticket_id', 'ticket-1')
+    expect(messagesFilter.eq).toHaveBeenCalledWith('is_internal', false)
+  })
+
+  it('maps Supabase list errors to a stable user-safe message', async () => {
+    createSupabaseServerClient.mockResolvedValue({
+      auth: { getUser: jest.fn().mockResolvedValue({ data: { user: { id: 'auth-1' } } }) },
+      from: jest.fn().mockReturnValue({ select: jest.fn().mockReturnValue({ order: jest.fn().mockResolvedValue({ data: null, error: { message: 'relation support_tickets does not exist' } }) }) }),
+    })
+
+    await expect(listSupportTickets()).resolves.toEqual({ success: false, error: 'Unable to load support tickets', tickets: [] })
+  })
+
+  it('adds reporter public replies only', async () => {
+    const insert = jest.fn().mockResolvedValue({ error: null })
+    createSupabaseServerClient.mockResolvedValue({
+      auth: { getUser: jest.fn().mockResolvedValue({ data: { user: { id: 'auth-1' } } }) },
+      from: createFromMock({ usuarioId: 'usuario-1', insert }),
+    })
+
+    const result = await createSupportTicketMessage('ticket-1', createMessageFormData())
+
+    expect(result).toEqual({ success: true })
+    expect(insert).toHaveBeenCalledWith({ ticket_id: 'ticket-1', author_usuario_id: 'usuario-1', body: 'I can reproduce it on mobile.', is_internal: false })
+    expect(revalidatePath).toHaveBeenCalledWith('/ayuda/tickets/ticket-1')
+  })
+})
+
+function createTicketFormData() {
+  const formData = new FormData()
+  formData.set('title', 'Cannot open group map')
+  formData.set('description', 'The map stays blank after I open the dashboard.')
+  formData.set('category', 'bug')
+  formData.set('severity', 'normal')
+  formData.set('currentRoute', '/dashboard')
+  formData.set('browserName', 'Chrome')
+  formData.set('osName', 'macOS')
+  formData.set('viewport', '1440x900')
+  formData.set('appBuildVersion', 'build-123')
+  formData.set('sentryEventId', 'event-1')
+  formData.set('diagnosticsConsent', 'true')
+  formData.set('cookies', 'private')
+  return formData
+}
+
+function createMessageFormData() {
+  const formData = new FormData()
+  formData.set('body', 'I can reproduce it on mobile.')
+  formData.set('isInternal', 'true')
+  return formData
+}
+
+function createFromMock(input: { usuarioId: string; insert: jest.Mock }) {
+  return jest.fn((table) => {
+    if (table === 'usuarios') return { select: jest.fn().mockReturnValue({ eq: jest.fn().mockReturnValue({ maybeSingle: jest.fn().mockResolvedValue({ data: { id: input.usuarioId }, error: null }) }) }) }
+    return { insert: input.insert }
+  })
+}

--- a/__tests__/lib/actions/support.actions.test.ts
+++ b/__tests__/lib/actions/support.actions.test.ts
@@ -3,8 +3,8 @@ import {
   createSupportTicketMessage,
   getSupportTicketDetail,
   listSupportTickets,
-  sanitizeSupportEvidence,
 } from '@/lib/actions/support.actions'
+import { sanitizeSupportEvidence } from '@/lib/support/support-evidence'
 
 const createSupabaseServerClient = jest.fn()
 const revalidatePath = jest.fn()

--- a/app/(auth)/ayuda/page.tsx
+++ b/app/(auth)/ayuda/page.tsx
@@ -1,0 +1,34 @@
+import Link from 'next/link'
+import { FileText, History } from 'lucide-react'
+
+import { BotonSistema, ContenedorDashboard, TarjetaSistema, TextoSistema, TituloSistema } from '@/components/ui/sistema-diseno'
+
+export default async function AyudaPage() {
+  return (
+    <ContenedorDashboard titulo="Help" descripcion="Report problems and follow support updates from one place.">
+      <div className="grid gap-4 md:grid-cols-2">
+        <TarjetaSistema className="space-y-4">
+          <FileText className="h-8 w-8 text-[var(--brand-primary)]" />
+          <div className="space-y-2">
+            <TituloSistema nivel={2}>Report a problem</TituloSistema>
+            <TextoSistema variante="sutil">Send the support team safe steps and diagnostics without exposing private browser data.</TextoSistema>
+          </div>
+          <Link href="/ayuda/reportar">
+            <BotonSistema>Report a problem</BotonSistema>
+          </Link>
+        </TarjetaSistema>
+
+        <TarjetaSistema className="space-y-4">
+          <History className="h-8 w-8 text-[var(--brand-primary)]" />
+          <div className="space-y-2">
+            <TituloSistema nivel={2}>Ticket history</TituloSistema>
+            <TextoSistema variante="sutil">Review the status of your reports and reply when support needs more information.</TextoSistema>
+          </div>
+          <Link href="/ayuda/tickets">
+            <BotonSistema variante="outline">View my tickets</BotonSistema>
+          </Link>
+        </TarjetaSistema>
+      </div>
+    </ContenedorDashboard>
+  )
+}

--- a/app/(auth)/ayuda/reportar/page.tsx
+++ b/app/(auth)/ayuda/reportar/page.tsx
@@ -1,0 +1,48 @@
+import { createSupportTicket } from '@/lib/actions/support.actions'
+import { BotonSistema, ContenedorDashboard, InputSistema, TarjetaSistema, TextareaSistema, TextoSistema } from '@/components/ui/sistema-diseno'
+
+export default async function ReportarPage() {
+  async function submitTicket(formData: FormData) {
+    'use server'
+    await createSupportTicket(formData)
+  }
+
+  return (
+    <ContenedorDashboard titulo="Report a problem" botonRegreso={{ href: '/ayuda', texto: 'Back to Help' }}>
+      <TarjetaSistema>
+        <form action={submitTicket} className="space-y-5">
+          <InputSistema name="title" label="Title" minLength={5} maxLength={160} required placeholder="Example: Cannot open group map" />
+          <TextareaSistema name="description" label="Steps and expected result" filas={6} minLength={10} maxLength={8000} required placeholder="Tell us what happened, what you expected, and how to reproduce it." />
+          <div className="grid gap-4 md:grid-cols-2">
+            <label className="space-y-2 text-sm font-medium text-foreground">
+              <span>Category</span>
+              <select name="category" defaultValue="bug" className="block w-full min-h-[44px] rounded-xl border border-border bg-card/50 px-3 py-3 text-foreground focus:outline-none focus:ring-2 focus:ring-[var(--brand-primary)]/20">
+                <option value="bug">Bug</option><option value="access">Access</option><option value="data">Data</option><option value="other">Other</option>
+              </select>
+            </label>
+            <label className="space-y-2 text-sm font-medium text-foreground">
+              <span>Severity</span>
+              <select name="severity" defaultValue="normal" className="block w-full min-h-[44px] rounded-xl border border-border bg-card/50 px-3 py-3 text-foreground focus:outline-none focus:ring-2 focus:ring-[var(--brand-primary)]/20">
+                <option value="low">Low</option><option value="normal">Normal</option><option value="high">High</option><option value="urgent">Urgent</option>
+              </select>
+            </label>
+          </div>
+          <div className="grid gap-4 md:grid-cols-2">
+            <InputSistema name="currentRoute" label="Route" placeholder="/dashboard" />
+            <InputSistema name="viewport" label="Viewport" placeholder="390x844" />
+            <InputSistema name="browserName" label="Browser" placeholder="Chrome, Safari, Edge" />
+            <InputSistema name="osName" label="Operating system" placeholder="macOS, iOS, Android" />
+          </div>
+          <InputSistema name="sentryEventId" label="Sentry event ID" placeholder="Optional reference" />
+          <input type="hidden" name="appBuildVersion" value={process.env.NEXT_PUBLIC_APP_VERSION ?? ''} />
+          <label className="flex items-start gap-3 text-sm text-foreground">
+            <input type="checkbox" name="diagnosticsConsent" value="true" className="mt-1 h-4 w-4 rounded border-border" />
+            <span><strong>Allow safe diagnostics</strong><br /><span className="text-muted-foreground">Only route, browser, OS, viewport, app version, and Sentry reference are stored. Cookies, passwords, localStorage, and raw payloads are never collected.</span></span>
+          </label>
+          <TextoSistema variante="muted" tamaño="sm">Attachments are uploaded after ticket creation from the private attachment flow.</TextoSistema>
+          <BotonSistema type="submit">Submit ticket</BotonSistema>
+        </form>
+      </TarjetaSistema>
+    </ContenedorDashboard>
+  )
+}

--- a/app/(auth)/ayuda/tickets/[id]/page.tsx
+++ b/app/(auth)/ayuda/tickets/[id]/page.tsx
@@ -1,0 +1,46 @@
+import { notFound } from 'next/navigation'
+
+import { createSupportTicketMessage, getSupportTicketDetail } from '@/lib/actions/support.actions'
+import { BadgeSistema, BotonSistema, ContenedorDashboard, TarjetaSistema, TextareaSistema, TextoSistema, TituloSistema } from '@/components/ui/sistema-diseno'
+
+export default async function TicketDetailPage({ params }: { params: Promise<{ id: string }> }) {
+  const { id } = await params
+  const result = await getSupportTicketDetail(id)
+  if (!result.success || !result.ticket) notFound()
+  const ticket = result.ticket
+
+  async function replyAction(formData: FormData) {
+    'use server'
+    await createSupportTicketMessage(ticket.id, formData)
+  }
+
+  return (
+    <ContenedorDashboard titulo={`Ticket #${ticket.ticketNumber}`} botonRegreso={{ href: '/ayuda/tickets', texto: 'Back to tickets' }}>
+      <TarjetaSistema className="space-y-4">
+        <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
+          <div className="space-y-2">
+            <TituloSistema nivel={2}>{ticket.title}</TituloSistema>
+            <TextoSistema>{ticket.description}</TextoSistema>
+          </div>
+          <BadgeSistema variante="info">{ticket.status.replaceAll('_', ' ')}</BadgeSistema>
+        </div>
+        {ticket.evidence.diagnosticsConsent && (
+          <TextoSistema variante="muted" tamaño="sm">Safe diagnostics: {ticket.evidence.currentRoute ?? 'route unavailable'} · {ticket.evidence.browserName ?? 'browser unavailable'} · {ticket.evidence.osName ?? 'OS unavailable'} · {ticket.evidence.viewport ?? 'viewport unavailable'}</TextoSistema>
+        )}
+      </TarjetaSistema>
+
+      <TarjetaSistema className="space-y-4">
+        <TituloSistema nivel={2}>Conversation</TituloSistema>
+        {ticket.messages.length === 0 ? <TextoSistema variante="sutil">No replies yet.</TextoSistema> : ticket.messages.map((message) => (
+          <div key={message.id} className="rounded-xl border border-border bg-card/50 p-3">
+            <TextoSistema>{message.body}</TextoSistema>
+          </div>
+        ))}
+        <form action={replyAction} className="space-y-3">
+          <TextareaSistema name="body" label="Reply" filas={4} required />
+          <BotonSistema type="submit">Send reply</BotonSistema>
+        </form>
+      </TarjetaSistema>
+    </ContenedorDashboard>
+  )
+}

--- a/app/(auth)/ayuda/tickets/page.tsx
+++ b/app/(auth)/ayuda/tickets/page.tsx
@@ -1,0 +1,29 @@
+import Link from 'next/link'
+
+import { listSupportTickets } from '@/lib/actions/support.actions'
+import { BadgeSistema, BotonSistema, ContenedorDashboard, TarjetaSistema, TextoSistema } from '@/components/ui/sistema-diseno'
+
+export default async function TicketsPage() {
+  const result = await listSupportTickets()
+  const tickets = result.success ? result.tickets : []
+
+  return (
+    <ContenedorDashboard titulo="My support tickets" accionPrincipal={<Link href="/ayuda/reportar"><BotonSistema tamaño="sm">New ticket</BotonSistema></Link>}>
+      <div className="space-y-3">
+        {tickets.length === 0 ? (
+          <TarjetaSistema><TextoSistema variante="sutil">You have not submitted support tickets yet.</TextoSistema></TarjetaSistema>
+        ) : tickets.map((ticket) => (
+          <Link key={ticket.id} href={`/ayuda/tickets/${ticket.id}`} className="block focus-ring rounded-2xl">
+            <TarjetaSistema className="flex items-center justify-between gap-4">
+              <div>
+                <p className="font-semibold text-foreground">#{ticket.ticketNumber} {ticket.title}</p>
+                <TextoSistema variante="sutil" tamaño="sm">{ticket.category} · {ticket.severity}</TextoSistema>
+              </div>
+              <BadgeSistema variante="info">{ticket.status.replaceAll('_', ' ')}</BadgeSistema>
+            </TarjetaSistema>
+          </Link>
+        ))}
+      </div>
+    </ContenedorDashboard>
+  )
+}

--- a/components/ui/desktop-header.tsx
+++ b/components/ui/desktop-header.tsx
@@ -3,7 +3,7 @@
 import React, { useState, useEffect, useRef } from 'react'
 import Link from 'next/link'
 import { usePathname } from 'next/navigation'
-import { LogOut, User, ArrowLeft, Bell } from 'lucide-react'
+import { LogOut, User, ArrowLeft, Bell, HelpCircle } from 'lucide-react'
 import { logout } from "@/lib/actions/auth.actions"
 import { ThemeToggle } from './theme-toggle'
 import { UserAvatar } from './UserAvatar'
@@ -116,6 +116,14 @@ export function DesktopHeader({ titulo, accionPrincipal, breadcrumbs, botonRegre
                 {/* Right: theme toggle + user avatar popover */}
                 <div className="flex items-center gap-2 flex-shrink-0">
                     <ThemeToggle />
+
+                    <Link
+                        href="/ayuda"
+                        aria-label="Ayuda"
+                        className="relative flex items-center justify-center rounded-xl w-9 h-9 hover:bg-[var(--brand-accent)] transition-[background-color,transform] duration-200 ease-expo press-scale focus-ring touch-manipulation"
+                    >
+                        <HelpCircle className="w-5 h-5 text-muted-foreground" />
+                    </Link>
 
                     {/* Notification bell */}
                     <button

--- a/components/ui/header-movil.tsx
+++ b/components/ui/header-movil.tsx
@@ -577,19 +577,19 @@ export function HeaderMovil({ titulo }: HeaderMovilProps) {
             )} />
             <span className="font-medium text-sm">Actualizaciones</span>
           </Link>
-          {/* Ayuda — toast */}
-          <button
-            onClick={() => toast.info('Próximamente')}
+          <Link
+            href="/ayuda"
+            aria-current={isActive('/ayuda') ? "page" : undefined}
             className={cn(
               "flex items-center gap-3 px-3 py-2.5 rounded-xl min-h-[44px] w-full text-left",
               "transition-[background-color,color,transform] duration-200 ease-expo",
               "press-scale focus-ring touch-manipulation",
-              "text-foreground hover:bg-[var(--brand-accent)]"
+              isActive('/ayuda') ? "bg-[var(--brand-accent)] text-[var(--brand-primary)]" : "text-foreground hover:bg-[var(--brand-accent)]"
             )}
           >
-            <HelpCircle className="w-5 h-5 flex-shrink-0 text-muted-foreground" />
+            <HelpCircle className={cn("w-5 h-5 flex-shrink-0", isActive('/ayuda') ? "text-[var(--brand-primary)]" : "text-muted-foreground")} />
             <span className="font-medium text-sm">Ayuda</span>
-          </button>
+          </Link>
 
           {/* Theme Toggle */}
           <button

--- a/components/ui/menu-inferior-movil.tsx
+++ b/components/ui/menu-inferior-movil.tsx
@@ -5,46 +5,22 @@ import Link from 'next/link'
 import { usePathname } from 'next/navigation'
 import { LayoutDashboard, Users, UsersRound, HelpCircle } from 'lucide-react'
 import { cn } from '@/lib/utils'
-import { useNotificaciones } from '@/hooks/use-notificaciones'
 
 const elementosMenu = [
   { nombre: "Dashboard", icono: LayoutDashboard, enlace: "/dashboard", id: "dashboard" },
   { nombre: "Usuarios", icono: Users, enlace: "/users", id: "users" },
   { nombre: "Grupos de Vida", icono: UsersRound, enlace: "/grupos-vida", id: "grupos-vida" },
-  { nombre: "Ayuda", icono: HelpCircle, enlace: null, id: "ayuda" },
+  { nombre: "Ayuda", icono: HelpCircle, enlace: "/ayuda", id: "ayuda" },
 ]
 
 export function MenuInferiorMovil() {
   const pathname = usePathname()
-  const toast = useNotificaciones()
 
   return (
     <div className="md:hidden fixed bottom-0 left-0 right-0 z-50 bg-white/60 dark:bg-[rgba(35,35,45,0.60)] backdrop-blur-[40px] [-webkit-backdrop-filter:blur(40px)] backdrop-saturate-[1.8] border-t border-[var(--glass-border)] shadow-[var(--glass-shadow)] [transform:translateZ(0)] touch-manipulation">
       <div className="flex items-center justify-around px-2 py-2 safe-area-pb">
         {elementosMenu.map((elemento) => {
           const Icono = elemento.icono
-
-          // Ayuda → toast
-          if (!elemento.enlace) {
-            return (
-              <button
-                key={elemento.id}
-                onClick={() => toast.info('Próximamente')}
-                aria-label={elemento.nombre}
-                className={cn(
-                  "flex flex-col items-center justify-center px-3 py-2 rounded-xl min-w-0 flex-1 min-h-[44px]",
-                  "transition-[background-color,color,transform] duration-200 ease-expo",
-                  "press-scale focus-ring",
-                  "text-muted-foreground hover:text-[var(--brand-primary)] hover:bg-[var(--brand-accent)]"
-                )}
-              >
-                <Icono className="w-5 h-5 mb-1 text-muted-foreground" />
-                <span className="text-xs font-medium truncate max-w-full text-muted-foreground">
-                  {elemento.nombre}
-                </span>
-              </button>
-            )
-          }
 
           const esActivo = pathname === elemento.enlace ||
             (elemento.enlace !== "/dashboard" && pathname?.startsWith(elemento.enlace))

--- a/components/ui/sidebar-moderna.tsx
+++ b/components/ui/sidebar-moderna.tsx
@@ -6,7 +6,6 @@ import { usePathname, useRouter } from 'next/navigation'
 import { cn } from '@/lib/utils'
 import { LogoGlobalConnect } from '@/components/ui/logo-global-connect'
 import { SelectorCampus } from '@/components/ui/selector-campus'
-import { useNotificaciones } from '@/hooks/use-notificaciones'
 import {
   Users,
   UserCheck,
@@ -125,7 +124,6 @@ export function SidebarModerna({ className }: SidebarModernaProps) {
   const pathname = usePathname()
   const { usuario, roles, loading } = useCurrentUser()
   const branding = useBranding()
-  const toast = useNotificaciones()
 
 
   // ─── Tooltip hover handlers (collapsed mode) ───
@@ -493,27 +491,23 @@ export function SidebarModerna({ className }: SidebarModernaProps) {
               </Link>
             )
           })}
-          {/* Ayuda — toast */}
-          <button
-            onClick={() => toast.info('Próximamente')}
-            className={cn(
-              "flex items-center gap-3 px-3 py-2 rounded-xl group relative w-full min-h-[44px]",
-              "transition-[background-color,color,transform] duration-200 ease-expo",
-              "text-foreground hover:bg-[var(--brand-accent)] hover:text-foreground",
-              "touch-manipulation cursor-pointer",
-              isCollapsed && "justify-center px-2"
-            )}
+          <Link
+            href="/ayuda"
+            aria-current={isActive('/ayuda') ? "page" : undefined}
+            className={linkClasses(isActive('/ayuda'))}
             onMouseEnter={(e) => showTooltip(e, 'Ayuda')}
             onMouseLeave={hideTooltip}
           >
+            {isActive('/ayuda') && <ActivePill />}
             <HelpCircle className={cn(
-              "flex-shrink-0 transition-colors text-muted-foreground group-hover:text-foreground",
+              "flex-shrink-0 transition-colors",
+              isActive('/ayuda') ? "text-[var(--brand-primary)]" : "text-muted-foreground group-hover:text-foreground",
               isCollapsed ? "w-6 h-6" : "w-5 h-5"
             )} />
             {!isCollapsed && (
               <span className="font-medium truncate">Ayuda</span>
             )}
-          </button>
+          </Link>
           {/* Theme Toggle — same layout as other footer items */}
           <div
             className={cn(

--- a/lib/actions/support.actions.ts
+++ b/lib/actions/support.actions.ts
@@ -1,0 +1,173 @@
+"use server"
+
+import { revalidatePath } from 'next/cache'
+import { z } from 'zod'
+
+import { createSupabaseServerClient } from '@/lib/supabase/server'
+
+const diagnosticsConsentSchema = z.preprocess((value) => value === true || value === 'true' || value === 'on' || value === '1', z.boolean())
+
+const supportTicketSchema = z.object({
+  title: z.string().trim().min(5).max(160),
+  description: z.string().trim().min(10).max(8000),
+  category: z.string().trim().min(2).max(80),
+  severity: z.enum(['low', 'normal', 'high', 'urgent']).default('normal'),
+  currentRoute: z.string().trim().max(500).optional(),
+  browserName: z.string().trim().max(120).optional(),
+  osName: z.string().trim().max(120).optional(),
+  viewport: z.string().trim().max(40).optional(),
+  appBuildVersion: z.string().trim().max(120).optional(),
+  sentryEventId: z.string().trim().max(120).optional(),
+  diagnosticsConsent: diagnosticsConsentSchema,
+})
+
+const messageSchema = z.object({ body: z.string().trim().min(1).max(8000) })
+
+const SUPPORT_TICKET_CREATE_ERROR = 'Unable to create support ticket'
+const SUPPORT_TICKET_LIST_ERROR = 'Unable to load support tickets'
+const SUPPORT_TICKET_DETAIL_ERROR = 'Unable to load support ticket'
+const SUPPORT_TICKET_MESSAGE_ERROR = 'Unable to send support reply'
+
+type SupportTicketRow = {
+  id: string
+  ticket_number: number
+  title: string
+  description: string
+  status: string
+  category: string
+  severity: string
+  current_route: string | null
+  browser_name: string | null
+  os_name: string | null
+  viewport: string | null
+  app_build_version: string | null
+  sentry_event_id: string | null
+  diagnostics_consent: boolean
+  created_at: string
+  updated_at: string
+}
+
+type SupportMessageRow = { id: string; body: string; created_at: string }
+
+export function sanitizeSupportEvidence(input: Record<string, unknown>) {
+  const parsed = supportTicketSchema.partial().parse(input)
+  const diagnosticsConsent = parsed.diagnosticsConsent ?? false
+  return {
+    current_route: sanitizeRouteEvidence(parsed.currentRoute),
+    browser_name: diagnosticsConsent ? parsed.browserName || null : null,
+    os_name: diagnosticsConsent ? parsed.osName || null : null,
+    viewport: diagnosticsConsent ? parsed.viewport || null : null,
+    app_build_version: diagnosticsConsent ? parsed.appBuildVersion || null : null,
+    sentry_event_id: diagnosticsConsent ? parsed.sentryEventId || null : null,
+    diagnostics_consent: diagnosticsConsent,
+  }
+}
+
+export async function createSupportTicket(formData: FormData) {
+  const parsed = supportTicketSchema.safeParse(Object.fromEntries(formData))
+  if (!parsed.success) return { success: false, error: parsed.error.errors[0]?.message ?? 'Invalid support ticket' }
+
+  const supabase = await createSupabaseServerClient()
+  const actor = await getActorUsuarioId(supabase)
+  if (!actor.success) return actor
+
+  const { data, error } = await supabase.from('support_tickets').insert({
+    reporter_usuario_id: actor.usuarioId,
+    status: 'received',
+    title: parsed.data.title,
+    description: parsed.data.description,
+    category: parsed.data.category,
+    severity: parsed.data.severity,
+    ...sanitizeSupportEvidence(parsed.data),
+  }).select('id,ticket_number').single()
+
+  if (error || !data) return { success: false, error: SUPPORT_TICKET_CREATE_ERROR }
+  revalidatePath('/ayuda/tickets')
+  return { success: true, ticketId: data.id, ticketNumber: data.ticket_number }
+}
+
+export async function listSupportTickets() {
+  const supabase = await createSupabaseServerClient()
+  const { data: { user } } = await supabase.auth.getUser()
+  if (!user) return { success: false, error: 'Not authenticated', tickets: [] }
+
+  const { data, error } = await supabase
+    .from('support_tickets')
+    .select('id,ticket_number,title,status,category,severity,created_at,updated_at')
+    .order('created_at', { ascending: false })
+
+  if (error) return { success: false, error: SUPPORT_TICKET_LIST_ERROR, tickets: [] }
+  return { success: true, tickets: (data ?? []).map(toTicketSummary) }
+}
+
+export async function getSupportTicketDetail(ticketId: string) {
+  const supabase = await createSupabaseServerClient()
+  const { data: { user } } = await supabase.auth.getUser()
+  if (!user) return { success: false, error: 'Not authenticated' }
+
+  const { data: ticket, error } = await supabase
+    .from('support_tickets')
+    .select('id,ticket_number,title,description,status,category,severity,current_route,browser_name,os_name,viewport,app_build_version,sentry_event_id,diagnostics_consent,created_at,updated_at')
+    .eq('id', ticketId)
+    .maybeSingle()
+
+  if (error) return { success: false, error: SUPPORT_TICKET_DETAIL_ERROR }
+  if (!ticket) return { success: false, error: 'Ticket not found' }
+
+  const { data: messages, error: messagesError } = await supabase
+    .from('support_ticket_messages')
+    .select('id,body,created_at')
+    .eq('ticket_id', ticketId)
+    .eq('is_internal', false)
+    .order('created_at', { ascending: true })
+
+  if (messagesError) return { success: false, error: SUPPORT_TICKET_DETAIL_ERROR }
+  return { success: true, ticket: toTicketDetail(ticket as SupportTicketRow, messages ?? []) }
+}
+
+export async function createSupportTicketMessage(ticketId: string, formData: FormData) {
+  const parsed = messageSchema.safeParse(Object.fromEntries(formData))
+  if (!parsed.success) return { success: false, error: parsed.error.errors[0]?.message ?? 'Invalid reply' }
+
+  const supabase = await createSupabaseServerClient()
+  const actor = await getActorUsuarioId(supabase)
+  if (!actor.success) return actor
+
+  const { error } = await supabase.from('support_ticket_messages').insert({
+    ticket_id: ticketId,
+    author_usuario_id: actor.usuarioId,
+    body: parsed.data.body,
+    is_internal: false,
+  })
+
+  if (error) return { success: false, error: SUPPORT_TICKET_MESSAGE_ERROR }
+  revalidatePath(`/ayuda/tickets/${ticketId}`)
+  return { success: true }
+}
+
+async function getActorUsuarioId(supabase: Awaited<ReturnType<typeof createSupabaseServerClient>>) {
+  const { data: { user } } = await supabase.auth.getUser()
+  if (!user) return { success: false as const, error: 'Not authenticated' }
+  const { data, error } = await supabase.from('usuarios').select('id').eq('auth_id', user.id).maybeSingle()
+  if (error || !data?.id) return { success: false as const, error: 'User profile not found' }
+  return { success: true as const, usuarioId: data.id }
+}
+
+function sanitizeRouteEvidence(route: string | undefined) {
+  const [withoutHash] = (route ?? '').split('#', 1)
+  const [withoutQuery] = withoutHash.split('?', 1)
+  return withoutQuery || null
+}
+
+function toTicketSummary(ticket: Omit<SupportTicketRow, 'description' | 'current_route' | 'browser_name' | 'os_name' | 'viewport' | 'app_build_version' | 'sentry_event_id' | 'diagnostics_consent'>) {
+  return { id: ticket.id, ticketNumber: ticket.ticket_number, title: ticket.title, status: ticket.status, category: ticket.category, severity: ticket.severity, createdAt: ticket.created_at, updatedAt: ticket.updated_at }
+}
+
+function toTicketDetail(ticket: SupportTicketRow, messages: SupportMessageRow[]) {
+  return {
+    ...toTicketSummary(ticket),
+    description: ticket.description,
+    evidence: { currentRoute: ticket.current_route, browserName: ticket.browser_name, osName: ticket.os_name, viewport: ticket.viewport, appBuildVersion: ticket.app_build_version, sentryEventId: ticket.sentry_event_id, diagnosticsConsent: ticket.diagnostics_consent },
+    messages: messages.map((message) => ({ id: message.id, body: message.body, createdAt: message.created_at })),
+  }
+}

--- a/lib/actions/support.actions.ts
+++ b/lib/actions/support.actions.ts
@@ -3,9 +3,8 @@
 import { revalidatePath } from 'next/cache'
 import { z } from 'zod'
 
+import { diagnosticsConsentSchema, sanitizeSupportEvidence } from '@/lib/support/support-evidence'
 import { createSupabaseServerClient } from '@/lib/supabase/server'
-
-const diagnosticsConsentSchema = z.preprocess((value) => value === true || value === 'true' || value === 'on' || value === '1', z.boolean())
 
 const supportTicketSchema = z.object({
   title: z.string().trim().min(5).max(160),
@@ -48,20 +47,6 @@ type SupportTicketRow = {
 }
 
 type SupportMessageRow = { id: string; body: string; created_at: string }
-
-export function sanitizeSupportEvidence(input: Record<string, unknown>) {
-  const parsed = supportTicketSchema.partial().parse(input)
-  const diagnosticsConsent = parsed.diagnosticsConsent ?? false
-  return {
-    current_route: sanitizeRouteEvidence(parsed.currentRoute),
-    browser_name: diagnosticsConsent ? parsed.browserName || null : null,
-    os_name: diagnosticsConsent ? parsed.osName || null : null,
-    viewport: diagnosticsConsent ? parsed.viewport || null : null,
-    app_build_version: diagnosticsConsent ? parsed.appBuildVersion || null : null,
-    sentry_event_id: diagnosticsConsent ? parsed.sentryEventId || null : null,
-    diagnostics_consent: diagnosticsConsent,
-  }
-}
 
 export async function createSupportTicket(formData: FormData) {
   const parsed = supportTicketSchema.safeParse(Object.fromEntries(formData))
@@ -151,12 +136,6 @@ async function getActorUsuarioId(supabase: Awaited<ReturnType<typeof createSupab
   const { data, error } = await supabase.from('usuarios').select('id').eq('auth_id', user.id).maybeSingle()
   if (error || !data?.id) return { success: false as const, error: 'User profile not found' }
   return { success: true as const, usuarioId: data.id }
-}
-
-function sanitizeRouteEvidence(route: string | undefined) {
-  const [withoutHash] = (route ?? '').split('#', 1)
-  const [withoutQuery] = withoutHash.split('?', 1)
-  return withoutQuery || null
 }
 
 function toTicketSummary(ticket: Omit<SupportTicketRow, 'description' | 'current_route' | 'browser_name' | 'os_name' | 'viewport' | 'app_build_version' | 'sentry_event_id' | 'diagnostics_consent'>) {

--- a/lib/support/support-evidence.ts
+++ b/lib/support/support-evidence.ts
@@ -1,0 +1,34 @@
+import { z } from 'zod'
+
+export const diagnosticsConsentSchema = z.preprocess((value) => value === true || value === 'true' || value === 'on' || value === '1', z.boolean())
+
+const supportEvidenceSchema = z.object({
+  currentRoute: z.string().trim().max(500).optional(),
+  browserName: z.string().trim().max(120).optional(),
+  osName: z.string().trim().max(120).optional(),
+  viewport: z.string().trim().max(40).optional(),
+  appBuildVersion: z.string().trim().max(120).optional(),
+  sentryEventId: z.string().trim().max(120).optional(),
+  diagnosticsConsent: diagnosticsConsentSchema.optional(),
+})
+
+export function sanitizeSupportEvidence(input: Record<string, unknown>) {
+  const parsed = supportEvidenceSchema.parse(input)
+  const diagnosticsConsent = parsed.diagnosticsConsent ?? false
+
+  return {
+    current_route: sanitizeRouteEvidence(parsed.currentRoute),
+    browser_name: diagnosticsConsent ? parsed.browserName || null : null,
+    os_name: diagnosticsConsent ? parsed.osName || null : null,
+    viewport: diagnosticsConsent ? parsed.viewport || null : null,
+    app_build_version: diagnosticsConsent ? parsed.appBuildVersion || null : null,
+    sentry_event_id: diagnosticsConsent ? parsed.sentryEventId || null : null,
+    diagnostics_consent: diagnosticsConsent,
+  }
+}
+
+function sanitizeRouteEvidence(route: string | undefined) {
+  const [withoutHash] = (route ?? '').split('#', 1)
+  const [withoutQuery] = withoutHash.split('?', 1)
+  return withoutQuery || null
+}

--- a/openspec/changes/support-ticket-system/apply-progress.md
+++ b/openspec/changes/support-ticket-system/apply-progress.md
@@ -5,9 +5,9 @@
 - Mode: Strict TDD
 - Delivery: force-chained
 - Chain strategy: feature-branch-chain
-- Current slice: Phase 2, tasks 2.1, 2.2, and 2.3 completed with private R2 validators, signing helpers, attachment intent/finalize/download routes, MIME/size checks, rejected-object cleanup, R2 failure surfacing, explicit bodyless HEAD handling, and route-level authorization tests.
-- Completed tasks: 1.1, 1.2, 1.3, 1.4, 2.1, 2.2, 2.3
-- Latest update: R2 attachment helpers and routes are implemented under the Phase 2 boundary. Phase 2 follow-up hardening verified R2 response failure surfacing, unauthorized adapter access, explicit bodyless HEAD handling, support regression tests, and TypeScript verification with `pnpm`.
+- Current slice: Phase 3, tasks 3.1, 3.2, 3.3, and 3.4 completed with reporter-safe support actions, `/ayuda` reporter pages, toast-to-link navigation replacement, privacy-hardened evidence persistence, and focused/full CI verification.
+- Completed tasks: 1.1, 1.2, 1.3, 1.4, 2.1, 2.2, 2.3, 3.1, 3.2, 3.3, 3.4
+- Latest update: Reporter ticket flow is implemented under the Phase 3 boundary. Server actions use authenticated Supabase server clients and RLS for create/list/detail/reply, evidence fields are allowlisted, route evidence is stripped of query/hash before persistence, browser/OS/viewport/app/Sentry diagnostics are only persisted with reporter consent, reporter detail messages explicitly filter public/non-internal messages, raw Supabase errors are mapped to stable user-safe action messages, reporter pages are server-rendered App Router routes, and navigation now links to `/ayuda` instead of showing “Próximamente” toasts.
 
 ## TDD Cycle Evidence
 
@@ -22,6 +22,11 @@
 | 2.1 | `__tests__/lib/support/r2.test.ts` | Unit/domain helpers | N/A (new files) | `npm test -- __tests__/lib/support/r2.test.ts __tests__/app/support-attachments-route.test.ts --runInBand` failed because `@/lib/support/r2` and `@/lib/support/r2-routes` did not exist | `pnpm test -- __tests__/lib/support/r2.test.ts __tests__/app/support-attachments-route.test.ts --runInBand` passed with 2 suites and 9 tests | 5 cases cover allowed screenshots, unsafe filename normalization, oversize/MIME rejection, magic-byte sniffing, private bucket env config, and deterministic SigV4 signed URLs | Replaced an incorrect HMAC placeholder hash with real SHA-256 and added a signature fixture to guard R2 URL signing |
 | 2.2 | `__tests__/app/support-attachments-route.test.ts` | Unit/route behavior with mocked R2 and metadata dependencies | N/A (new files) | Route tests referenced missing `createAttachmentIntentResponse`, `finalizeAttachmentResponse`, and `createAttachmentDownloadResponse` before implementation; follow-up RED also exposed missing explicit HEAD helper and jsdom Request/Response runtime gaps | `pnpm test -- __tests__/lib/support/capabilities.test.ts __tests__/supabase/support-ticket-system-migration.test.ts __tests__/lib/support/r2.test.ts __tests__/app/support-attachments-route.test.ts --runInBand` passed with 4 suites and 25 tests | 8 route cases cover signed upload intent, oversize rejection, finalize HEAD/MIME rejection with cleanup, cleanup failure surfacing, adapter-level R2 DELETE HTTP failure surfacing, forbidden/unauthorized download, and bodyless HEAD status behavior | Shared download status resolution between GET and HEAD; kept HEAD bodyless and added R2 `response.ok` checks for HEAD, prefix GET, and DELETE |
 | 2.3 | `__tests__/lib/support/r2.test.ts`, `__tests__/app/support-attachments-route.test.ts` | Unit + route behavior | Existing support suites included as regression coverage | Verification was pending until Phase 2 helpers and routes existed | `pnpm exec tsc --noEmit` passed; focused and support regression Jest suites passed | Coverage verifies allowed files pass, oversized/MIME failures reject, and bypassed downloads without authorized uploaded metadata return 403 | No further refactor needed |
+| 3.1 | `__tests__/lib/actions/support.actions.test.ts` | Unit/server action with mocked Supabase RLS client | N/A (new file) | Test referenced missing `@/lib/actions/support.actions` and failed before implementation | `pnpm test -- __tests__/lib/actions/support.actions.test.ts __tests__/components/support-navigation.test.tsx __tests__/app/support-pages.test.tsx --runInBand` passed with 3 suites and 12 tests | 6 cases cover safe evidence allowlist, anonymous create rejection, authenticated create, list projection, detail with public messages, and reporter public replies | Wrapped page form actions separately so reusable tested actions can return results while App Router forms receive `Promise<void>` handlers |
+| 3.2 | `__tests__/app/support-pages.test.tsx` | Integration/page rendering with mocked actions | N/A (new routes) | Test referenced missing `/ayuda` home/report/history/detail pages before implementation | Focused Phase 3 suites passed; `pnpm exec tsc --noEmit` passed; `pnpm test:ci` passed | 4 cases cover home links, report form safe evidence fields, ticket history link, and detail/reply rendering | Replaced design-system `SelectSistema` usage in the report form with native styled selects to avoid controlled/uncontrolled select misuse in server-rendered form defaults |
+| 3.3 | `__tests__/components/support-navigation.test.tsx` | Component rendering | Existing nav components modified after RED tests | RED failed because mobile bottom nav rendered Ayuda as a button and sidebar rendered Ayuda as a toast button | Focused Phase 3 suites passed; `pnpm test:ci` passed | 2 cases cover mobile bottom `/ayuda` link and desktop sidebar `/ayuda` footer link; desktop header and mobile drawer were also changed to real links | Removed dead Ayuda toast dependency from sidebar and mobile bottom nav |
+| 3.4 | `__tests__/lib/actions/support.actions.test.ts`, `__tests__/components/support-navigation.test.tsx`, `__tests__/app/support-pages.test.tsx` | Unit + component/page integration | Phase 1/2 support suites included in full CI | Verification was pending until reporter actions, pages, and nav existed | `pnpm test:ci` passed with Jest 10 suites/54 tests and Node Test Runner 17 tests; `pnpm exec tsc --noEmit` passed | Submit, anonymous rejection, reporter list/detail/reply, and mobile `/ayuda` navigation are covered by focused tests; manual browser execution was not run | `pnpm lint` blocked by missing `eslint-plugin-security` in the current install, not by Phase 3 code |
+| 3.4 privacy review fix | `__tests__/lib/actions/support.actions.test.ts` | Unit/server action with mocked Supabase RLS client | Fresh Phase 3 review reported `needs_fix` privacy blocker | Existing evidence test expected `/dashboard?token=secret`, proving route query persistence; diagnostics were stored even when consent was false | `npm test -- __tests__/lib/actions/support.actions.test.ts --runInBand` passed with 8/8 tests; `npm test -- __tests__/lib/actions/support.actions.test.ts __tests__/components/support-navigation.test.tsx __tests__/app/support-pages.test.tsx --runInBand` passed with 3 suites and 14 tests; `npx tsc --noEmit` passed | Coverage now proves route query/hash redaction, diagnostics consent gating including string `"false"`, explicit public/non-internal message filtering, and stable user-safe list error mapping | Kept the fix inside `lib/actions/support.actions.ts`; no Supabase production mutation or SQL execution was performed |
 
 ## Completed Tasks
 
@@ -32,6 +37,10 @@
 - [x] 2.1 Added `lib/support/r2.ts` with private bucket constants, server-only env validation, attachment limits, safe key building, SigV4 signed URL generation, and MIME magic-byte sniffing.
 - [x] 2.2 Added support attachment route handlers for intent, finalize, and download/HEAD, with authorization before signed URL issuance and rejected-object cleanup after failed finalization.
 - [x] 2.3 Verified allowed files pass, oversized/MIME failures reject, and direct/bypassed download attempts without authorized uploaded metadata fail with 403.
+- [x] 3.1 Added `lib/actions/support.actions.ts` for authenticated reporter create/list/detail/message flows with Zod validation and allowlisted evidence mapping.
+- [x] 3.2 Added `/ayuda`, `/ayuda/reportar`, `/ayuda/tickets`, and `/ayuda/tickets/[id]` App Router pages using existing dashboard/design-system primitives.
+- [x] 3.3 Replaced Ayuda “Próximamente” toast buttons with real `/ayuda` navigation in sidebar, mobile drawer, mobile bottom menu, and desktop header.
+- [x] 3.4 Verified submit, anonymous rejection, reporter view/reply, and mobile `/ayuda` navigation through focused tests plus full CI test execution.
 
 ## Staging Baseline Setup
 
@@ -68,6 +77,15 @@
 - Phase 2 focused GREEN: `pnpm test -- __tests__/lib/support/r2.test.ts __tests__/app/support-attachments-route.test.ts --runInBand` passed with 2 suites and 9 tests.
 - Phase 2 required runner verification: `pnpm test -- __tests__/lib/support/capabilities.test.ts __tests__/supabase/support-ticket-system-migration.test.ts __tests__/lib/support/r2.test.ts __tests__/app/support-attachments-route.test.ts --runInBand` passed with 4 suites and 25 tests after the R2/HEAD hardening follow-up.
 - Phase 2 type verification: `pnpm exec tsc --noEmit` passed.
+- Phase 3 RED baseline: `pnpm test -- __tests__/lib/actions/support.actions.test.ts __tests__/components/support-navigation.test.tsx --runInBand` failed because `@/lib/actions/support.actions` did not exist and Ayuda navigation still rendered toast buttons.
+- Phase 3 focused GREEN: `pnpm test -- __tests__/lib/actions/support.actions.test.ts __tests__/components/support-navigation.test.tsx __tests__/app/support-pages.test.tsx --runInBand` passed with 3 suites and 12 tests. React emitted non-failing Suspense/act warnings from lazy desktop header resolution in page tests.
+- Phase 3 type verification: `pnpm exec tsc --noEmit` passed after page-local void-returning form action wrappers were added.
+- Phase 3 full CI verification: `pnpm test:ci` passed with Jest 10 suites/54 tests and Node Test Runner 17 tests.
+- Phase 3 Node Test Runner verification: `pnpm test:node` passed with 17 tests.
+- Phase 3 lint verification: `pnpm lint` failed before linting because `eslint-plugin-security` could not be resolved from the current install.
+- Phase 3 privacy review fix verification: `npm test -- __tests__/lib/actions/support.actions.test.ts --runInBand` passed with 1 suite and 8 tests.
+- Phase 3 related regression verification: `npm test -- __tests__/lib/actions/support.actions.test.ts __tests__/components/support-navigation.test.tsx __tests__/app/support-pages.test.tsx --runInBand` passed with 3 suites and 14 tests. React emitted the existing non-failing Suspense/act warnings from page tests.
+- Phase 3 privacy review type verification: `npx tsc --noEmit` passed.
 
 ## Production Safety
 
@@ -77,12 +95,19 @@
 - Review fix edited only the not-yet-applied migration contract: no production SQL execution and no destructive command was run.
 - Task 1.2 type generation used Supabase staging; no production SQL or schema mutation was executed.
 - Phase 2 performed no Supabase production mutations and no live R2 calls during tests; R2 interactions are signed server-side and mocked in unit coverage.
+- Phase 3 performed no Supabase production mutations and no live R2 calls; Supabase access was mocked in tests and implementation uses the authenticated server client so RLS remains the authorization boundary.
+- Phase 3 privacy review fix performed no Supabase production mutations, no SQL execution, and no live Supabase calls; Supabase access remained mocked in tests.
 - No GitHub issue sync was implemented.
 - Staging baseline docs/scripts target project ref `ebwtdjtajclzciwipevw`; old package scripts for `wcnqocyqtksxhthnquta` were blocked or replaced with staging-safe commands.
 
 ## Remaining Tasks
 
-- [ ] 3.1 Create `lib/actions/support*.ts` for authenticated ticket create/list/detail/message with Zod validation and safe evidence fields.
-- [ ] 3.2 Build `app/(auth)/ayuda/**` home, report form, history, and detail with UI components.
-- [ ] 3.3 Replace Ayuda toasts in `sidebar-moderna.tsx`, `header-movil.tsx`, `menu-inferior-movil.tsx`, and `desktop-header`.
-- [ ] 3.4 Verify submit, anonymous rejection, reporter view/reply, and mobile `/ayuda` navigation.
+- [ ] 4.1 Build `app/(auth)/ayuda/admin` queue with filters and Postgres FTS.
+- [ ] 4.2 Add staff reply, assignment, and status transition actions in `lib/actions/support*.ts` with audit events.
+- [ ] 4.3 Verify capabilities, unauthorized denial, search/filter, and audited status saves.
+- [ ] 5.1 Add `emails/support-*.tsx` templates and `lib/email/**` calls with safe authenticated links only.
+- [ ] 5.2 Add `lib/support/inngest*.ts` events with ID-only payloads and idempotency keys.
+- [ ] 5.3 Verify one email per event/recipient and no evidence, attachments, raw Sentry, or GitHub issues.
+- [ ] 6.1 Harden `instrumentation-client.ts`, `sentry.server.config.ts`, and `sentry.edge.config.ts` for no default PII/raw replay.
+- [ ] 6.2 Document R2/Inngest/Resend envs, rollback, retention question, and future sanitized GitHub boundary.
+- [ ] 6.3 Run `pnpm test:rls`, unit/integration suites, build/typecheck, and manual reporter/staff flows.

--- a/openspec/changes/support-ticket-system/tasks.md
+++ b/openspec/changes/support-ticket-system/tasks.md
@@ -43,10 +43,10 @@ Chain strategy: feature-branch-chain
 
 ## Phase 3: Reporter Ticket Flow
 
-- [ ] 3.1 Create `lib/actions/support*.ts` for authenticated ticket create/list/detail/message with Zod validation and safe evidence fields.
-- [ ] 3.2 Build `app/(auth)/ayuda/**` home, report form, history, and detail with UI components.
-- [ ] 3.3 Replace Ayuda toasts in `sidebar-moderna.tsx`, `header-movil.tsx`, `menu-inferior-movil.tsx`, and `desktop-header`.
-- [ ] 3.4 Verify submit, anonymous rejection, reporter view/reply, and mobile `/ayuda` navigation.
+- [x] 3.1 Create `lib/actions/support*.ts` for authenticated ticket create/list/detail/message with Zod validation and safe evidence fields.
+- [x] 3.2 Build `app/(auth)/ayuda/**` home, report form, history, and detail with UI components.
+- [x] 3.3 Replace Ayuda toasts in `sidebar-moderna.tsx`, `header-movil.tsx`, `menu-inferior-movil.tsx`, and `desktop-header`.
+- [x] 3.4 Verify submit, anonymous rejection, reporter view/reply, and mobile `/ayuda` navigation.
 
 ## Phase 4: Support Console
 


### PR DESCRIPTION
Closes #119

# Título del PR
feat(support): add reporter ticket actions

## Resumen
This PR adds authenticated reporter support actions for creating, listing, reading, and replying to support tickets.

## Qué Incluye
- `lib/actions/support.actions.ts` with create/list/detail/message actions.
- Zod validation for reporter inputs and safe evidence allowlist.
- Privacy fixes for route evidence and diagnostics consent.
- Tests for submit, auth rejection, reporter detail/reply behavior, and safe errors.

## Motivación / Por Qué
Reporter pages need server actions that rely on Supabase RLS while keeping evidence and diagnostics safe.

## Chain Context
Strategy: feature-branch-chain

```text
main
└── feat/support-reporter-flow-tracker
    └── feat/support-reporter-actions 📍
        └── feat/support-reporter-pages
            └── feat/support-reporter-navigation
                └── docs/support-reporter-sdd
```

Current PR boundary:
- Reporter support actions and tests only.

Out of scope:
- `/ayuda` pages.
- Navigation updates.
- Staff console.
- Notifications.
- Production database mutation.

## Evidencia Visual (si aplica)
No aplica.

## Migraciones / Base de Datos
- [x] No aplica
- [ ] Sí (orden exacto):
```text
N/A
```

## Impacto y Riesgos
- Actions depend on existing Supabase RLS from the merged support foundation.
- Raw diagnostics are not persisted without explicit consent.

## Checklist Autor
- [x] Código formateado (Prettier/ESLint)
- [x] Sin `console.log` / debugger
- [x] Validaciones con zod para entradas nuevas
- [x] Estados loading/error/empty cubiertos
- [x] Tipos TypeScript correctos
- [x] Migraciones probadas local
- [x] Documentación actualizada (`docs/` o README)
- [x] Variables de entorno documentadas
- [x] Rebase con `main` limpio

## Checklist Revisor
- [ ] Propósito claro
- [ ] Nombres descriptivos
- [ ] Sin lógica duplicada evidente
- [ ] Manejo adecuado de errores
- [ ] Cambios acotados al alcance
- [ ] Sin secretos / datos sensibles

## Pruebas Manuales Realizadas
- `pnpm test -- __tests__/lib/actions/support.actions.test.ts __tests__/components/support-navigation.test.tsx __tests__/app/support-pages.test.tsx --runInBand` passed.
- `pnpm test:ci` passed locally before PR chain creation.
- `pnpm exec tsc --noEmit` passed.

## Pendientes / Follow-up
- Reporter pages in the next chained PR.

## Notas Adicionales
This PR contains the privacy fix reviewed after Phase 3 implementation.
