### PR TITLE
feat(support): link ayuda navigation

### DIFF
--- a/__tests__/components/support-navigation.test.tsx
+++ b/__tests__/components/support-navigation.test.tsx
@@ -1,0 +1,28 @@
+import { render, screen } from '@testing-library/react'
+
+import { MenuInferiorMovil } from '@/components/ui/menu-inferior-movil'
+import { SidebarModerna } from '@/components/ui/sidebar-moderna'
+
+jest.mock('next/navigation', () => ({
+  usePathname: () => '/dashboard',
+  useRouter: () => ({ push: jest.fn() }),
+}))
+jest.mock('@/hooks/useCurrentUser', () => ({ useCurrentUser: () => ({ usuario: null, roles: ['miembro'], loading: false }) }))
+jest.mock('@/hooks/useBranding', () => ({ useBranding: () => ({ logoLightUrl: null, logoDarkUrl: null }) }))
+jest.mock('@/hooks/use-notificaciones', () => ({ useNotificaciones: () => ({ info: jest.fn() }) }))
+jest.mock('@/hooks/useCampus', () => ({ useCampus: () => ({ campusActivo: null, localidadActiva: null, campusDisponibles: [], localidadesDisponibles: [], campusId: null, localidadId: null, esSuperadmin: false, loading: false, seleccionarCampus: jest.fn(), seleccionarLocalidad: jest.fn() }) }))
+jest.mock('@/lib/actions/auth.actions', () => ({ logout: jest.fn() }))
+
+describe('support navigation links', () => {
+  it('renders the mobile bottom Ayuda item as a real /ayuda link', () => {
+    render(<MenuInferiorMovil />)
+
+    expect(screen.getByLabelText('Navegar a Ayuda')).toHaveAttribute('href', '/ayuda')
+  })
+
+  it('renders the desktop sidebar Ayuda footer item as a real /ayuda link', () => {
+    render(<SidebarModerna />)
+
+    expect(screen.getByRole('link', { name: 'Ayuda' })).toHaveAttribute('href', '/ayuda')
+  })
+})

--- a/components/ui/desktop-header.tsx
+++ b/components/ui/desktop-header.tsx
@@ -3,7 +3,7 @@
 import React, { useState, useEffect, useRef } from 'react'
 import Link from 'next/link'
 import { usePathname } from 'next/navigation'
-import { LogOut, User, ArrowLeft, Bell } from 'lucide-react'
+import { LogOut, User, ArrowLeft, Bell, HelpCircle } from 'lucide-react'
 import { logout } from "@/lib/actions/auth.actions"
 import { ThemeToggle } from './theme-toggle'
 import { UserAvatar } from './UserAvatar'
