### PR TITLE
feat(support): add support email templates

### DIFF
--- a/__tests__/lib/email/support.test.tsx
+++ b/__tests__/lib/email/support.test.tsx
@@ -1,0 +1,134 @@
+import { renderToStaticMarkup } from 'react-dom/server'
+
+import {
+  SupportTicketCreatedEmail,
+  SupportTicketMessageEmail,
+  SupportTicketStatusChangedEmail,
+} from '@/emails/support-ticket'
+import {
+  sendSupportTicketCreatedEmail,
+  sendSupportTicketMessageEmail,
+  sendSupportTicketStatusChangedEmail,
+} from '@/lib/email/support'
+import { sendEmail } from '@/lib/email/send'
+
+jest.mock('@/lib/email/send', () => ({ sendEmail: jest.fn() }))
+
+const sendEmailMock = jest.mocked(sendEmail)
+
+describe('support email helpers', () => {
+  beforeEach(() => {
+    sendEmailMock.mockReset()
+    process.env.NEXT_PUBLIC_SITE_URL = 'https://connect.yosoyglobal.org'
+  })
+
+  it('sends a ticket creation acknowledgement with an authenticated app link only', async () => {
+    sendEmailMock.mockResolvedValue({ success: true, id: 'email-1' })
+
+    await expect(sendSupportTicketCreatedEmail({
+      recipientEmail: 'reporter@example.com',
+      recipientName: 'Isaac',
+      ticketId: 'ticket-1',
+      ticketNumber: 42,
+      title: 'Cannot open group map',
+      status: 'received',
+      idempotencyKey: 'email:event-1:reporter@example.com',
+    })).resolves.toEqual({ success: true, id: 'email-1' })
+
+    expect(sendEmailMock).toHaveBeenCalledWith(expect.objectContaining({
+      to: 'reporter@example.com',
+      subject: 'Recibimos tu solicitud #42',
+      idempotencyKey: 'email:event-1:reporter@example.com',
+    }))
+    const html = renderToStaticMarkup(sendEmailMock.mock.calls[0][0].template)
+    expect(html).toContain('https://connect.yosoyglobal.org/ayuda/tickets/ticket-1')
+    expect(html).toContain('Cannot open group map')
+    expect(html).not.toContain('sentry')
+    expect(html).not.toContain('attachment')
+    expect(html).not.toContain('github')
+    expect(html).not.toContain('support/ticket-1')
+  })
+
+  it('encodes special-character ticket IDs in authenticated app links', async () => {
+    sendEmailMock.mockResolvedValue({ success: true, id: 'email-special-id' })
+
+    await sendSupportTicketCreatedEmail({
+      recipientEmail: 'reporter@example.com',
+      ticketId: 'ticket/with spaces?x=1&next=https://evil.test',
+      ticketNumber: 46,
+      title: 'Link encoding check',
+      status: 'received',
+    })
+
+    const html = renderToStaticMarkup(sendEmailMock.mock.calls[0][0].template)
+    expect(html).toContain(
+      'https://connect.yosoyglobal.org/ayuda/tickets/ticket%2Fwith%20spaces%3Fx%3D1%26next%3Dhttps%3A%2F%2Fevil.test'
+    )
+    expect(html).not.toContain('/ayuda/tickets/ticket/with spaces')
+  })
+
+  it('sends a new message notification without message body or diagnostics', async () => {
+    sendEmailMock.mockResolvedValue({ success: true, id: 'email-2' })
+
+    await sendSupportTicketMessageEmail({
+      recipientEmail: 'reporter@example.com',
+      recipientName: 'Isaac',
+      ticketId: 'ticket-2',
+      ticketNumber: 43,
+      title: 'Attendance issue',
+      status: 'in_progress',
+      idempotencyKey: 'email:event-2:reporter@example.com',
+    })
+
+    expect(sendEmailMock).toHaveBeenCalledWith(expect.objectContaining({
+      to: 'reporter@example.com',
+      subject: 'Nueva respuesta en tu solicitud #43',
+    }))
+    const html = renderToStaticMarkup(sendEmailMock.mock.calls[0][0].template)
+    expect(html).toContain('https://connect.yosoyglobal.org/ayuda/tickets/ticket-2')
+    expect(html).not.toContain('I can reproduce it')
+    expect(html).not.toContain('Chrome')
+    expect(html).not.toContain('rawSentryPayload')
+  })
+
+  it('sends a status change notification with the safe status label', async () => {
+    sendEmailMock.mockResolvedValue({ success: true, id: 'email-3' })
+
+    await sendSupportTicketStatusChangedEmail({
+      recipientEmail: 'reporter@example.com',
+      recipientName: 'Isaac',
+      ticketId: 'ticket-3',
+      ticketNumber: 44,
+      title: 'Cannot save profile',
+      status: 'resolved',
+      idempotencyKey: 'email:event-3:reporter@example.com',
+    })
+
+    expect(sendEmailMock).toHaveBeenCalledWith(expect.objectContaining({
+      subject: 'Actualizamos tu solicitud #44',
+    }))
+    const html = renderToStaticMarkup(sendEmailMock.mock.calls[0][0].template)
+    expect(html).toContain('Resuelto')
+    expect(html).toContain('/ayuda/tickets/ticket-3')
+  })
+
+  it('renders support templates without unsafe evidence, attachments, R2 keys, or GitHub details', async () => {
+    const sharedProps = {
+      recipientName: 'Isaac',
+      ticketNumber: 45,
+      title: 'Map fails after login',
+      status: 'received' as const,
+      ticketUrl: 'https://connect.yosoyglobal.org/ayuda/tickets/ticket-4',
+    }
+
+    const html = [
+      renderToStaticMarkup(<SupportTicketCreatedEmail {...sharedProps} />),
+      renderToStaticMarkup(<SupportTicketMessageEmail {...sharedProps} />),
+      renderToStaticMarkup(<SupportTicketStatusChangedEmail {...sharedProps} status="closed" />),
+    ].join('\n')
+
+    expect(html).toContain('Map fails after login')
+    expect(html).toContain('https://connect.yosoyglobal.org/ayuda/tickets/ticket-4')
+    expect(html).not.toMatch(/sentry|diagnostic|evidence|attachment|github|support\/ticket-4|r2/i)
+  })
+})

