### PR TITLE
feat(support): add reporter ayuda pages

### DIFF
--- a/__tests__/app/support-pages.test.tsx
+++ b/__tests__/app/support-pages.test.tsx
@@ -1,0 +1,62 @@
+import { render, screen } from '@testing-library/react'
+
+import AyudaPage from '@/app/(auth)/ayuda/page'
+import ReportarPage from '@/app/(auth)/ayuda/reportar/page'
+import TicketsPage from '@/app/(auth)/ayuda/tickets/page'
+import TicketDetailPage from '@/app/(auth)/ayuda/tickets/[id]/page'
+
+jest.mock('@/lib/actions/support.actions', () => ({
+  createSupportTicket: jest.fn(),
+  createSupportTicketMessage: jest.fn(),
+  getSupportTicketDetail: jest.fn().mockResolvedValue({
+    success: true,
+    ticket: {
+      id: 'ticket-1',
+      ticketNumber: 42,
+      title: 'Map bug',
+      description: 'The group map does not load.',
+      status: 'received',
+      category: 'bug',
+      severity: 'normal',
+      createdAt: '2026-06-09T00:00:00Z',
+      updatedAt: '2026-06-09T00:00:00Z',
+      evidence: { currentRoute: '/dashboard', browserName: 'Chrome', osName: 'macOS', viewport: '1440x900', appBuildVersion: null, sentryEventId: null, diagnosticsConsent: true },
+      messages: [{ id: 'message-1', body: 'Public reply', createdAt: '2026-06-09T00:01:00Z' }],
+    },
+  }),
+  listSupportTickets: jest.fn().mockResolvedValue({ success: true, tickets: [{ id: 'ticket-1', ticketNumber: 42, title: 'Map bug', status: 'received', category: 'bug', severity: 'normal', createdAt: '2026-06-09T00:00:00Z', updatedAt: '2026-06-09T00:00:00Z' }] }),
+}))
+jest.mock('@/hooks/useCurrentUser', () => ({ useCurrentUser: () => ({ usuario: null, roles: ['miembro'], loading: false }) }))
+jest.mock('@/hooks/useBranding', () => ({ useBranding: () => ({ logoLightUrl: null, logoDarkUrl: null }) }))
+jest.mock('@/hooks/use-notificaciones', () => ({ useNotificaciones: () => ({ info: jest.fn() }) }))
+
+describe('reporter support pages', () => {
+  it('renders the /ayuda home with report and history links', async () => {
+    render(await AyudaPage())
+
+    expect(screen.getByRole('link', { name: /Report a problem/i })).toHaveAttribute('href', '/ayuda/reportar')
+    expect(screen.getByRole('link', { name: /View my tickets/i })).toHaveAttribute('href', '/ayuda/tickets')
+  })
+
+  it('renders the report form with safe evidence fields', async () => {
+    render(await ReportarPage())
+
+    expect(screen.getByLabelText(/Title/i)).toHaveAttribute('name', 'title')
+    expect(screen.getByLabelText(/Allow safe diagnostics/i)).toHaveAttribute('name', 'diagnosticsConsent')
+    expect(document.querySelector('[name="cookies"]')).not.toBeInTheDocument()
+  })
+
+  it('renders the reporter ticket history', async () => {
+    render(await TicketsPage())
+
+    expect(screen.getByRole('link', { name: /#42 Map bug/i })).toHaveAttribute('href', '/ayuda/tickets/ticket-1')
+  })
+
+  it('renders reporter-visible ticket details and reply form', async () => {
+    render(await TicketDetailPage({ params: Promise.resolve({ id: 'ticket-1' }) }))
+
+    expect(screen.getByText('The group map does not load.')).toBeInTheDocument()
+    expect(screen.getByText('Public reply')).toBeInTheDocument()
+    expect(screen.getByLabelText(/Reply/i)).toHaveAttribute('name', 'body')
+  })
+})

--- a/__tests__/lib/actions/support.actions.test.ts
+++ b/__tests__/lib/actions/support.actions.test.ts
@@ -3,8 +3,8 @@ import {
   createSupportTicketMessage,
   getSupportTicketDetail,
   listSupportTickets,
-  sanitizeSupportEvidence,
 } from '@/lib/actions/support.actions'
+import { sanitizeSupportEvidence } from '@/lib/support/support-evidence'
 
 const createSupabaseServerClient = jest.fn()
 const revalidatePath = jest.fn()

--- a/app/(auth)/ayuda/page.tsx
+++ b/app/(auth)/ayuda/page.tsx
@@ -1,0 +1,34 @@
+import Link from 'next/link'
+import { FileText, History } from 'lucide-react'
+
+import { BotonSistema, ContenedorDashboard, TarjetaSistema, TextoSistema, TituloSistema } from '@/components/ui/sistema-diseno'
+
+export default async function AyudaPage() {
+  return (
+    <ContenedorDashboard titulo="Help" descripcion="Report problems and follow support updates from one place.">
+      <div className="grid gap-4 md:grid-cols-2">
+        <TarjetaSistema className="space-y-4">
+          <FileText className="h-8 w-8 text-[var(--brand-primary)]" />
+          <div className="space-y-2">
+            <TituloSistema nivel={2}>Report a problem</TituloSistema>
+            <TextoSistema variante="sutil">Send the support team safe steps and diagnostics without exposing private browser data.</TextoSistema>
+          </div>
+          <Link href="/ayuda/reportar">
+            <BotonSistema>Report a problem</BotonSistema>
+          </Link>
+        </TarjetaSistema>
+
+        <TarjetaSistema className="space-y-4">
+          <History className="h-8 w-8 text-[var(--brand-primary)]" />
+          <div className="space-y-2">
+            <TituloSistema nivel={2}>Ticket history</TituloSistema>
+            <TextoSistema variante="sutil">Review the status of your reports and reply when support needs more information.</TextoSistema>
+          </div>
+          <Link href="/ayuda/tickets">
+            <BotonSistema variante="outline">View my tickets</BotonSistema>
+          </Link>
+        </TarjetaSistema>
+      </div>
+    </ContenedorDashboard>
+  )
+}

--- a/app/(auth)/ayuda/reportar/page.tsx
+++ b/app/(auth)/ayuda/reportar/page.tsx
@@ -1,0 +1,48 @@
+import { createSupportTicket } from '@/lib/actions/support.actions'
+import { BotonSistema, ContenedorDashboard, InputSistema, TarjetaSistema, TextareaSistema, TextoSistema } from '@/components/ui/sistema-diseno'
+
+export default async function ReportarPage() {
+  async function submitTicket(formData: FormData) {
+    'use server'
+    await createSupportTicket(formData)
+  }
+
+  return (
+    <ContenedorDashboard titulo="Report a problem" botonRegreso={{ href: '/ayuda', texto: 'Back to Help' }}>
+      <TarjetaSistema>
+        <form action={submitTicket} className="space-y-5">
+          <InputSistema name="title" label="Title" minLength={5} maxLength={160} required placeholder="Example: Cannot open group map" />
+          <TextareaSistema name="description" label="Steps and expected result" filas={6} minLength={10} maxLength={8000} required placeholder="Tell us what happened, what you expected, and how to reproduce it." />
+          <div className="grid gap-4 md:grid-cols-2">
+            <label className="space-y-2 text-sm font-medium text-foreground">
+              <span>Category</span>
+              <select name="category" defaultValue="bug" className="block w-full min-h-[44px] rounded-xl border border-border bg-card/50 px-3 py-3 text-foreground focus:outline-none focus:ring-2 focus:ring-[var(--brand-primary)]/20">
+                <option value="bug">Bug</option><option value="access">Access</option><option value="data">Data</option><option value="other">Other</option>
+              </select>
+            </label>
+            <label className="space-y-2 text-sm font-medium text-foreground">
+              <span>Severity</span>
+              <select name="severity" defaultValue="normal" className="block w-full min-h-[44px] rounded-xl border border-border bg-card/50 px-3 py-3 text-foreground focus:outline-none focus:ring-2 focus:ring-[var(--brand-primary)]/20">
+                <option value="low">Low</option><option value="normal">Normal</option><option value="high">High</option><option value="urgent">Urgent</option>
+              </select>
+            </label>
+          </div>
+          <div className="grid gap-4 md:grid-cols-2">
+            <InputSistema name="currentRoute" label="Route" placeholder="/dashboard" />
+            <InputSistema name="viewport" label="Viewport" placeholder="390x844" />
+            <InputSistema name="browserName" label="Browser" placeholder="Chrome, Safari, Edge" />
+            <InputSistema name="osName" label="Operating system" placeholder="macOS, iOS, Android" />
+          </div>
+          <InputSistema name="sentryEventId" label="Sentry event ID" placeholder="Optional reference" />
+          <input type="hidden" name="appBuildVersion" value={process.env.NEXT_PUBLIC_APP_VERSION ?? ''} />
+          <label className="flex items-start gap-3 text-sm text-foreground">
+            <input type="checkbox" name="diagnosticsConsent" value="true" className="mt-1 h-4 w-4 rounded border-border" />
+            <span><strong>Allow safe diagnostics</strong><br /><span className="text-muted-foreground">Only route, browser, OS, viewport, app version, and Sentry reference are stored. Cookies, passwords, localStorage, and raw payloads are never collected.</span></span>
+          </label>
+          <TextoSistema variante="muted" tamaño="sm">Attachments are uploaded after ticket creation from the private attachment flow.</TextoSistema>
+          <BotonSistema type="submit">Submit ticket</BotonSistema>
+        </form>
+      </TarjetaSistema>
+    </ContenedorDashboard>
+  )
+}

--- a/app/(auth)/ayuda/tickets/[id]/page.tsx
+++ b/app/(auth)/ayuda/tickets/[id]/page.tsx
@@ -1,0 +1,46 @@
+import { notFound } from 'next/navigation'
+
+import { createSupportTicketMessage, getSupportTicketDetail } from '@/lib/actions/support.actions'
+import { BadgeSistema, BotonSistema, ContenedorDashboard, TarjetaSistema, TextareaSistema, TextoSistema, TituloSistema } from '@/components/ui/sistema-diseno'
+
+export default async function TicketDetailPage({ params }: { params: Promise<{ id: string }> }) {
+  const { id } = await params
+  const result = await getSupportTicketDetail(id)
+  if (!result.success || !result.ticket) notFound()
+  const ticket = result.ticket
+
+  async function replyAction(formData: FormData) {
+    'use server'
+    await createSupportTicketMessage(ticket.id, formData)
+  }
+
+  return (
+    <ContenedorDashboard titulo={`Ticket #${ticket.ticketNumber}`} botonRegreso={{ href: '/ayuda/tickets', texto: 'Back to tickets' }}>
+      <TarjetaSistema className="space-y-4">
+        <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
+          <div className="space-y-2">
+            <TituloSistema nivel={2}>{ticket.title}</TituloSistema>
+            <TextoSistema>{ticket.description}</TextoSistema>
+          </div>
+          <BadgeSistema variante="info">{ticket.status.replaceAll('_', ' ')}</BadgeSistema>
+        </div>
+        {ticket.evidence.diagnosticsConsent && (
+          <TextoSistema variante="muted" tamaño="sm">Safe diagnostics: {ticket.evidence.currentRoute ?? 'route unavailable'} · {ticket.evidence.browserName ?? 'browser unavailable'} · {ticket.evidence.osName ?? 'OS unavailable'} · {ticket.evidence.viewport ?? 'viewport unavailable'}</TextoSistema>
+        )}
+      </TarjetaSistema>
+
+      <TarjetaSistema className="space-y-4">
+        <TituloSistema nivel={2}>Conversation</TituloSistema>
+        {ticket.messages.length === 0 ? <TextoSistema variante="sutil">No replies yet.</TextoSistema> : ticket.messages.map((message) => (
+          <div key={message.id} className="rounded-xl border border-border bg-card/50 p-3">
+            <TextoSistema>{message.body}</TextoSistema>
+          </div>
+        ))}
+        <form action={replyAction} className="space-y-3">
+          <TextareaSistema name="body" label="Reply" filas={4} required />
+          <BotonSistema type="submit">Send reply</BotonSistema>
+        </form>
+      </TarjetaSistema>
+    </ContenedorDashboard>
+  )
+}

--- a/app/(auth)/ayuda/tickets/page.tsx
+++ b/app/(auth)/ayuda/tickets/page.tsx
@@ -1,0 +1,29 @@
+import Link from 'next/link'
+
+import { listSupportTickets } from '@/lib/actions/support.actions'
+import { BadgeSistema, BotonSistema, ContenedorDashboard, TarjetaSistema, TextoSistema } from '@/components/ui/sistema-diseno'
+
+export default async function TicketsPage() {
+  const result = await listSupportTickets()
+  const tickets = result.success ? result.tickets : []
+
+  return (
+    <ContenedorDashboard titulo="My support tickets" accionPrincipal={<Link href="/ayuda/reportar"><BotonSistema tamaño="sm">New ticket</BotonSistema></Link>}>
+      <div className="space-y-3">
+        {tickets.length === 0 ? (
+          <TarjetaSistema><TextoSistema variante="sutil">You have not submitted support tickets yet.</TextoSistema></TarjetaSistema>
+        ) : tickets.map((ticket) => (
+          <Link key={ticket.id} href={`/ayuda/tickets/${ticket.id}`} className="block focus-ring rounded-2xl">
+            <TarjetaSistema className="flex items-center justify-between gap-4">
+              <div>
+                <p className="font-semibold text-foreground">#{ticket.ticketNumber} {ticket.title}</p>
+                <TextoSistema variante="sutil" tamaño="sm">{ticket.category} · {ticket.severity}</TextoSistema>
+              </div>
+              <BadgeSistema variante="info">{ticket.status.replaceAll('_', ' ')}</BadgeSistema>
+            </TarjetaSistema>
+          </Link>
+        ))}
+      </div>
+    </ContenedorDashboard>
+  )
+}

--- a/lib/actions/support.actions.ts
+++ b/lib/actions/support.actions.ts
@@ -3,9 +3,8 @@
 import { revalidatePath } from 'next/cache'
 import { z } from 'zod'
 
+import { diagnosticsConsentSchema, sanitizeSupportEvidence } from '@/lib/support/support-evidence'
 import { createSupabaseServerClient } from '@/lib/supabase/server'
-
-const diagnosticsConsentSchema = z.preprocess((value) => value === true || value === 'true' || value === 'on' || value === '1', z.boolean())
 
 const supportTicketSchema = z.object({
   title: z.string().trim().min(5).max(160),
@@ -48,20 +47,6 @@ type SupportTicketRow = {
 }
 
 type SupportMessageRow = { id: string; body: string; created_at: string }
-
-export function sanitizeSupportEvidence(input: Record<string, unknown>) {
-  const parsed = supportTicketSchema.partial().parse(input)
-  const diagnosticsConsent = parsed.diagnosticsConsent ?? false
-  return {
-    current_route: sanitizeRouteEvidence(parsed.currentRoute),
-    browser_name: diagnosticsConsent ? parsed.browserName || null : null,
-    os_name: diagnosticsConsent ? parsed.osName || null : null,
-    viewport: diagnosticsConsent ? parsed.viewport || null : null,
-    app_build_version: diagnosticsConsent ? parsed.appBuildVersion || null : null,
-    sentry_event_id: diagnosticsConsent ? parsed.sentryEventId || null : null,
-    diagnostics_consent: diagnosticsConsent,
-  }
-}
 
 export async function createSupportTicket(formData: FormData) {
   const parsed = supportTicketSchema.safeParse(Object.fromEntries(formData))
@@ -151,12 +136,6 @@ async function getActorUsuarioId(supabase: Awaited<ReturnType<typeof createSupab
   const { data, error } = await supabase.from('usuarios').select('id').eq('auth_id', user.id).maybeSingle()
   if (error || !data?.id) return { success: false as const, error: 'User profile not found' }
   return { success: true as const, usuarioId: data.id }
-}
-
-function sanitizeRouteEvidence(route: string | undefined) {
-  const [withoutHash] = (route ?? '').split('#', 1)
-  const [withoutQuery] = withoutHash.split('?', 1)
-  return withoutQuery || null
 }
 
 function toTicketSummary(ticket: Omit<SupportTicketRow, 'description' | 'current_route' | 'browser_name' | 'os_name' | 'viewport' | 'app_build_version' | 'sentry_event_id' | 'diagnostics_consent'>) {

--- a/lib/support/support-evidence.ts
+++ b/lib/support/support-evidence.ts
@@ -1,0 +1,34 @@
+import { z } from 'zod'
+
+export const diagnosticsConsentSchema = z.preprocess((value) => value === true || value === 'true' || value === 'on' || value === '1', z.boolean())
+
+const supportEvidenceSchema = z.object({
+  currentRoute: z.string().trim().max(500).optional(),
+  browserName: z.string().trim().max(120).optional(),
+  osName: z.string().trim().max(120).optional(),
+  viewport: z.string().trim().max(40).optional(),
+  appBuildVersion: z.string().trim().max(120).optional(),
+  sentryEventId: z.string().trim().max(120).optional(),
+  diagnosticsConsent: diagnosticsConsentSchema.optional(),
+})
+
+export function sanitizeSupportEvidence(input: Record<string, unknown>) {
+  const parsed = supportEvidenceSchema.parse(input)
+  const diagnosticsConsent = parsed.diagnosticsConsent ?? false
+
+  return {
+    current_route: sanitizeRouteEvidence(parsed.currentRoute),
+    browser_name: diagnosticsConsent ? parsed.browserName || null : null,
+    os_name: diagnosticsConsent ? parsed.osName || null : null,
+    viewport: diagnosticsConsent ? parsed.viewport || null : null,
+    app_build_version: diagnosticsConsent ? parsed.appBuildVersion || null : null,
+    sentry_event_id: diagnosticsConsent ? parsed.sentryEventId || null : null,
+    diagnostics_consent: diagnosticsConsent,
+  }
+}
+
+function sanitizeRouteEvidence(route: string | undefined) {
+  const [withoutHash] = (route ?? '').split('#', 1)
+  const [withoutQuery] = withoutHash.split('?', 1)
+  return withoutQuery || null
+}


### PR DESCRIPTION
Closes #119

# Título del PR
feat(support): add reporter ayuda pages

## Resumen
This PR adds reporter-facing `/ayuda` pages for creating tickets, viewing ticket history, and reading/replying to ticket details.

## Qué Incluye
- `/ayuda` support home.
- `/ayuda/reportar` ticket report form.
- `/ayuda/tickets` reporter ticket history.
- `/ayuda/tickets/[id]` ticket detail and public reply form.
- Page tests for the reporter flow.

## Motivación / Por Qué
Reporters need a real first-party support entry point now that support actions and backend foundation exist.

## Chain Context
Strategy: feature-branch-chain

```text
main
└── feat/support-reporter-flow-tracker
    └── feat/support-reporter-actions
        └── feat/support-reporter-pages 📍
            └── feat/support-reporter-navigation
                └── docs/support-reporter-sdd
```

Current PR boundary:
- Reporter pages and page tests only.

Out of scope:
- Navigation changes.
- Staff console.
- Notifications.
- Production database mutation.

## Evidencia Visual (si aplica)
No aplica.

## Migraciones / Base de Datos
- [x] No aplica
- [ ] Sí (orden exacto):
```text
N/A
```

## Impacto y Riesgos
- Adds new authenticated pages under `/ayuda`.
- Forms rely on server actions and Supabase RLS.

## Checklist Autor
- [x] Código formateado (Prettier/ESLint)
- [x] Sin `console.log` / debugger
- [x] Validaciones con zod para entradas nuevas
- [x] Estados loading/error/empty cubiertos
- [x] Tipos TypeScript correctos
- [x] Migraciones probadas local
- [x] Documentación actualizada (`docs/` o README)
- [x] Variables de entorno documentadas
- [x] Rebase con `main` limpio

## Checklist Revisor
- [ ] Propósito claro
- [ ] Nombres descriptivos
- [ ] Sin lógica duplicada evidente
- [ ] Manejo adecuado de errores
- [ ] Cambios acotados al alcance
- [ ] Sin secretos / datos sensibles

## Pruebas Manuales Realizadas
- Phase 3 focused tests passed locally: 14 tests.
- `pnpm test:ci` passed locally before PR chain creation.
- `pnpm exec tsc --noEmit` passed.

## Pendientes / Follow-up
- Navigation links in the next chained PR.

## Notas Adicionales
Page tests currently emit non-failing React Suspense/act warnings from lazy header resolution.
