### PR TITLE
docs(support): add operations runbook

### DIFF
--- a/docs/support-operations.md
+++ b/docs/support-operations.md
@@ -1,0 +1,143 @@
+# Support Operations Runbook
+
+This runbook covers the operational path for the support ticket system. It is intentionally non-mutating: production Supabase migrations, provider changes, and credential rotation remain explicit reviewed operations.
+
+## Quick Path
+
+1. Confirm the support feature slice being released and review the migration diff before any hosted apply.
+2. Configure server-only provider environment variables for R2, Inngest, Resend, and Sentry/privacy controls in the target environment.
+3. Apply support migrations only after explicit review approval; do not apply production migrations from an unreviewed local branch.
+4. Verify `/ayuda` reporter flow, staff queue access, private attachment signing, and safe notification payloads with test accounts.
+5. If a rollout issue appears, hide support entry points and disable side effects first; preserve production data unless a reviewed retention/export plan exists.
+
+## Safety Boundary
+
+| Area | Rule |
+|------|------|
+| Production Supabase | Migration application is manual, explicit, reviewed, and separate from this documentation change. |
+| R2 | Buckets stay private; signed URLs are issued only after app authorization. |
+| Inngest | Events carry IDs only; workers must fetch data after authorization and must be idempotent. |
+| Resend | Emails contain safe authenticated links only; no evidence, attachments, or raw diagnostics. |
+| Sentry | Support stores Sentry references only; raw payloads, replay media, cookies, headers, and diagnostics are scrubbed. |
+| GitHub | No MVP sync. Future GitHub issues are downstream engineering artifacts only. |
+
+## Environment Checklist
+
+Set secrets only in the runtime provider or deployment environment. Never commit them to the repository, docs, OpenSpec artifacts, screenshots, or support tickets.
+
+### Cloudflare R2
+
+| Variable / Setting | Required | Notes |
+|--------------------|----------|-------|
+| `R2_ACCOUNT_ID` | Yes | Used to build the Cloudflare R2 endpoint. |
+| `R2_ACCESS_KEY_ID` | Yes | Must be scoped to the private support bucket where possible. |
+| `R2_SECRET_ACCESS_KEY` | Yes | Server-only secret. Rotate on suspected exposure. |
+| Bucket name | Yes | Code expects private bucket `global-connect-support`. |
+| Public access | Must be disabled | Attachment reads use short-lived signed GET URLs after authorization. |
+| CORS | Required for browser uploads | Allow the deployed app origin for signed PUT uploads only. |
+
+Operational limits from code and spec:
+
+- Signed upload URLs expire after 5 minutes.
+- Signed download URLs expire after 60 seconds.
+- Screenshots: PNG, JPG, or WebP, max 10 MB each, max 5 per ticket.
+- Videos: MP4, WebM, or MOV, max 100 MB, max 1 per ticket.
+- Total active attachments per ticket: max 150 MB.
+- Object keys follow `support/{ticket_id}/{attachment_id}/{safe_filename}`; object keys are not authorization proof.
+
+### Inngest
+
+| Setting | Required | Notes |
+|---------|----------|-------|
+| Event names | Yes | `support/ticket.created`, `support/ticket.message.created`, `support/ticket.status.changed`, `support/attachment.finalized`. |
+| Payload shape | Yes | IDs only: `eventId`, `ticketId`, optional `actorUserId`, and relevant message or attachment IDs. |
+| Idempotency | Yes | Email keys use `email:{eventId}:{recipient}`. Preserve this shape in any worker integration. |
+| Provider credentials | Future wiring | The current support module defines event contracts and email dispatch helpers; provider-specific live Inngest client wiring must be reviewed before enabling. |
+
+Workers must fetch ticket data server-side, avoid long user text in events, and never include evidence, attachment URLs, R2 keys, raw Sentry payloads, diagnostics, cookies, tokens, emails beyond the intended recipient, phone numbers, church/member details, or database internals in queued payloads.
+
+### Resend
+
+| Variable | Required | Notes |
+|----------|----------|-------|
+| `RESEND_API_KEY` | Yes for live email | Server-only key used by `lib/email/resend.ts`. |
+| `RESEND_FROM_NAME` | Optional | Defaults to `GlobalConnect`. |
+| `RESEND_FROM_EMAIL` | Optional | Defaults to `team@connect.yosoyglobal.org`; verify domain ownership before production sends. |
+| `NEXT_PUBLIC_SITE_URL` | Recommended | Used to build authenticated support ticket links; defaults to `https://connect.yosoyglobal.org`. |
+
+Email bodies must stay notification-only: ticket number, title, status label, and authenticated `/ayuda/tickets/{id}` link. Do not include message bodies, evidence, attachment links, raw diagnostics, Sentry payloads, R2 object keys, or GitHub details.
+
+### Sentry And Support Privacy
+
+Before enabling support evidence in production, reviewers must confirm:
+
+- `sendDefaultPii` remains disabled through shared privacy options.
+- Client replay sampling remains `0` unless a separate explicit consent design is reviewed.
+- Replay text is masked and media is blocked by default.
+- Support evidence stores allowlisted diagnostics and Sentry event IDs only.
+- Sentry requests, headers, bodies, user fields, URLs, and support contexts are scrubbed before send.
+
+## Rollback Guidance
+
+Use the least destructive rollback first. Rollback should protect users and preserve production records unless deletion has been explicitly reviewed.
+
+| Problem | First action | Follow-up |
+|---------|--------------|-----------|
+| Bad UI rollout | Hide `/ayuda` navigation and staff links. | Keep routes gated while the fix is reviewed. |
+| Attachment signing issue | Disable upload/finalize/download route exposure or revoke R2 signing credentials. | Keep R2 objects private; review stale pending upload cleanup before deleting objects. |
+| Email noise or unsafe copy | Disable support notification worker/send path. | Keep audit events and tickets; resume only after template/payload review. |
+| Inngest retry loop | Pause the support functions or filter support events. | Check idempotency keys before replaying jobs. |
+| Sentry privacy concern | Disable support evidence collection or Sentry send for the affected runtime. | Preserve ticket records and investigate scrubber coverage before re-enabling. |
+| Migration defect before production data | Revert the migration only after review confirms no production support data exists. | Prefer additive follow-up migrations when possible. |
+| Migration defect after production data | Do not drop support tables or columns. | Hide feature entry points, export/archive affected records if needed, and ship an additive corrective migration. |
+
+Production migration application remains an explicit reviewed operation. Do not run production Supabase DDL, DML, branch merges, resets, or destructive rollback commands as part of routine support operations.
+
+## Retention Open Questions
+
+Retention is not finalized. Until it is reviewed, operators must not implement destructive cleanup for uploaded support evidence or ticket history.
+
+Open decisions:
+
+- Final retention duration for support tickets, messages, evidence metadata, audit events, and attachments.
+- Cleanup cadence for stale `pending_upload` attachments and rejected R2 objects.
+- Whether retention differs by ticket status, campus, requester role, or legal hold.
+- Export/archive process before deleting any support data.
+- Operator approval path for retention jobs and emergency privacy deletion requests.
+
+Temporary operating rule: cleanup may remove only clearly stale pending uploads after review of the exact object keys and database rows. Closed or resolved ticket records and uploaded evidence remain preserved until the retention decision is complete.
+
+## Future GitHub Sync Boundary
+
+The MVP must not create GitHub issues. A future sync can exist only after sanitized investigation confirms an engineering issue.
+
+GitHub issues are downstream engineering artifacts only. They must never receive:
+
+- Evidence blobs, screenshots, videos, signed URLs, or attachment metadata that reveals private object keys.
+- Raw Sentry payloads, replay links, request bodies, headers, cookies, tokens, localStorage, diagnostics, or stack traces with user-sensitive data.
+- R2 account IDs, access keys, secret keys, bucket object keys, or signed URLs.
+- Internal staff messages, private audit notes, assignment details, capability lists, or support-only comments.
+- User-sensitive details such as emails, phone numbers, church/member data, campus-specific private context, database IDs, or free-form descriptions that contain PII.
+
+Allowed future payload shape:
+
+- Sanitized problem summary.
+- Reproduction steps rewritten without user-identifying details.
+- General environment facts such as browser family, OS family, viewport class, route pattern, and app/build version.
+- Internal support ticket link for authorized staff.
+- Sentry event reference ID only when scrubbed and access-controlled.
+
+## Verification Checklist
+
+Operators and reviewers should confirm each item before enabling or reviewing the support operations slice:
+
+- [ ] Production migrations were not applied automatically and have explicit review approval before any hosted apply.
+- [ ] R2 bucket `global-connect-support` is private and credentials are server-only.
+- [ ] Attachment upload, finalize, and download flows authorize before issuing signed URLs.
+- [ ] Resend sender domain and `NEXT_PUBLIC_SITE_URL` produce authenticated support links for the target environment.
+- [ ] Inngest support events contain IDs only and preserve idempotency keys.
+- [ ] Email templates exclude evidence, attachments, diagnostics, raw Sentry, R2 keys, GitHub data, and long user text.
+- [ ] Sentry support privacy defaults remain scrubbed and replay is not captured by default.
+- [ ] Rollback plan starts with hiding feature entry points and disabling side effects, not dropping production data.
+- [ ] Retention is still tracked as an open question and no destructive retention job is enabled.
+- [ ] Future GitHub sync remains out of MVP and limited to sanitized downstream engineering artifacts.