--- a/emails/support-ticket.tsx
+++ b/emails/support-ticket.tsx
@@ -1,0 +1,120 @@
+import { Text } from '@react-email/components'
+
+import { EmailButton } from './components/EmailButton'
+import { EmailLayout } from './components/EmailLayout'
+
+export type SupportEmailStatus = 'received' | 'in_review' | 'in_progress' | 'resolved' | 'closed'
+
+interface SupportTicketEmailProps {
+  recipientName?: string
+  ticketNumber: number
+  title: string
+  status: SupportEmailStatus
+  ticketUrl: string
+}
+
+export function SupportTicketCreatedEmail({ recipientName = 'Usuario', ticketNumber, title, status, ticketUrl }: SupportTicketEmailProps) {
+  return (
+    <EmailLayout preview={`Recibimos tu solicitud #${ticketNumber}`}>
+      <Text style={styles.title}>Recibimos tu solicitud, {recipientName}</Text>
+      <Text style={styles.text}>
+        Tu solicitud #{ticketNumber} fue registrada y nuestro equipo la revisará desde GlobalConnect.
+      </Text>
+      <TicketSummary title={title} status={status} />
+      <EmailButton href={ticketUrl}>Ver mi solicitud</EmailButton>
+      <Text style={styles.hint}>
+        Por seguridad, los detalles completos solo están disponibles al iniciar sesión.
+      </Text>
+    </EmailLayout>
+  )
+}
+
+export function SupportTicketMessageEmail({ recipientName = 'Usuario', ticketNumber, title, status, ticketUrl }: SupportTicketEmailProps) {
+  return (
+    <EmailLayout preview={`Nueva respuesta en tu solicitud #${ticketNumber}`}>
+      <Text style={styles.title}>Tienes una nueva respuesta, {recipientName}</Text>
+      <Text style={styles.text}>
+        Nuestro equipo agregó una respuesta a tu solicitud #{ticketNumber}.
+      </Text>
+      <TicketSummary title={title} status={status} />
+      <EmailButton href={ticketUrl}>Abrir solicitud</EmailButton>
+      <Text style={styles.hint}>
+        Ingresa a GlobalConnect para leer la conversación completa y responder si hace falta.
+      </Text>
+    </EmailLayout>
+  )
+}
+
+export function SupportTicketStatusChangedEmail({ recipientName = 'Usuario', ticketNumber, title, status, ticketUrl }: SupportTicketEmailProps) {
+  return (
+    <EmailLayout preview={`Actualizamos tu solicitud #${ticketNumber}`}>
+      <Text style={styles.title}>Actualizamos tu solicitud, {recipientName}</Text>
+      <Text style={styles.text}>
+        El estado de tu solicitud #{ticketNumber} cambió a {getSupportStatusLabel(status)}.
+      </Text>
+      <TicketSummary title={title} status={status} />
+      <EmailButton href={ticketUrl}>Revisar solicitud</EmailButton>
+      <Text style={styles.hint}>
+        Este correo solo incluye un resumen seguro. Los detalles están protegidos dentro de tu sesión.
+      </Text>
+    </EmailLayout>
+  )
+}
+
+function TicketSummary({ title, status }: Pick<SupportTicketEmailProps, 'title' | 'status'>) {
+  return (
+    <>
+      <Text style={styles.label}>Solicitud</Text>
+      <Text style={styles.summary}>{title}</Text>
+      <Text style={styles.label}>Estado</Text>
+      <Text style={styles.summary}>{getSupportStatusLabel(status)}</Text>
+    </>
+  )
+}
+
+export function getSupportStatusLabel(status: SupportEmailStatus) {
+  const labels: Record<SupportEmailStatus, string> = {
+    received: 'Recibido',
+    in_review: 'En revisión',
+    in_progress: 'En progreso',
+    resolved: 'Resuelto',
+    closed: 'Cerrado',
+  }
+
+  return labels[status]
+}
+
+const styles = {
+  title: {
+    fontSize: '24px',
+    fontWeight: '700' as const,
+    color: '#ffffff',
+    margin: '0 0 16px',
+  },
+  text: {
+    fontSize: '15px',
+    lineHeight: '1.6',
+    color: '#a0a0b0',
+    margin: '0 0 16px',
+  },
+  label: {
+    fontSize: '12px',
+    fontWeight: '700' as const,
+    letterSpacing: '0.04em',
+    textTransform: 'uppercase' as const,
+    color: '#D06D2D',
+    margin: '20px 0 6px',
+  },
+  summary: {
+    fontSize: '15px',
+    lineHeight: '1.5',
+    color: '#ffffff',
+    margin: '0',
+  },
+  hint: {
+    fontSize: '13px',
+    color: '#6b7280',
+    marginTop: '24px',
+    lineHeight: '1.5',
+  },
+}