@@ -116,6 +116,14 @@ export function DesktopHeader({ titulo, accionPrincipal, breadcrumbs, botonRegre
                 {/* Right: theme toggle + user avatar popover */}
                 <div className="flex items-center gap-2 flex-shrink-0">
                     <ThemeToggle />
+
+                    <Link
+                        href="/ayuda"
+                        aria-label="Ayuda"
+                        className="relative flex items-center justify-center rounded-xl w-9 h-9 hover:bg-[var(--brand-accent)] transition-[background-color,transform] duration-200 ease-expo press-scale focus-ring touch-manipulation"
+                    >
+                        <HelpCircle className="w-5 h-5 text-muted-foreground" />
+                    </Link>
 
                     {/* Notification bell */}
                     <button

--- a/components/ui/header-movil.tsx
+++ b/components/ui/header-movil.tsx
@@ -577,19 +577,19 @@ export function HeaderMovil({ titulo }: HeaderMovilProps) {
             )} />
             <span className="font-medium text-sm">Actualizaciones</span>
           </Link>
-          {/* Ayuda — toast */}
-          <button
-            onClick={() => toast.info('Próximamente')}
+          <Link
+            href="/ayuda"
+            aria-current={isActive('/ayuda') ? "page" : undefined}
             className={cn(
               "flex items-center gap-3 px-3 py-2.5 rounded-xl min-h-[44px] w-full text-left",
               "transition-[background-color,color,transform] duration-200 ease-expo",
               "press-scale focus-ring touch-manipulation",
-              "text-foreground hover:bg-[var(--brand-accent)]"
+              isActive('/ayuda') ? "bg-[var(--brand-accent)] text-[var(--brand-primary)]" : "text-foreground hover:bg-[var(--brand-accent)]"
             )}
           >
-            <HelpCircle className="w-5 h-5 flex-shrink-0 text-muted-foreground" />
+            <HelpCircle className={cn("w-5 h-5 flex-shrink-0", isActive('/ayuda') ? "text-[var(--brand-primary)]" : "text-muted-foreground")} />
             <span className="font-medium text-sm">Ayuda</span>
-          </button>
+          </Link>
 
           {/* Theme Toggle */}
           <button

--- a/components/ui/menu-inferior-movil.tsx
+++ b/components/ui/menu-inferior-movil.tsx
@@ -5,46 +5,22 @@ import Link from 'next/link'
 import { usePathname } from 'next/navigation'
 import { LayoutDashboard, Users, UsersRound, HelpCircle } from 'lucide-react'
 import { cn } from '@/lib/utils'
-import { useNotificaciones } from '@/hooks/use-notificaciones'
 
 const elementosMenu = [
   { nombre: "Dashboard", icono: LayoutDashboard, enlace: "/dashboard", id: "dashboard" },
   { nombre: "Usuarios", icono: Users, enlace: "/users", id: "users" },
   { nombre: "Grupos de Vida", icono: UsersRound, enlace: "/grupos-vida", id: "grupos-vida" },
-  { nombre: "Ayuda", icono: HelpCircle, enlace: null, id: "ayuda" },
+  { nombre: "Ayuda", icono: HelpCircle, enlace: "/ayuda", id: "ayuda" },
 ]
 
 export function MenuInferiorMovil() {
   const pathname = usePathname()
-  const toast = useNotificaciones()
 
   return (
     <div className="md:hidden fixed bottom-0 left-0 right-0 z-50 bg-white/60 dark:bg-[rgba(35,35,45,0.60)] backdrop-blur-[40px] [-webkit-backdrop-filter:blur(40px)] backdrop-saturate-[1.8] border-t border-[var(--glass-border)] shadow-[var(--glass-shadow)] [transform:translateZ(0)] touch-manipulation">
       <div className="flex items-center justify-around px-2 py-2 safe-area-pb">
         {elementosMenu.map((elemento) => {
           const Icono = elemento.icono
-
-          // Ayuda → toast
-          if (!elemento.enlace) {
-            return (
-              <button
-                key={elemento.id}
-                onClick={() => toast.info('Próximamente')}
-                aria-label={elemento.nombre}
-                className={cn(
-                  "flex flex-col items-center justify-center px-3 py-2 rounded-xl min-w-0 flex-1 min-h-[44px]",
-                  "transition-[background-color,color,transform] duration-200 ease-expo",
-                  "press-scale focus-ring",
-                  "text-muted-foreground hover:text-[var(--brand-primary)] hover:bg-[var(--brand-accent)]"
-                )}
-              >
-                <Icono className="w-5 h-5 mb-1 text-muted-foreground" />
-                <span className="text-xs font-medium truncate max-w-full text-muted-foreground">
-                  {elemento.nombre}
-                </span>
-              </button>
-            )
-          }
 
           const esActivo = pathname === elemento.enlace ||
             (elemento.enlace !== "/dashboard" && pathname?.startsWith(elemento.enlace))

--- a/components/ui/sidebar-moderna.tsx
+++ b/components/ui/sidebar-moderna.tsx
@@ -6,7 +6,6 @@ import { usePathname, useRouter } from 'next/navigation'
 import { cn } from '@/lib/utils'
 import { LogoGlobalConnect } from '@/components/ui/logo-global-connect'
 import { SelectorCampus } from '@/components/ui/selector-campus'
-import { useNotificaciones } from '@/hooks/use-notificaciones'
 import {
   Users,
   UserCheck,
@@ -125,7 +124,6 @@ export function SidebarModerna({ className }: SidebarModernaProps) {
   const pathname = usePathname()
   const { usuario, roles, loading } = useCurrentUser()
   const branding = useBranding()
-  const toast = useNotificaciones()
 
 
   // ─── Tooltip hover handlers (collapsed mode) ───
@@ -493,27 +491,23 @@ export function SidebarModerna({ className }: SidebarModernaProps) {
               </Link>
             )
           })}
-          {/* Ayuda — toast */}
-          <button
-            onClick={() => toast.info('Próximamente')}
-            className={cn(
-              "flex items-center gap-3 px-3 py-2 rounded-xl group relative w-full min-h-[44px]",
-              "transition-[background-color,color,transform] duration-200 ease-expo",
-              "text-foreground hover:bg-[var(--brand-accent)] hover:text-foreground",
-              "touch-manipulation cursor-pointer",
-              isCollapsed && "justify-center px-2"
-            )}
+          <Link
+            href="/ayuda"
+            aria-current={isActive('/ayuda') ? "page" : undefined}
+            className={linkClasses(isActive('/ayuda'))}
             onMouseEnter={(e) => showTooltip(e, 'Ayuda')}
             onMouseLeave={hideTooltip}
           >
+            {isActive('/ayuda') && <ActivePill />}
             <HelpCircle className={cn(
-              "flex-shrink-0 transition-colors text-muted-foreground group-hover:text-foreground",
+              "flex-shrink-0 transition-colors",
+              isActive('/ayuda') ? "text-[var(--brand-primary)]" : "text-muted-foreground group-hover:text-foreground",
               isCollapsed ? "w-6 h-6" : "w-5 h-5"
             )} />
             {!isCollapsed && (
               <span className="font-medium truncate">Ayuda</span>
             )}
-          </button>
+          </Link>
           {/* Theme Toggle — same layout as other footer items */}
           <div
             className={cn(

--- a/openspec/changes/support-ticket-system/apply-progress.md
+++ b/openspec/changes/support-ticket-system/apply-progress.md
@@ -5,9 +5,9 @@
 - Mode: Strict TDD
 - Delivery: force-chained
 - Chain strategy: feature-branch-chain
-- Current slice: Phase 2, tasks 2.1, 2.2, and 2.3 completed with private R2 validators, signing helpers, attachment intent/finalize/download routes, MIME/size checks, rejected-object cleanup, R2 failure surfacing, explicit bodyless HEAD handling, and route-level authorization tests.
-- Completed tasks: 1.1, 1.2, 1.3, 1.4, 2.1, 2.2, 2.3
-- Latest update: R2 attachment helpers and routes are implemented under the Phase 2 boundary. Phase 2 follow-up hardening verified R2 response failure surfacing, unauthorized adapter access, explicit bodyless HEAD handling, support regression tests, and TypeScript verification with `pnpm`.
+- Current slice: Phase 3, tasks 3.1, 3.2, 3.3, and 3.4 completed with reporter-safe support actions, `/ayuda` reporter pages, toast-to-link navigation replacement, privacy-hardened evidence persistence, and focused/full CI verification.
+- Completed tasks: 1.1, 1.2, 1.3, 1.4, 2.1, 2.2, 2.3, 3.1, 3.2, 3.3, 3.4
+- Latest update: Reporter ticket flow is implemented under the Phase 3 boundary. Server actions use authenticated Supabase server clients and RLS for create/list/detail/reply, evidence fields are allowlisted, route evidence is stripped of query/hash before persistence, browser/OS/viewport/app/Sentry diagnostics are only persisted with reporter consent, reporter detail messages explicitly filter public/non-internal messages, raw Supabase errors are mapped to stable user-safe action messages, reporter pages are server-rendered App Router routes, and navigation now links to `/ayuda` instead of showing “Próximamente” toasts.
 
 ## TDD Cycle Evidence
 
@@ -22,6 +22,11 @@
 | 2.1 | `__tests__/lib/support/r2.test.ts` | Unit/domain helpers | N/A (new files) | `npm test -- __tests__/lib/support/r2.test.ts __tests__/app/support-attachments-route.test.ts --runInBand` failed because `@/lib/support/r2` and `@/lib/support/r2-routes` did not exist | `pnpm test -- __tests__/lib/support/r2.test.ts __tests__/app/support-attachments-route.test.ts --runInBand` passed with 2 suites and 9 tests | 5 cases cover allowed screenshots, unsafe filename normalization, oversize/MIME rejection, magic-byte sniffing, private bucket env config, and deterministic SigV4 signed URLs | Replaced an incorrect HMAC placeholder hash with real SHA-256 and added a signature fixture to guard R2 URL signing |
 | 2.2 | `__tests__/app/support-attachments-route.test.ts` | Unit/route behavior with mocked R2 and metadata dependencies | N/A (new files) | Route tests referenced missing `createAttachmentIntentResponse`, `finalizeAttachmentResponse`, and `createAttachmentDownloadResponse` before implementation; follow-up RED also exposed missing explicit HEAD helper and jsdom Request/Response runtime gaps | `pnpm test -- __tests__/lib/support/capabilities.test.ts __tests__/supabase/support-ticket-system-migration.test.ts __tests__/lib/support/r2.test.ts __tests__/app/support-attachments-route.test.ts --runInBand` passed with 4 suites and 25 tests | 8 route cases cover signed upload intent, oversize rejection, finalize HEAD/MIME rejection with cleanup, cleanup failure surfacing, adapter-level R2 DELETE HTTP failure surfacing, forbidden/unauthorized download, and bodyless HEAD status behavior | Shared download status resolution between GET and HEAD; kept HEAD bodyless and added R2 `response.ok` checks for HEAD, prefix GET, and DELETE |
 | 2.3 | `__tests__/lib/support/r2.test.ts`, `__tests__/app/support-attachments-route.test.ts` | Unit + route behavior | Existing support suites included as regression coverage | Verification was pending until Phase 2 helpers and routes existed | `pnpm exec tsc --noEmit` passed; focused and support regression Jest suites passed | Coverage verifies allowed files pass, oversized/MIME failures reject, and bypassed downloads without authorized uploaded metadata return 403 | No further refactor needed |
+| 3.1 | `__tests__/lib/actions/support.actions.test.ts` | Unit/server action with mocked Supabase RLS client | N/A (new file) | Test referenced missing `@/lib/actions/support.actions` and failed before implementation | `pnpm test -- __tests__/lib/actions/support.actions.test.ts __tests__/components/support-navigation.test.tsx __tests__/app/support-pages.test.tsx --runInBand` passed with 3 suites and 12 tests | 6 cases cover safe evidence allowlist, anonymous create rejection, authenticated create, list projection, detail with public messages, and reporter public replies | Wrapped page form actions separately so reusable tested actions can return results while App Router forms receive `Promise<void>` handlers |
+| 3.2 | `__tests__/app/support-pages.test.tsx` | Integration/page rendering with mocked actions | N/A (new routes) | Test referenced missing `/ayuda` home/report/history/detail pages before implementation | Focused Phase 3 suites passed; `pnpm exec tsc --noEmit` passed; `pnpm test:ci` passed | 4 cases cover home links, report form safe evidence fields, ticket history link, and detail/reply rendering | Replaced design-system `SelectSistema` usage in the report form with native styled selects to avoid controlled/uncontrolled select misuse in server-rendered form defaults |
+| 3.3 | `__tests__/components/support-navigation.test.tsx` | Component rendering | Existing nav components modified after RED tests | RED failed because mobile bottom nav rendered Ayuda as a button and sidebar rendered Ayuda as a toast button | Focused Phase 3 suites passed; `pnpm test:ci` passed | 2 cases cover mobile bottom `/ayuda` link and desktop sidebar `/ayuda` footer link; desktop header and mobile drawer were also changed to real links | Removed dead Ayuda toast dependency from sidebar and mobile bottom nav |
+| 3.4 | `__tests__/lib/actions/support.actions.test.ts`, `__tests__/components/support-navigation.test.tsx`, `__tests__/app/support-pages.test.tsx` | Unit + component/page integration | Phase 1/2 support suites included in full CI | Verification was pending until reporter actions, pages, and nav existed | `pnpm test:ci` passed with Jest 10 suites/54 tests and Node Test Runner 17 tests; `pnpm exec tsc --noEmit` passed | Submit, anonymous rejection, reporter list/detail/reply, and mobile `/ayuda` navigation are covered by focused tests; manual browser execution was not run | `pnpm lint` blocked by missing `eslint-plugin-security` in the current install, not by Phase 3 code |
+| 3.4 privacy review fix | `__tests__/lib/actions/support.actions.test.ts` | Unit/server action with mocked Supabase RLS client | Fresh Phase 3 review reported `needs_fix` privacy blocker | Existing evidence test expected `/dashboard?token=secret`, proving route query persistence; diagnostics were stored even when consent was false | `npm test -- __tests__/lib/actions/support.actions.test.ts --runInBand` passed with 8/8 tests; `npm test -- __tests__/lib/actions/support.actions.test.ts __tests__/components/support-navigation.test.tsx __tests__/app/support-pages.test.tsx --runInBand` passed with 3 suites and 14 tests; `npx tsc --noEmit` passed | Coverage now proves route query/hash redaction, diagnostics consent gating including string `"false"`, explicit public/non-internal message filtering, and stable user-safe list error mapping | Kept the fix inside `lib/actions/support.actions.ts`; no Supabase production mutation or SQL execution was performed |
 
 ## Completed Tasks
 
@@ -32,6 +37,10 @@
 - [x] 2.1 Added `lib/support/r2.ts` with private bucket constants, server-only env validation, attachment limits, safe key building, SigV4 signed URL generation, and MIME magic-byte sniffing.
 - [x] 2.2 Added support attachment route handlers for intent, finalize, and download/HEAD, with authorization before signed URL issuance and rejected-object cleanup after failed finalization.
 - [x] 2.3 Verified allowed files pass, oversized/MIME failures reject, and direct/bypassed download attempts without authorized uploaded metadata fail with 403.
+- [x] 3.1 Added `lib/actions/support.actions.ts` for authenticated reporter create/list/detail/message flows with Zod validation and allowlisted evidence mapping.
+- [x] 3.2 Added `/ayuda`, `/ayuda/reportar`, `/ayuda/tickets`, and `/ayuda/tickets/[id]` App Router pages using existing dashboard/design-system primitives.
+- [x] 3.3 Replaced Ayuda “Próximamente” toast buttons with real `/ayuda` navigation in sidebar, mobile drawer, mobile bottom menu, and desktop header.
+- [x] 3.4 Verified submit, anonymous rejection, reporter view/reply, and mobile `/ayuda` navigation through focused tests plus full CI test execution.
 
 ## Staging Baseline Setup
 
@@ -68,6 +77,15 @@
 - Phase 2 focused GREEN: `pnpm test -- __tests__/lib/support/r2.test.ts __tests__/app/support-attachments-route.test.ts --runInBand` passed with 2 suites and 9 tests.
 - Phase 2 required runner verification: `pnpm test -- __tests__/lib/support/capabilities.test.ts __tests__/supabase/support-ticket-system-migration.test.ts __tests__/lib/support/r2.test.ts __tests__/app/support-attachments-route.test.ts --runInBand` passed with 4 suites and 25 tests after the R2/HEAD hardening follow-up.
 - Phase 2 type verification: `pnpm exec tsc --noEmit` passed.
+- Phase 3 RED baseline: `pnpm test -- __tests__/lib/actions/support.actions.test.ts __tests__/components/support-navigation.test.tsx --runInBand` failed because `@/lib/actions/support.actions` did not exist and Ayuda navigation still rendered toast buttons.
+- Phase 3 focused GREEN: `pnpm test -- __tests__/lib/actions/support.actions.test.ts __tests__/components/support-navigation.test.tsx __tests__/app/support-pages.test.tsx --runInBand` passed with 3 suites and 12 tests. React emitted non-failing Suspense/act warnings from lazy desktop header resolution in page tests.
+- Phase 3 type verification: `pnpm exec tsc --noEmit` passed after page-local void-returning form action wrappers were added.
+- Phase 3 full CI verification: `pnpm test:ci` passed with Jest 10 suites/54 tests and Node Test Runner 17 tests.
+- Phase 3 Node Test Runner verification: `pnpm test:node` passed with 17 tests.
+- Phase 3 lint verification: `pnpm lint` failed before linting because `eslint-plugin-security` could not be resolved from the current install.
+- Phase 3 privacy review fix verification: `npm test -- __tests__/lib/actions/support.actions.test.ts --runInBand` passed with 1 suite and 8 tests.
+- Phase 3 related regression verification: `npm test -- __tests__/lib/actions/support.actions.test.ts __tests__/components/support-navigation.test.tsx __tests__/app/support-pages.test.tsx --runInBand` passed with 3 suites and 14 tests. React emitted the existing non-failing Suspense/act warnings from page tests.
+- Phase 3 privacy review type verification: `npx tsc --noEmit` passed.
 
 ## Production Safety
 
@@ -77,12 +95,19 @@
 - Review fix edited only the not-yet-applied migration contract: no production SQL execution and no destructive command was run.
 - Task 1.2 type generation used Supabase staging; no production SQL or schema mutation was executed.
 - Phase 2 performed no Supabase production mutations and no live R2 calls during tests; R2 interactions are signed server-side and mocked in unit coverage.
+- Phase 3 performed no Supabase production mutations and no live R2 calls; Supabase access was mocked in tests and implementation uses the authenticated server client so RLS remains the authorization boundary.
+- Phase 3 privacy review fix performed no Supabase production mutations, no SQL execution, and no live Supabase calls; Supabase access remained mocked in tests.
 - No GitHub issue sync was implemented.
 - Staging baseline docs/scripts target project ref `ebwtdjtajclzciwipevw`; old package scripts for `wcnqocyqtksxhthnquta` were blocked or replaced with staging-safe commands.
 
 ## Remaining Tasks
 
-- [ ] 3.1 Create `lib/actions/support*.ts` for authenticated ticket create/list/detail/message with Zod validation and safe evidence fields.
-- [ ] 3.2 Build `app/(auth)/ayuda/**` home, report form, history, and detail with UI components.
-- [ ] 3.3 Replace Ayuda toasts in `sidebar-moderna.tsx`, `header-movil.tsx`, `menu-inferior-movil.tsx`, and `desktop-header`.
-- [ ] 3.4 Verify submit, anonymous rejection, reporter view/reply, and mobile `/ayuda` navigation.
+- [ ] 4.1 Build `app/(auth)/ayuda/admin` queue with filters and Postgres FTS.
+- [ ] 4.2 Add staff reply, assignment, and status transition actions in `lib/actions/support*.ts` with audit events.
+- [ ] 4.3 Verify capabilities, unauthorized denial, search/filter, and audited status saves.
+- [ ] 5.1 Add `emails/support-*.tsx` templates and `lib/email/**` calls with safe authenticated links only.
+- [ ] 5.2 Add `lib/support/inngest*.ts` events with ID-only payloads and idempotency keys.
+- [ ] 5.3 Verify one email per event/recipient and no evidence, attachments, raw Sentry, or GitHub issues.
+- [ ] 6.1 Harden `instrumentation-client.ts`, `sentry.server.config.ts`, and `sentry.edge.config.ts` for no default PII/raw replay.
+- [ ] 6.2 Document R2/Inngest/Resend envs, rollback, retention question, and future sanitized GitHub boundary.
+- [ ] 6.3 Run `pnpm test:rls`, unit/integration suites, build/typecheck, and manual reporter/staff flows.

--- a/openspec/changes/support-ticket-system/tasks.md
+++ b/openspec/changes/support-ticket-system/tasks.md
@@ -43,10 +43,10 @@ Chain strategy: feature-branch-chain
 
 ## Phase 3: Reporter Ticket Flow
 
-- [ ] 3.1 Create `lib/actions/support*.ts` for authenticated ticket create/list/detail/message with Zod validation and safe evidence fields.
-- [ ] 3.2 Build `app/(auth)/ayuda/**` home, report form, history, and detail with UI components.
-- [ ] 3.3 Replace Ayuda toasts in `sidebar-moderna.tsx`, `header-movil.tsx`, `menu-inferior-movil.tsx`, and `desktop-header`.
-- [ ] 3.4 Verify submit, anonymous rejection, reporter view/reply, and mobile `/ayuda` navigation.
+- [x] 3.1 Create `lib/actions/support*.ts` for authenticated ticket create/list/detail/message with Zod validation and safe evidence fields.
+- [x] 3.2 Build `app/(auth)/ayuda/**` home, report form, history, and detail with UI components.
+- [x] 3.3 Replace Ayuda toasts in `sidebar-moderna.tsx`, `header-movil.tsx`, `menu-inferior-movil.tsx`, and `desktop-header`.
+- [x] 3.4 Verify submit, anonymous rejection, reporter view/reply, and mobile `/ayuda` navigation.
 
 ## Phase 4: Support Console
 


### PR DESCRIPTION
Closes #119

# Título del PR
feat(support): link ayuda navigation

## Resumen
This PR connects the new reporter support flow from existing Ayuda navigation entry points.

## Qué Incluye
- Desktop/header/mobile navigation updates for `/ayuda`.
- Mobile bottom menu Ayuda link behavior.
- Navigation tests for support links.

## Chain Context
Strategy: feature-branch-chain

```text
main
└── feat/support-reporter-flow-tracker
    └── feat/support-reporter-actions
        └── feat/support-reporter-pages-clean
            └── feat/support-reporter-navigation-clean 📍
                └── docs/support-reporter-sdd-clean
```

## Migraciones / Base de Datos
- [x] No aplica

## Pruebas Manuales Realizadas
- `pnpm exec jest __tests__/lib/actions/support.actions.test.ts --runInBand` passed for the server-action fix in the ancestor branch.
- `pnpm exec tsc --noEmit` passed.
- `pnpm build` passed.

## Pendientes / Follow-up
- SDD apply-progress documentation update in the next chained PR.