--- a/openspec/changes/support-ticket-system/apply-progress.md
+++ b/openspec/changes/support-ticket-system/apply-progress.md
@@ -5,9 +5,9 @@
 - Mode: Strict TDD
 - Delivery: force-chained
 - Chain strategy: feature-branch-chain
-- Current slice: Phase 6 task 6.1 completed with repo-local Sentry privacy contract tests and no live Sentry calls. Client replay remains available only as masked/blocked integration wiring, but default session and on-error replay sampling are set to zero.
-- Completed tasks: 1.1, 1.2, 1.3, 1.4, 2.1, 2.2, 2.3, 3.1, 3.2, 3.3, 3.4, 4.1, 4.2, 4.3, 5.1, 5.2, 5.3, 6.1
-- Latest update: Phase 6.1 hardened `instrumentation-client.ts`, `sentry.server.config.ts`, and `sentry.edge.config.ts` with shared `createSentryPrivacyOptions()` defaults: `sendDefaultPii: false`, consistent `beforeSend`/`beforeSendTransaction` scrubbing, no default replay sampling, replay text masking, media blocking, support context allowlisting to Sentry references only, request body filtering, URL query/hash stripping, sensitive header removal, user PII removal except internal user id, and `extra` dropping to avoid raw diagnostics/evidence/attachments/R2 keys/Sentry payloads/GitHub details. No live Sentry call or credential was required.
+- Current slice: Phase 6 task 6.2 completed with a non-mutating support operations runbook covering R2/Inngest/Resend envs, Sentry/support privacy, rollback, retention open questions, future sanitized GitHub boundaries, operator verification, and explicit production migration review requirements.
+- Completed tasks: 1.1, 1.2, 1.3, 1.4, 2.1, 2.2, 2.3, 3.1, 3.2, 3.3, 3.4, 4.1, 4.2, 4.3, 5.1, 5.2, 5.3, 6.1, 6.2
+- Latest update: Phase 6.2 added `docs/support-operations.md` as the quick operational path for support release/rollback, with server-only R2 credentials, private bucket expectations, Inngest ID-only event boundary, Resend sender/link requirements, Sentry privacy confirmations, non-destructive rollback guidance, unresolved retention decisions, and a strict future GitHub sync boundary. No production Supabase mutation, live provider call, or credential access was performed.
 
 ## TDD Cycle Evidence
 