--- a/lib/email/support.ts
+++ b/lib/email/support.ts
@@ -1,0 +1,59 @@
+"use server"
+
+import { SupportTicketCreatedEmail, SupportTicketMessageEmail, SupportTicketStatusChangedEmail } from '@/emails/support-ticket'
+import type { SupportEmailStatus } from '@/emails/support-ticket'
+import { sendEmail } from '@/lib/email/send'
+
+interface SupportEmailParams {
+  recipientEmail: string
+  recipientName?: string
+  ticketId: string
+  ticketNumber: number
+  title: string
+  status: SupportEmailStatus
+  idempotencyKey?: string
+}
+
+export async function sendSupportTicketCreatedEmail(params: SupportEmailParams) {
+  return sendEmail({
+    to: params.recipientEmail,
+    subject: `Recibimos tu solicitud #${params.ticketNumber}`,
+    template: SupportTicketCreatedEmail(toTemplateProps(params)),
+    idempotencyKey: params.idempotencyKey,
+  })
+}
+
+export async function sendSupportTicketMessageEmail(params: SupportEmailParams) {
+  return sendEmail({
+    to: params.recipientEmail,
+    subject: `Nueva respuesta en tu solicitud #${params.ticketNumber}`,
+    template: SupportTicketMessageEmail(toTemplateProps(params)),
+    idempotencyKey: params.idempotencyKey,
+  })
+}
+
+export async function sendSupportTicketStatusChangedEmail(params: SupportEmailParams) {
+  return sendEmail({
+    to: params.recipientEmail,
+    subject: `Actualizamos tu solicitud #${params.ticketNumber}`,
+    template: SupportTicketStatusChangedEmail(toTemplateProps(params)),
+    idempotencyKey: params.idempotencyKey,
+  })
+}
+
+function toTemplateProps(params: SupportEmailParams) {
+  return {
+    recipientName: params.recipientName,
+    ticketNumber: params.ticketNumber,
+    title: params.title,
+    status: params.status,
+    ticketUrl: getSupportTicketUrl(params.ticketId),
+  }
+}
+
+function getSupportTicketUrl(ticketId: string) {
+  const siteUrl = process.env.NEXT_PUBLIC_SITE_URL || 'https://connect.yosoyglobal.org'
+  const origin = new URL(siteUrl).origin
+
+  return `${origin}/ayuda/tickets/${encodeURIComponent(ticketId)}`
+}

--- a/openspec/changes/support-ticket-system/apply-progress.md
+++ b/openspec/changes/support-ticket-system/apply-progress.md
@@ -5,9 +5,9 @@
 - Mode: Strict TDD
 - Delivery: force-chained
 - Chain strategy: feature-branch-chain
-- Current slice: Phase 4 task 4.3 verification completed with focused action-layer and static migration coverage for staff capabilities, unauthorized denial, search/filter safety, audited status saves, and direct table bypass closure. Live/staging RLS was not executed because required Supabase credentials are unavailable in this workspace.
-- Completed tasks: 1.1, 1.2, 1.3, 1.4, 2.1, 2.2, 2.3, 3.1, 3.2, 3.3, 3.4, 4.1, 4.2, 4.3
-- Latest update: Phase 4.3 verified that `support.view`, `support.reply`, and `support.manage` boundaries are covered by focused action tests and static SQL contracts; staff queue search uses plain `simple` FTS with bounded filters; status/assignment/reply mutations are routed through authenticated-only audited RPCs; direct staff table UPDATE/INSERT bypasses remain closed. The already-applied `20260610134000_add_support_staff_action_rpcs.sql` migration was restored to `origin/main`, and replayable migration `20260610161000_harden_staff_reply_rpc_body.sql` now rejects blank direct `p_body` inputs before message and audit insertion.
+- Current slice: Phase 5 task 5.1 completed with support email templates and helper calls that build authenticated `/ayuda/tickets/:id` links only. Inngest event wiring remains pending for 5.2.
+- Completed tasks: 1.1, 1.2, 1.3, 1.4, 2.1, 2.2, 2.3, 3.1, 3.2, 3.3, 3.4, 4.1, 4.2, 4.3, 5.1
+- Latest update: Phase 5.1 added React Email templates for ticket creation, new public message, and status changes plus `lib/email/support.ts` helpers that delegate to existing `sendEmail` with optional idempotency keys. Email bodies include only recipient name, ticket number, title, status label, and an authenticated app link; they exclude evidence, attachments, raw Sentry, R2 object keys, and GitHub issue details.
 
 ## TDD Cycle Evidence
 