@@ -36,6 +36,7 @@
 | 5.2 | `__tests__/lib/support/inngest.test.ts` | Unit/event contract + mocked email helpers | `pnpm test -- __tests__/lib/email/support.test.tsx --runInBand` passed with 1 suite and 5 tests before edits | `pnpm test -- __tests__/lib/support/inngest.test.ts --runInBand` failed because `@/lib/support/inngest` did not exist | `pnpm test -- __tests__/lib/support/inngest.test.ts --runInBand` passed with 1 suite and 4 tests; focused notification regression passed with 2 suites and 9 tests; `pnpm exec tsc --noEmit` passed | 4 cases cover ID-only event payloads, Inngest deduplication IDs, normalized event-recipient email idempotency keys, safe routing to Phase 5.1 helpers, and no attachment-finalized email send in the MVP | Refined the unsafe-payload assertion to avoid falsely matching valid `support/ticket.*` event names; implementation stays dependency-free because no existing Inngest convention or `inngest` package is present in this repo |
 | 5.3 | `__tests__/lib/support/inngest.test.ts`, `__tests__/lib/email/support.test.tsx` | Unit/event contract + mocked email helpers/templates | `pnpm test -- __tests__/lib/support/inngest.test.ts --runInBand` passed with 1 suite and 4 tests before edits | `pnpm test -- __tests__/lib/support/inngest.test.ts --runInBand` failed because `sendSupportNotificationEmails` did not exist | `pnpm test -- __tests__/lib/support/inngest.test.ts --runInBand` passed with 1 suite and 6 tests; focused notification regression passed with 2 suites and 11 tests; `pnpm exec tsc --noEmit` passed | 2 new cases cover one email per event/normalized recipient and noisy payload stripping for evidence, attachments, R2 keys, raw Sentry, diagnostics, GitHub details, message bodies, descriptions, and long user text | Added a minimal batch helper that deduplicates normalized recipients before delegating to the single-recipient sender; no live Inngest/Resend calls were made |
 | 6.1 | `__tests__/lib/support/sentry-privacy.test.ts` | Unit/static config contract + pure scrubber behavior | Existing Sentry config had `sendDefaultPii: true`, default client replay sampling, and no privacy scrubber coverage | `pnpm test -- __tests__/lib/support/sentry-privacy.test.ts --runInBand` failed because `@/lib/support/sentry-privacy` did not exist | `pnpm test -- __tests__/lib/support/sentry-privacy.test.ts --runInBand` passed with 1 suite and 5 tests; `pnpm exec tsc --noEmit` passed | 5 cases cover config-file defaults, client replay privacy options, consistent server/edge privacy options including transaction scrubbing, absolute support URL/body/header/context/user scrubbing, and relative URL/mixed-case header/user-PII scrubbing | Extracted shared `lib/support/sentry-privacy.ts`; typed Sentry hooks generically because browser/server/edge error and transaction hooks accept narrower event subtypes |