@@ -32,6 +32,7 @@
 | 4.2 review fix | `__tests__/lib/actions/support.actions.test.ts`, `__tests__/supabase/support-ticket-system-migration.test.ts` | Unit/server action + static migration contract | Fresh review verdict reported staff reply capability bypass and non-atomic mutation/audit blockers | Review blocker proved the previous split write design could allow reporter-owned ticket replies through RLS and leave mutations without audit if audit insertion failed | `pnpm test -- __tests__/lib/actions/support.actions.test.ts __tests__/supabase/support-ticket-system-migration.test.ts --runInBand` passed with 2 suites and 28 tests; `pnpm exec tsc --noEmit` passed | Coverage now denies direct staff replies without `support.reply` before RPC invocation, verifies staff actions call atomic RPCs, and statically asserts RPC capability gates plus audit writes | Added repo-only migration SQL; no live Supabase migration was applied |
 | 4.2 delivery blocker fix | `__tests__/supabase/support-ticket-system-migration.test.ts` | Static migration delivery contract | Fresh review verdict reported RPCs were added by editing `20260609130000_support_ticket_system.sql`, a migration already in `origin/main` and applied to staging | Supabase records migration versions, so staging/prod-like databases would not replay edits to `20260609130000`; `git diff --exit-code origin/main -- supabase/migrations/20260609130000_support_ticket_system.sql` proved the restored base migration now matches main | `pnpm test -- __tests__/lib/actions/support.actions.test.ts __tests__/supabase/support-ticket-system-migration.test.ts --runInBand` passed with 2 suites and 29 tests; support regression, typecheck, migration lint, and diff whitespace checks passed | Static tests now assert the base migration stays free of post-staging RPCs while the effective support SQL across migrations contains hardened atomic staff RPCs with fixed `search_path`, capability checks, audit writes, and authenticated-only grants | Added follow-up migration `20260610134000_add_support_staff_action_rpcs.sql`; no live Supabase migration was applied |
 | 4.3 | `__tests__/lib/actions/support.actions.test.ts`, `__tests__/supabase/support-ticket-system-migration.test.ts` | Unit/server action + static migration contract | `pnpm test -- __tests__/lib/actions/support.actions.test.ts __tests__/supabase/support-ticket-system-migration.test.ts --runInBand` passed with 2 suites and 31 tests before edits | RED failed because the staff reply RPC did not reject blank direct `p_body` values before inserting a message/audit row | `pnpm test -- __tests__/supabase/support-ticket-system-migration.test.ts --runInBand` passed with 15 tests; support regression passed with 7 suites and 55 tests | Existing action tests cover `support.view` queue denial, FTS/filter query construction, `support.reply` and `support.manage` denial, status validation, audited RPC calls, and stable denial mapping; static coverage now reads the latest effective RPC definition across follow-up migrations and verifies direct RPC blank replies are rejected before mutation/audit | Restored already-applied migration `20260610134000_add_support_staff_action_rpcs.sql` to `origin/main` and added follow-up migration `20260610161000_harden_staff_reply_rpc_body.sql`; live/staging RLS was not run because Supabase credentials are unavailable |
+| 5.1 | `__tests__/lib/email/support.test.tsx` | Unit/template rendering + mocked email send | N/A (new files) | `pnpm test -- __tests__/lib/email/support.test.tsx --runInBand` failed because `@/emails/support-ticket` and `@/lib/email/support` did not exist | `pnpm test -- __tests__/lib/email/support.test.tsx --runInBand` passed with 1 suite and 5 tests | 5 cases cover creation acknowledgement, encoded special-character ticket IDs in authenticated app links, new message notification without message body/diagnostics, status change labels, and unsafe evidence/attachment/R2/GitHub exclusion across templates | Switched tests from `@react-email/render` to `react-dom/server` because the React Email renderer requires `--experimental-vm-modules` in this Jest setup; production still uses the existing `sendEmail` React Email renderer |
 
 ## Completed Tasks
 