+| 6.2 | `docs/support-operations.md` | Documentation/static operations runbook | OpenSpec task 6.2 and existing `docs/supabase-staging-baseline.md` patterns | Docs gap existed for support provider envs, rollback, retention, and GitHub boundary | `git diff --check` passed | Checklist covers R2, Inngest, Resend, Sentry/privacy, production migration review, non-destructive rollback, retention open questions, and future sanitized GitHub sync boundary | Kept this slice documentation-only; no live provider calls, production Supabase mutation, or final 6.3 verification was performed |
 
 ## Completed Tasks
 
@@ -57,6 +58,7 @@
 - [x] 5.2 Added `lib/support/inngest.ts` support event factories and notification dispatch helpers with ID-only Inngest payloads plus event-recipient email idempotency keys.
 - [x] 5.3 Verified support notification safety with repo-local mocked tests: one email per event/normalized recipient, deterministic idempotency keys, no evidence/attachments/R2 keys/raw Sentry/diagnostics/GitHub details/message bodies/long user text in queued payloads, and no attachment-finalized email in MVP.
 - [x] 6.1 Hardened Sentry client/server/edge defaults with no default PII, no default raw replay, masked/blocked replay integration options, shared `beforeSend`/`beforeSendTransaction` scrubbing, and focused static/unit coverage for support-related URL/header/body/context/user data redaction.
+- [x] 6.2 Added `docs/support-operations.md` documenting the support operations quick path, R2/Inngest/Resend environment checklist, Sentry/support privacy checks, non-destructive rollback guidance, retention open questions, future sanitized GitHub sync boundary, and operator/reviewer verification checklist.
 
 ## Staging Baseline Setup
 
@@ -152,6 +154,8 @@
 - Phase 6.1 type verification: `pnpm exec tsc --noEmit` passed.
 - Phase 6.1 diff whitespace verification: `git diff --check` passed.
 - Phase 6.1 live provider verification gap: no live Sentry call was made, no Sentry credentials were required, and replay/error delivery was verified only by local config/static/unit contracts.
+- Phase 6.2 docs/static verification: `git diff --check` passed.
+- Phase 6.2 live provider verification gap: no live Supabase, R2, Inngest, Resend, Sentry, or GitHub service call was made; this slice intentionally avoided final 6.3 verification.
 
 ## Production Safety
 
@@ -170,10 +174,10 @@
 - Phase 5.2 performed no Supabase production/staging mutations, no SQL execution, no live Supabase calls, no live Resend calls, and no live Inngest calls. Email helpers were mocked in tests, and the new Inngest contract module has no credential requirements.
 - Phase 5.3 performed no Supabase production/staging mutations, no SQL execution, no live Supabase calls, no live Resend calls, no live Inngest calls, and no real email sends. Email helpers/templates were mocked or rendered locally in tests.
 - Phase 6.1 performed no Supabase production/staging mutations, no SQL execution, no live Supabase calls, no live Sentry calls, and no Sentry credential access. Sentry behavior was validated through local config/static/unit tests only.
+- Phase 6.2 performed no Supabase production/staging mutations, no SQL execution, no live Supabase/R2/Inngest/Resend/Sentry/GitHub calls, and no credential access. Documentation states production migration application remains an explicit reviewed operation.
 - No GitHub issue sync was implemented.
 - Staging baseline docs/scripts target project ref `ebwtdjtajclzciwipevw`; old package scripts for `wcnqocyqtksxhthnquta` were blocked or replaced with staging-safe commands.
 
 ## Remaining Tasks
 
-- [ ] 6.2 Document R2/Inngest/Resend envs, rollback, retention question, and future sanitized GitHub boundary.
 - [ ] 6.3 Run `pnpm test:rls`, unit/integration suites, build/typecheck, and manual reporter/staff flows.

--- a/openspec/changes/support-ticket-system/tasks.md
+++ b/openspec/changes/support-ticket-system/tasks.md
@@ -63,5 +63,5 @@ Chain strategy: feature-branch-chain
 ## Phase 6: Hardening and Documentation
 
 - [x] 6.1 Harden `instrumentation-client.ts`, `sentry.server.config.ts`, and `sentry.edge.config.ts` for no default PII/raw replay.
-- [ ] 6.2 Document R2/Inngest/Resend envs, rollback, retention question, and future sanitized GitHub boundary.
+- [x] 6.2 Document R2/Inngest/Resend envs, rollback, retention question, and future sanitized GitHub boundary.
 - [ ] 6.3 Run `pnpm test:rls`, unit/integration suites, build/typecheck, and manual reporter/staff flows.


### PR DESCRIPTION
## Linked Issue
Closes #142

## PR Type
- [ ] Bug fix
- [ ] New feature
- [x] Documentation only
- [ ] Code refactoring
- [ ] Maintenance/tooling
- [ ] Breaking change

## Summary
- Adds the Phase 6.2 support operations runbook.
- Documents safe boundaries for R2, Inngest, Resend, rollback, retention, and future GitHub sync.
- Updates SDD task/apply-progress tracking while leaving Phase 6.3 final verification pending.

## Changes
| File | Change |
|------|--------|
| `docs/support-operations.md` | Adds support operations guidance and safety boundaries. |
| `openspec/changes/support-ticket-system/tasks.md` | Marks Phase 6.2 runbook task complete. |
| `openspec/changes/support-ticket-system/apply-progress.md` | Records Phase 6.2 completion and notes Phase 6.3 remains pending. |

## Test Plan
- [x] Fresh re-review passed for docs scope and privacy boundaries.
- [x] Verified diff is docs/OpenSpec tracking only and under the 400-line review budget.
- [x] No live Supabase, R2, Inngest, Resend, Sentry, or GitHub provider integration calls were made by this change.
- [x] No production migration, DDL/DML, credential access, or destructive rollback performed.

## Contributor Checklist
- [x] Linked an approved issue
- [x] Added exactly one `type:*` label
- [x] Ran shellcheck on modified scripts or confirmed no shell scripts changed
- [x] Skills tested in at least one agent or not applicable for docs-only change
- [x] Docs updated if behavior changed
- [x] Conventional commit format
- [x] No `Co-Authored-By` trailers