@@ -49,6 +50,7 @@
 - [x] 4.1 Built `/ayuda/admin` staff queue with `support.view` authorization, server-side filters, Postgres FTS query construction, and focused page/action coverage.
 - [x] 4.2 Added staff reply, assignment, and status transition server actions with append-only support audit event writes, focused action coverage, and follow-up migration delivery for atomic staff RPCs.
 - [x] 4.3 Verified support staff capabilities, unauthorized denial, search/filter behavior, audited status saves, and direct staff table bypass closure through focused Jest/static migration coverage; live/staging RLS was not executed because required credentials are unavailable.
+- [x] 5.1 Added support ticket email templates and `lib/email/support.ts` helpers for creation, message, and status notifications with safe authenticated app links only.
 
 ## Staging Baseline Setup
 
@@ -124,6 +126,10 @@
 - Phase 4.3 migration lint verification: `pnpm lint:migrations` passed with 0 errors; repo-wide historical warnings remain.
 - Phase 4.3 diff whitespace verification: `git diff --check origin/main` passed.
 - Phase 4.3 live/staging RLS verification gap: `pnpm test:rls` did not run because `NEXT_PUBLIC_SUPABASE_URL`, `SUPABASE_SERVICE_ROLE_KEY`, and `NEXT_PUBLIC_SUPABASE_ANON_KEY` are not present in this workspace. No Supabase mutation tool, live migration, or destructive SQL was executed.
+- Phase 5.1 RED: `pnpm test -- __tests__/lib/email/support.test.tsx --runInBand` failed because the support email template/helper modules did not exist.
+- Phase 5.1 focused GREEN: `pnpm test -- __tests__/lib/email/support.test.tsx --runInBand` passed with 1 suite and 5 tests, including special-character `ticketId` link encoding.
+- Phase 5.1 type verification: `pnpm exec tsc --noEmit` passed.
+- Phase 5.1 support regression verification: `pnpm test -- __tests__/lib/email/support.test.tsx __tests__/lib/actions/support.actions.test.ts __tests__/app/support-pages.test.tsx __tests__/components/support-navigation.test.tsx __tests__/app/support-attachments-route.test.ts __tests__/lib/support/r2.test.ts __tests__/lib/support/capabilities.test.ts --runInBand` passed with 7 suites and 44 tests. React emitted existing non-failing Suspense/act warnings from page tests.
 
 ## Production Safety
 
@@ -138,12 +144,12 @@
 - Phase 4.1 performed no Supabase production mutations, no SQL execution, no migrations, and no live Supabase calls; Supabase access remained mocked in focused tests and implementation uses authenticated server clients plus RLS-protected tables.
 - Phase 4.2 performed no Supabase production/staging mutations, no SQL execution, and no live Supabase calls; repo-only follow-up migration SQL now defines atomic staff mutation RPCs, and tests mock Supabase access rather than applying those functions live.
 - Phase 4.3 performed no Supabase production/staging mutations, no SQL execution, no live migrations, and no live Supabase calls; the hardened staff reply RPC ships only as a repo migration file because credentials for `pnpm test:rls` are unavailable.
+- Phase 5.1 performed no Supabase production/staging mutations, no SQL execution, no live Supabase calls, no live Resend calls, and no Inngest event wiring. `sendEmail` was mocked in tests.
 - No GitHub issue sync was implemented.
 - Staging baseline docs/scripts target project ref `ebwtdjtajclzciwipevw`; old package scripts for `wcnqocyqtksxhthnquta` were blocked or replaced with staging-safe commands.
 
 ## Remaining Tasks
 
-- [ ] 5.1 Add `emails/support-*.tsx` templates and `lib/email/**` calls with safe authenticated links only.
 - [ ] 5.2 Add `lib/support/inngest*.ts` events with ID-only payloads and idempotency keys.
 - [ ] 5.3 Verify one email per event/recipient and no evidence, attachments, raw Sentry, or GitHub issues.
 - [ ] 6.1 Harden `instrumentation-client.ts`, `sentry.server.config.ts`, and `sentry.edge.config.ts` for no default PII/raw replay.

--- a/openspec/changes/support-ticket-system/tasks.md
+++ b/openspec/changes/support-ticket-system/tasks.md
@@ -56,7 +56,7 @@ Chain strategy: feature-branch-chain
 
 ## Phase 5: Notifications and Audit
 
-- [ ] 5.1 Add `emails/support-*.tsx` templates and `lib/email/**` calls with safe authenticated links only.
+- [x] 5.1 Add `emails/support-*.tsx` templates and `lib/email/**` calls with safe authenticated links only.
 - [ ] 5.2 Add `lib/support/inngest*.ts` events with ID-only payloads and idempotency keys.
 - [ ] 5.3 Verify one email per event/recipient and no evidence, attachments, raw Sentry, or GitHub issues.
 


### PR DESCRIPTION
Closes #134

# Título del PR
feat(support): add support email templates

## Resumen
This PR implements Phase 5.1 support email foundations: safe React Email templates and helper calls for support notifications.

## Qué Incluye
- `emails/support-ticket.tsx` templates for ticket created, message, and status notifications.
- `lib/email/support.ts` helpers using the existing email infrastructure.
- Tests enforcing safe summary-only content and encoded authenticated ticket links.
- OpenSpec progress updates marking only Phase 5.1 complete.

## Motivación / Por Qué
Support notifications need reusable safe email templates before Phase 5.2 wires event delivery and idempotency.

## SDD Scope
Change: `support-ticket-system`

Completed in this PR:
- [x] 5.1 Add `emails/support-*.tsx` templates and `lib/email/**` calls with safe authenticated links only.

Still pending:
- [ ] 5.2 Add `lib/support/inngest*.ts` events with ID-only payloads and idempotency keys.
- [ ] 5.3 Verify one email per event/recipient and no evidence, attachments, raw Sentry, or GitHub issues.

## Privacy / Security Notes
- Emails contain safe summaries only: recipient name, ticket number, title, status label, and app link.
- No evidence, attachments, diagnostics, raw Sentry, R2 object keys, GitHub details, or staff-only content.
- Ticket links are app-origin authenticated links to `/ayuda/tickets/:id`.
- Special ticket IDs are encoded before being placed into links.

## Migraciones / Base de Datos
- [x] No aplica
- [ ] Sí (orden exacto):
```text
N/A
```

## Impacto y Riesgos
- No live email sends.
- No Inngest wiring in this PR.
- No Supabase mutation.

## Checklist Autor
- [x] Código formateado (Prettier/ESLint)
- [x] Sin `console.log` / debugger
- [x] Validaciones con zod para entradas nuevas
- [x] Estados loading/error/empty cubiertos
- [x] Tipos TypeScript correctos
- [x] Migraciones probadas local
- [x] Documentación actualizada (`docs/` o README)
- [x] Variables de entorno documentadas
- [x] Rebase con `main` limpio

## Checklist Revisor
- [ ] Propósito claro
- [ ] Nombres descriptivos
- [ ] Sin lógica duplicada evidente
- [ ] Manejo adecuado de errores
- [ ] Cambios acotados al alcance
- [ ] Sin secretos / datos sensibles

## Pruebas Manuales Realizadas
- Fresh review verdict: `PASS`.
- `pnpm test -- __tests__/lib/email/support.test.tsx --runInBand` passed: 1 suite / 5 tests.
- `pnpm exec tsc --noEmit` passed.
- Support regression suite passed: 7 suites / 45 tests.
- `git diff --check origin/main...HEAD` passed.

## Pendientes / Follow-up
- Phase 5.2 Inngest event wiring.
- Phase 5.3 one-email-per-event/recipient verification.

## Notas Adicionales
Review workload is under budget: 5 files, 324 insertions, 5 deletions.
