### PR TITLE
fix(support): stabilize admin queue render

### DIFF
--- a/__tests__/app/support-pages.test.tsx
+++ b/__tests__/app/support-pages.test.tsx
@@ -42,15 +42,15 @@ describe('reporter support pages', () => {
   it('renders the /ayuda home with report and history links', async () => {
     render(await AyudaPage())
 
-    expect(screen.getByRole('link', { name: /Report a problem/i })).toHaveAttribute('href', '/ayuda/reportar')
-    expect(screen.getByRole('link', { name: /View my tickets/i })).toHaveAttribute('href', '/ayuda/tickets')
+    expect(screen.getByRole('link', { name: /Reportar un problema/i })).toHaveAttribute('href', '/ayuda/reportar')
+    expect(screen.getByRole('link', { name: /Ver mis tickets/i })).toHaveAttribute('href', '/ayuda/tickets')
   })
 
   it('renders the report form with safe evidence fields', async () => {
     render(await ReportarPage())
 
-    expect(screen.getByLabelText(/Title/i)).toHaveAttribute('name', 'title')
-    expect(screen.getByLabelText(/Allow safe diagnostics/i)).toHaveAttribute('name', 'diagnosticsConsent')
+    expect(screen.getByLabelText(/Titulo/i)).toHaveAttribute('name', 'title')
+    expect(screen.getByLabelText(/Permitir diagnosticos seguros/i)).toHaveAttribute('name', 'diagnosticsConsent')
     expect(document.querySelector('[name="cookies"]')).not.toBeInTheDocument()
   })
 
@@ -65,15 +65,16 @@ describe('reporter support pages', () => {
 
     expect(screen.getByText('The group map does not load.')).toBeInTheDocument()
     expect(screen.getByText('Public reply')).toBeInTheDocument()
-    expect(screen.getByLabelText(/Reply/i)).toHaveAttribute('name', 'body')
+    expect(screen.getByLabelText(/Respuesta/i)).toHaveAttribute('name', 'body')
   })
 
   it('renders the staff queue with search and filter controls', async () => {
     render(await SupportAdminPage({ searchParams: Promise.resolve({ search: 'attendance', status: 'in_progress', category: 'bug' }) }))
 
     expect(listStaffSupportTickets).toHaveBeenCalledWith({ search: 'attendance', status: 'in_progress', category: 'bug', campusId: undefined, assigneeId: undefined })
-    expect(screen.getByRole('searchbox', { name: /Search tickets/i })).toHaveValue('attendance')
-    expect(screen.getByLabelText(/Status/i)).toHaveValue('in_progress')
+    expect(screen.getByRole('searchbox', { name: /Buscar tickets/i })).toHaveValue('attendance')
+    expect(screen.getByLabelText(/Estado/i)).toHaveValue('in_progress')
     expect(screen.getByRole('link', { name: /#43 Cannot submit attendance/i })).toHaveAttribute('href', '/ayuda/tickets/ticket-2')
+    expect(screen.getAllByText('En progreso')).toHaveLength(2)
   })
 })

--- a/__tests__/lib/actions/support.actions.test.ts
+++ b/__tests__/lib/actions/support.actions.test.ts
@@ -74,7 +74,7 @@ describe('support reporter actions', () => {
 
     const result = await createSupportTicket(createTicketFormData())
 
-    expect(result).toEqual({ success: false, error: 'Not authenticated' })
+    expect(result).toEqual({ success: false, error: 'No autenticado' })
     expect(insert).not.toHaveBeenCalled()
   })
 
@@ -132,7 +132,7 @@ describe('support reporter actions', () => {
       from: jest.fn().mockReturnValue({ select: jest.fn().mockReturnValue({ order: jest.fn().mockResolvedValue({ data: null, error: { message: 'relation support_tickets does not exist' } }) }) }),
     })
 
-    await expect(listSupportTickets()).resolves.toEqual({ success: false, error: 'Unable to load support tickets', tickets: [] })
+    await expect(listSupportTickets()).resolves.toEqual({ success: false, error: 'No se pudieron cargar los tickets de soporte', tickets: [] })
   })
 
   it('adds reporter public replies only', async () => {
@@ -158,7 +158,7 @@ describe('support reporter actions', () => {
 
     const result = await listStaffSupportTickets({})
 
-    expect(result).toEqual({ success: false, error: 'Not authorized', tickets: [] })
+    expect(result).toEqual({ success: false, error: 'No autorizado', tickets: [] })
     expect(supportTicketsQuery.select).not.toHaveBeenCalled()
   })
 
@@ -188,7 +188,7 @@ describe('support reporter actions', () => {
       from: createStaffFromMock({ usuarioId: 'usuario-1', hasCapability: true, supportTicketsQuery }),
     })
 
-    await expect(listStaffSupportTickets({})).resolves.toEqual({ success: false, error: 'Unable to load support queue', tickets: [] })
+    await expect(listStaffSupportTickets({})).resolves.toEqual({ success: false, error: 'No se pudo cargar la cola de soporte', tickets: [] })
   })
 
   it('denies direct staff replies without support.reply before invoking the atomic RPC', async () => {
@@ -201,7 +201,7 @@ describe('support reporter actions', () => {
 
     const result = await createStaffSupportTicketReply('ticket-1', createMessageFormData())
 
-    expect(result).toEqual({ success: false, error: 'Not authorized' })
+    expect(result).toEqual({ success: false, error: 'No autorizado' })
     expect(rpc).not.toHaveBeenCalled()
   })
 
@@ -245,7 +245,7 @@ describe('support reporter actions', () => {
 
     const result = await updateSupportTicketStatus('ticket-1', 'invalid')
 
-    expect(result).toEqual({ success: false, error: 'Invalid support ticket status' })
+    expect(result).toEqual({ success: false, error: 'Estado de ticket de soporte invalido' })
     expect(rpc).not.toHaveBeenCalled()
   })
 
@@ -273,7 +273,7 @@ describe('support reporter actions', () => {
 
     const result = await updateSupportTicketStatus('ticket-1', 'closed')
 
-    expect(result).toEqual({ success: false, error: 'Unable to update support ticket status' })
+    expect(result).toEqual({ success: false, error: 'No se pudo actualizar el estado del ticket de soporte' })
   })
 })
 

--- a/app/(auth)/ayuda/admin/page.tsx
+++ b/app/(auth)/ayuda/admin/page.tsx
@@ -1,6 +1,7 @@
 import Link from 'next/link'
 
 import { listStaffSupportTickets } from '@/lib/actions/support.actions'
+import { formatSupportCategory, formatSupportSeverity, formatSupportStatus } from '@/lib/support/support-labels'
 import { BadgeSistema, BotonSistema, ContenedorDashboard, InputSistema, SelectSistema, TarjetaSistema, TextoSistema } from '@/components/ui/sistema-diseno'
 
 type SupportAdminPageProps = {
@@ -14,12 +15,12 @@ type SupportAdminPageProps = {
 }
 
 const STATUS_OPTIONS = [
-  { valor: '', etiqueta: 'All statuses' },
-  { valor: 'received', etiqueta: 'Received' },
-  { valor: 'in_review', etiqueta: 'In review' },
-  { valor: 'in_progress', etiqueta: 'In progress' },
-  { valor: 'resolved', etiqueta: 'Resolved' },
-  { valor: 'closed', etiqueta: 'Closed' },
+  { valor: '', etiqueta: 'Todos los estados' },
+  { valor: 'received', etiqueta: 'Recibido' },
+  { valor: 'in_review', etiqueta: 'En revision' },
+  { valor: 'in_progress', etiqueta: 'En progreso' },
+  { valor: 'resolved', etiqueta: 'Resuelto' },
+  { valor: 'closed', etiqueta: 'Cerrado' },
 ]
 
 export default async function SupportAdminPage({ searchParams }: SupportAdminPageProps) {
@@ -35,20 +36,20 @@ export default async function SupportAdminPage({ searchParams }: SupportAdminPag
   const tickets = result.success ? result.tickets : []
 
   return (
-    <ContenedorDashboard titulo="Support queue" descripcion="Search and triage authorized support tickets without exposing reporter-only views.">
+    <ContenedorDashboard titulo="Cola de soporte" descripcion="Busca y prioriza tickets autorizados sin exponer vistas exclusivas del reportante.">
       <form className="grid gap-3 md:grid-cols-[minmax(0,1fr)_180px_180px_auto]" action="/ayuda/admin">
-        <InputSistema label="Search tickets" name="search" type="search" role="searchbox" defaultValue={filters.search ?? ''} placeholder="Ticket number, title, description" />
-        <SelectSistema label="Status" name="status" value={filters.status ?? ''} opciones={STATUS_OPTIONS} />
-        <InputSistema label="Category" name="category" defaultValue={filters.category ?? ''} placeholder="bug, access, billing" />
+        <InputSistema label="Buscar tickets" name="search" type="search" role="searchbox" defaultValue={filters.search ?? ''} placeholder="Numero de ticket, titulo, descripcion" />
+        <SelectSistema label="Estado" name="status" defaultValue={filters.status ?? ''} opciones={STATUS_OPTIONS} />
+        <InputSistema label="Categoria" name="category" defaultValue={filters.category ?? ''} placeholder="bug, access, billing" />
         <div className="flex items-end">
-          <BotonSistema type="submit" className="w-full">Filter</BotonSistema>
+          <BotonSistema type="submit" className="w-full">Filtrar</BotonSistema>
         </div>
       </form>
 
       {!result.success ? (
         <TarjetaSistema><TextoSistema variante="sutil">{result.error}</TextoSistema></TarjetaSistema>
       ) : tickets.length === 0 ? (
-        <TarjetaSistema><TextoSistema variante="sutil">No support tickets match these filters.</TextoSistema></TarjetaSistema>
+        <TarjetaSistema><TextoSistema variante="sutil">Ningun ticket de soporte coincide con estos filtros.</TextoSistema></TarjetaSistema>
       ) : (
         <div className="space-y-3">
           {tickets.map((ticket) => (
@@ -56,9 +57,9 @@ export default async function SupportAdminPage({ searchParams }: SupportAdminPag
               <TarjetaSistema className="flex items-center justify-between gap-4">
                 <div>
                   <p className="font-semibold text-foreground">#{ticket.ticketNumber} {ticket.title}</p>
-                  <TextoSistema variante="sutil" tamaño="sm">{ticket.category} · {ticket.severity}</TextoSistema>
+                  <TextoSistema variante="sutil" tamaño="sm">{formatSupportCategory(ticket.category)} · {formatSupportSeverity(ticket.severity)}</TextoSistema>
                 </div>
-                <BadgeSistema variante="info">{ticket.status.replaceAll('_', ' ')}</BadgeSistema>
+                <BadgeSistema variante="info">{formatSupportStatus(ticket.status)}</BadgeSistema>
               </TarjetaSistema>
             </Link>
           ))}

--- a/app/(auth)/ayuda/page.tsx
+++ b/app/(auth)/ayuda/page.tsx
@@ -5,27 +5,27 @@ import { BotonSistema, ContenedorDashboard, TarjetaSistema, TextoSistema, Titulo
 
 export default async function AyudaPage() {
   return (
-    <ContenedorDashboard titulo="Help" descripcion="Report problems and follow support updates from one place.">
+    <ContenedorDashboard titulo="Ayuda" descripcion="Reporta problemas y da seguimiento a tus solicitudes desde un solo lugar.">
       <div className="grid gap-4 md:grid-cols-2">
         <TarjetaSistema className="space-y-4">
           <FileText className="h-8 w-8 text-[var(--brand-primary)]" />
           <div className="space-y-2">
-            <TituloSistema nivel={2}>Report a problem</TituloSistema>
-            <TextoSistema variante="sutil">Send the support team safe steps and diagnostics without exposing private browser data.</TextoSistema>
+            <TituloSistema nivel={2}>Reportar un problema</TituloSistema>
+            <TextoSistema variante="sutil">Envia al equipo de soporte los pasos y diagnosticos seguros sin exponer datos privados del navegador.</TextoSistema>
           </div>
           <Link href="/ayuda/reportar">
-            <BotonSistema>Report a problem</BotonSistema>
+            <BotonSistema>Reportar un problema</BotonSistema>
           </Link>
         </TarjetaSistema>
 
         <TarjetaSistema className="space-y-4">
           <History className="h-8 w-8 text-[var(--brand-primary)]" />
           <div className="space-y-2">
-            <TituloSistema nivel={2}>Ticket history</TituloSistema>
-            <TextoSistema variante="sutil">Review the status of your reports and reply when support needs more information.</TextoSistema>
+            <TituloSistema nivel={2}>Historial de tickets</TituloSistema>
+            <TextoSistema variante="sutil">Revisa el estado de tus reportes y responde cuando soporte necesite mas informacion.</TextoSistema>
           </div>
           <Link href="/ayuda/tickets">
-            <BotonSistema variante="outline">View my tickets</BotonSistema>
+            <BotonSistema variante="outline">Ver mis tickets</BotonSistema>
           </Link>
         </TarjetaSistema>
       </div>

--- a/app/(auth)/ayuda/reportar/page.tsx
+++ b/app/(auth)/ayuda/reportar/page.tsx
@@ -8,39 +8,39 @@ export default async function ReportarPage() {
   }
 
   return (
-    <ContenedorDashboard titulo="Report a problem" botonRegreso={{ href: '/ayuda', texto: 'Back to Help' }}>
+    <ContenedorDashboard titulo="Reportar un problema" botonRegreso={{ href: '/ayuda', texto: 'Volver a Ayuda' }}>
       <TarjetaSistema>
         <form action={submitTicket} className="space-y-5">
-          <InputSistema name="title" label="Title" minLength={5} maxLength={160} required placeholder="Example: Cannot open group map" />
-          <TextareaSistema name="description" label="Steps and expected result" filas={6} minLength={10} maxLength={8000} required placeholder="Tell us what happened, what you expected, and how to reproduce it." />
+          <InputSistema name="title" label="Titulo" minLength={5} maxLength={160} required placeholder="Ejemplo: No puedo abrir el mapa del grupo" />
+          <TextareaSistema name="description" label="Pasos y resultado esperado" filas={6} minLength={10} maxLength={8000} required placeholder="Cuentanos que ocurrio, que esperabas y como reproducirlo." />
           <div className="grid gap-4 md:grid-cols-2">
             <label className="space-y-2 text-sm font-medium text-foreground">
-              <span>Category</span>
+              <span>Categoria</span>
               <select name="category" defaultValue="bug" className="block w-full min-h-[44px] rounded-xl border border-border bg-card/50 px-3 py-3 text-foreground focus:outline-none focus:ring-2 focus:ring-[var(--brand-primary)]/20">
-                <option value="bug">Bug</option><option value="access">Access</option><option value="data">Data</option><option value="other">Other</option>
+                <option value="bug">Error</option><option value="access">Acceso</option><option value="data">Datos</option><option value="other">Otro</option>
               </select>
             </label>
             <label className="space-y-2 text-sm font-medium text-foreground">
-              <span>Severity</span>
+              <span>Severidad</span>
               <select name="severity" defaultValue="normal" className="block w-full min-h-[44px] rounded-xl border border-border bg-card/50 px-3 py-3 text-foreground focus:outline-none focus:ring-2 focus:ring-[var(--brand-primary)]/20">
-                <option value="low">Low</option><option value="normal">Normal</option><option value="high">High</option><option value="urgent">Urgent</option>
+                <option value="low">Baja</option><option value="normal">Normal</option><option value="high">Alta</option><option value="urgent">Urgente</option>
               </select>
             </label>
           </div>
           <div className="grid gap-4 md:grid-cols-2">
-            <InputSistema name="currentRoute" label="Route" placeholder="/dashboard" />
+            <InputSistema name="currentRoute" label="Ruta" placeholder="/dashboard" />
             <InputSistema name="viewport" label="Viewport" placeholder="390x844" />
-            <InputSistema name="browserName" label="Browser" placeholder="Chrome, Safari, Edge" />
-            <InputSistema name="osName" label="Operating system" placeholder="macOS, iOS, Android" />
+            <InputSistema name="browserName" label="Navegador" placeholder="Chrome, Safari, Edge" />
+            <InputSistema name="osName" label="Sistema operativo" placeholder="macOS, iOS, Android" />
           </div>
-          <InputSistema name="sentryEventId" label="Sentry event ID" placeholder="Optional reference" />
+          <InputSistema name="sentryEventId" label="ID de evento de Sentry" placeholder="Referencia opcional" />
           <input type="hidden" name="appBuildVersion" value={process.env.NEXT_PUBLIC_APP_VERSION ?? ''} />
           <label className="flex items-start gap-3 text-sm text-foreground">
             <input type="checkbox" name="diagnosticsConsent" value="true" className="mt-1 h-4 w-4 rounded border-border" />
-            <span><strong>Allow safe diagnostics</strong><br /><span className="text-muted-foreground">Only route, browser, OS, viewport, app version, and Sentry reference are stored. Cookies, passwords, localStorage, and raw payloads are never collected.</span></span>
+            <span><strong>Permitir diagnosticos seguros</strong><br /><span className="text-muted-foreground">Solo se guardan ruta, navegador, sistema operativo, viewport, version de la app y referencia de Sentry. Nunca recopilamos cookies, contrasenas, localStorage ni payloads sin procesar.</span></span>
           </label>
-          <TextoSistema variante="muted" tamaño="sm">Attachments are uploaded after ticket creation from the private attachment flow.</TextoSistema>
-          <BotonSistema type="submit">Submit ticket</BotonSistema>
+          <TextoSistema variante="muted" tamaño="sm">Los adjuntos se suben despues de crear el ticket desde el flujo privado de adjuntos.</TextoSistema>
+          <BotonSistema type="submit">Enviar ticket</BotonSistema>
         </form>
       </TarjetaSistema>
     </ContenedorDashboard>

--- a/app/(auth)/ayuda/tickets/[id]/page.tsx
+++ b/app/(auth)/ayuda/tickets/[id]/page.tsx
@@ -1,6 +1,7 @@
 import { notFound } from 'next/navigation'
 
 import { createSupportTicketMessage, getSupportTicketDetail } from '@/lib/actions/support.actions'
+import { formatSupportStatus } from '@/lib/support/support-labels'
 import { BadgeSistema, BotonSistema, ContenedorDashboard, TarjetaSistema, TextareaSistema, TextoSistema, TituloSistema } from '@/components/ui/sistema-diseno'
 
 export default async function TicketDetailPage({ params }: { params: Promise<{ id: string }> }) {
@@ -15,30 +16,30 @@ export default async function TicketDetailPage({ params }: { params: Promise<{ i
   }
 
   return (
-    <ContenedorDashboard titulo={`Ticket #${ticket.ticketNumber}`} botonRegreso={{ href: '/ayuda/tickets', texto: 'Back to tickets' }}>
+    <ContenedorDashboard titulo={`Ticket #${ticket.ticketNumber}`} botonRegreso={{ href: '/ayuda/tickets', texto: 'Volver a tickets' }}>
       <TarjetaSistema className="space-y-4">
         <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
           <div className="space-y-2">
             <TituloSistema nivel={2}>{ticket.title}</TituloSistema>
             <TextoSistema>{ticket.description}</TextoSistema>
           </div>
-          <BadgeSistema variante="info">{ticket.status.replaceAll('_', ' ')}</BadgeSistema>
+          <BadgeSistema variante="info">{formatSupportStatus(ticket.status)}</BadgeSistema>
         </div>
         {ticket.evidence.diagnosticsConsent && (
-          <TextoSistema variante="muted" tamaño="sm">Safe diagnostics: {ticket.evidence.currentRoute ?? 'route unavailable'} · {ticket.evidence.browserName ?? 'browser unavailable'} · {ticket.evidence.osName ?? 'OS unavailable'} · {ticket.evidence.viewport ?? 'viewport unavailable'}</TextoSistema>
+          <TextoSistema variante="muted" tamaño="sm">Diagnosticos seguros: {ticket.evidence.currentRoute ?? 'ruta no disponible'} · {ticket.evidence.browserName ?? 'navegador no disponible'} · {ticket.evidence.osName ?? 'sistema operativo no disponible'} · {ticket.evidence.viewport ?? 'viewport no disponible'}</TextoSistema>
         )}
       </TarjetaSistema>
 
       <TarjetaSistema className="space-y-4">
-        <TituloSistema nivel={2}>Conversation</TituloSistema>
-        {ticket.messages.length === 0 ? <TextoSistema variante="sutil">No replies yet.</TextoSistema> : ticket.messages.map((message) => (
+        <TituloSistema nivel={2}>Conversacion</TituloSistema>
+        {ticket.messages.length === 0 ? <TextoSistema variante="sutil">Aun no hay respuestas.</TextoSistema> : ticket.messages.map((message) => (
           <div key={message.id} className="rounded-xl border border-border bg-card/50 p-3">
             <TextoSistema>{message.body}</TextoSistema>
           </div>
         ))}
         <form action={replyAction} className="space-y-3">
-          <TextareaSistema name="body" label="Reply" filas={4} required />
-          <BotonSistema type="submit">Send reply</BotonSistema>
+          <TextareaSistema name="body" label="Respuesta" filas={4} required />
+          <BotonSistema type="submit">Enviar respuesta</BotonSistema>
         </form>
       </TarjetaSistema>
     </ContenedorDashboard>

--- a/app/(auth)/ayuda/tickets/page.tsx
+++ b/app/(auth)/ayuda/tickets/page.tsx
@@ -1,6 +1,7 @@
 import Link from 'next/link'
 
 import { listSupportTickets } from '@/lib/actions/support.actions'
+import { formatSupportCategory, formatSupportSeverity, formatSupportStatus } from '@/lib/support/support-labels'
 import { BadgeSistema, BotonSistema, ContenedorDashboard, TarjetaSistema, TextoSistema } from '@/components/ui/sistema-diseno'
 
 export default async function TicketsPage() {
@@ -8,18 +9,18 @@ export default async function TicketsPage() {
   const tickets = result.success ? result.tickets : []
 
   return (
-    <ContenedorDashboard titulo="My support tickets" accionPrincipal={<Link href="/ayuda/reportar"><BotonSistema tamaño="sm">New ticket</BotonSistema></Link>}>
+    <ContenedorDashboard titulo="Mis tickets de soporte" accionPrincipal={<Link href="/ayuda/reportar"><BotonSistema tamaño="sm">Nuevo ticket</BotonSistema></Link>}>
       <div className="space-y-3">
         {tickets.length === 0 ? (
-          <TarjetaSistema><TextoSistema variante="sutil">You have not submitted support tickets yet.</TextoSistema></TarjetaSistema>
+          <TarjetaSistema><TextoSistema variante="sutil">Todavia no has enviado tickets de soporte.</TextoSistema></TarjetaSistema>
         ) : tickets.map((ticket) => (
           <Link key={ticket.id} href={`/ayuda/tickets/${ticket.id}`} className="block focus-ring rounded-2xl">
             <TarjetaSistema className="flex items-center justify-between gap-4">
               <div>
                 <p className="font-semibold text-foreground">#{ticket.ticketNumber} {ticket.title}</p>
-                <TextoSistema variante="sutil" tamaño="sm">{ticket.category} · {ticket.severity}</TextoSistema>
+                <TextoSistema variante="sutil" tamaño="sm">{formatSupportCategory(ticket.category)} · {formatSupportSeverity(ticket.severity)}</TextoSistema>
               </div>
-              <BadgeSistema variante="info">{ticket.status.replaceAll('_', ' ')}</BadgeSistema>
+              <BadgeSistema variante="info">{formatSupportStatus(ticket.status)}</BadgeSistema>
             </TarjetaSistema>
           </Link>
         ))}

--- a/components/ui/sistema-diseno.tsx
+++ b/components/ui/sistema-diseno.tsx
@@ -1,7 +1,6 @@
 import React, { useId } from 'react'
 import { cn } from '@/lib/utils'
-import { LucideIcon, ArrowLeft, ChevronDown } from 'lucide-react'
-import Link from 'next/link'
+import { LucideIcon, ChevronDown } from 'lucide-react'
 
 // Lazy load DesktopHeader (client component) to keep this file server-compatible
 const DesktopHeader = React.lazy(() => import('./desktop-header').then(m => ({ default: m.DesktopHeader })))
@@ -116,10 +115,12 @@ interface SelectSistemaProps extends Omit<React.SelectHTMLAttributes<HTMLSelectE
 }
 
 export const SelectSistema = React.forwardRef<HTMLSelectElement, SelectSistemaProps>(
-  ({ className, label, error, opciones, placeholder, value, onValueChange, onChange, id: idProp, ...props }, ref) => {
+  ({ className, label, error, opciones, placeholder, value, defaultValue, onValueChange, onChange, id: idProp, ...props }, ref) => {
     const idGenerado = useId()
     const id = idProp ?? idGenerado
     const idError = `${id}-error`
+    const tieneManejadorCambio = Boolean(onChange || onValueChange)
+    const valorVisual = value ?? defaultValue ?? ''
 
     const handleChange: React.ChangeEventHandler<HTMLSelectElement> = (e) => {
       onChange?.(e)
@@ -137,8 +138,9 @@ export const SelectSistema = React.forwardRef<HTMLSelectElement, SelectSistemaPr
           <select
             id={id}
             ref={ref}
-            value={value ?? ''}
-            onChange={handleChange}
+            value={tieneManejadorCambio && value !== undefined ? value : undefined}
+            defaultValue={!tieneManejadorCambio || value === undefined ? valorVisual : undefined}
+            onChange={tieneManejadorCambio ? handleChange : undefined}
             aria-invalid={error ? true : undefined}
             aria-describedby={error ? idError : undefined}
             className={cn(
@@ -148,7 +150,7 @@ export const SelectSistema = React.forwardRef<HTMLSelectElement, SelectSistemaPr
               "disabled:bg-muted disabled:text-muted-foreground disabled:cursor-not-allowed",
               "appearance-none cursor-pointer",
               error && "border-red-300 dark:border-red-500/50 focus:border-red-500 focus:ring-red-500/20",
-              !value && "text-muted-foreground",
+              !valorVisual && "text-muted-foreground",
               className
             )}
             {...props}

--- a/lib/actions/support.actions.ts
+++ b/lib/actions/support.actions.ts
@@ -34,14 +34,14 @@ const staffQueueFilterSchema = z.object({
   assigneeId: z.string().trim().max(120).optional(),
 })
 
-const SUPPORT_TICKET_CREATE_ERROR = 'Unable to create support ticket'
-const SUPPORT_TICKET_LIST_ERROR = 'Unable to load support tickets'
-const SUPPORT_TICKET_DETAIL_ERROR = 'Unable to load support ticket'
-const SUPPORT_TICKET_MESSAGE_ERROR = 'Unable to send support reply'
-const SUPPORT_STAFF_QUEUE_ERROR = 'Unable to load support queue'
-const SUPPORT_STAFF_REPLY_ERROR = 'Unable to send staff support reply'
-const SUPPORT_STAFF_ASSIGNMENT_ERROR = 'Unable to assign support ticket'
-const SUPPORT_STAFF_STATUS_ERROR = 'Unable to update support ticket status'
+const SUPPORT_TICKET_CREATE_ERROR = 'No se pudo crear el ticket de soporte'
+const SUPPORT_TICKET_LIST_ERROR = 'No se pudieron cargar los tickets de soporte'
+const SUPPORT_TICKET_DETAIL_ERROR = 'No se pudo cargar el ticket de soporte'
+const SUPPORT_TICKET_MESSAGE_ERROR = 'No se pudo enviar la respuesta de soporte'
+const SUPPORT_STAFF_QUEUE_ERROR = 'No se pudo cargar la cola de soporte'
+const SUPPORT_STAFF_REPLY_ERROR = 'No se pudo enviar la respuesta de soporte del equipo'
+const SUPPORT_STAFF_ASSIGNMENT_ERROR = 'No se pudo asignar el ticket de soporte'
+const SUPPORT_STAFF_STATUS_ERROR = 'No se pudo actualizar el estado del ticket de soporte'
 type SupportCapability = 'support.view' | 'support.reply' | 'support.manage'
 
 type SupportTicketRow = {
@@ -72,7 +72,7 @@ type StaffSupportTicketRow = Pick<SupportTicketRow, 'id' | 'ticket_number' | 'ti
 
 export async function createSupportTicket(formData: FormData) {
   const parsed = supportTicketSchema.safeParse(Object.fromEntries(formData))
-  if (!parsed.success) return { success: false, error: parsed.error.errors[0]?.message ?? 'Invalid support ticket' }
+  if (!parsed.success) return { success: false, error: parsed.error.errors[0]?.message ?? 'Ticket de soporte invalido' }
 
   const supabase = await createSupabaseServerClient()
   const actor = await getActorUsuarioId(supabase)
@@ -96,7 +96,7 @@ export async function createSupportTicket(formData: FormData) {
 export async function listSupportTickets() {
   const supabase = await createSupabaseServerClient()
   const { data: { user } } = await supabase.auth.getUser()
-  if (!user) return { success: false, error: 'Not authenticated', tickets: [] }
+  if (!user) return { success: false, error: 'No autenticado', tickets: [] }
 
   const { data, error } = await supabase
     .from('support_tickets')
@@ -109,7 +109,7 @@ export async function listSupportTickets() {
 
 export async function listStaffSupportTickets(filters: unknown) {
   const parsed = staffQueueFilterSchema.safeParse(filters)
-  if (!parsed.success) return { success: false, error: 'Invalid support queue filters', tickets: [] }
+  if (!parsed.success) return { success: false, error: 'Filtros de cola de soporte invalidos', tickets: [] }
 
   const supabase = await createSupabaseServerClient()
   const actor = await getActorUsuarioId(supabase)
@@ -137,7 +137,7 @@ export async function listStaffSupportTickets(filters: unknown) {
 
 export async function createStaffSupportTicketReply(ticketId: string, formData: FormData) {
   const parsed = messageSchema.safeParse(Object.fromEntries(formData))
-  if (!parsed.success) return { success: false, error: parsed.error.errors[0]?.message ?? 'Invalid reply' }
+  if (!parsed.success) return { success: false, error: parsed.error.errors[0]?.message ?? 'Respuesta invalida' }
 
   const supabase = await createSupabaseServerClient()
   const actor = await getActorUsuarioId(supabase)
@@ -155,7 +155,7 @@ export async function createStaffSupportTicketReply(ticketId: string, formData: 
 
 export async function assignSupportTicket(ticketId: string, assigneeUsuarioId: string | null) {
   const parsed = assigneeUsuarioIdSchema.safeParse(assigneeUsuarioId)
-  if (!parsed.success) return { success: false, error: 'Invalid support ticket assignee' }
+  if (!parsed.success) return { success: false, error: 'Responsable de ticket de soporte invalido' }
 
   const supabase = await createSupabaseServerClient()
   const actor = await getActorUsuarioId(supabase)
@@ -173,7 +173,7 @@ export async function assignSupportTicket(ticketId: string, assigneeUsuarioId: s
 
 export async function updateSupportTicketStatus(ticketId: string, status: string) {
   const parsed = supportTicketStatusSchema.safeParse(status)
-  if (!parsed.success) return { success: false, error: 'Invalid support ticket status' }
+  if (!parsed.success) return { success: false, error: 'Estado de ticket de soporte invalido' }
 
   const supabase = await createSupabaseServerClient()
   const actor = await getActorUsuarioId(supabase)
@@ -192,7 +192,7 @@ export async function updateSupportTicketStatus(ticketId: string, status: string
 export async function getSupportTicketDetail(ticketId: string) {
   const supabase = await createSupabaseServerClient()
   const { data: { user } } = await supabase.auth.getUser()
-  if (!user) return { success: false, error: 'Not authenticated' }
+  if (!user) return { success: false, error: 'No autenticado' }
 
   const { data: ticket, error } = await supabase
     .from('support_tickets')
@@ -201,7 +201,7 @@ export async function getSupportTicketDetail(ticketId: string) {
     .maybeSingle()
 
   if (error) return { success: false, error: SUPPORT_TICKET_DETAIL_ERROR }
-  if (!ticket) return { success: false, error: 'Ticket not found' }
+  if (!ticket) return { success: false, error: 'Ticket no encontrado' }
 
   const { data: messages, error: messagesError } = await supabase
     .from('support_ticket_messages')
@@ -216,7 +216,7 @@ export async function getSupportTicketDetail(ticketId: string) {
 
 export async function createSupportTicketMessage(ticketId: string, formData: FormData) {
   const parsed = messageSchema.safeParse(Object.fromEntries(formData))
-  if (!parsed.success) return { success: false, error: parsed.error.errors[0]?.message ?? 'Invalid reply' }
+  if (!parsed.success) return { success: false, error: parsed.error.errors[0]?.message ?? 'Respuesta invalida' }
 
   const supabase = await createSupabaseServerClient()
   const actor = await getActorUsuarioId(supabase)
@@ -236,9 +236,9 @@ export async function createSupportTicketMessage(ticketId: string, formData: For
 
 async function getActorUsuarioId(supabase: Awaited<ReturnType<typeof createSupabaseServerClient>>) {
   const { data: { user } } = await supabase.auth.getUser()
-  if (!user) return { success: false as const, error: 'Not authenticated' }
+  if (!user) return { success: false as const, error: 'No autenticado' }
   const { data, error } = await supabase.from('usuarios').select('id').eq('auth_id', user.id).maybeSingle()
-  if (error || !data?.id) return { success: false as const, error: 'User profile not found' }
+  if (error || !data?.id) return { success: false as const, error: 'Perfil de usuario no encontrado' }
   return { success: true as const, usuarioId: data.id }
 }
 
@@ -251,7 +251,7 @@ async function requireSupportCapability(supabase: Awaited<ReturnType<typeof crea
     .is('revoked_at', null)
     .maybeSingle()
 
-  if (error || !data) return { success: false as const, error: 'Not authorized' }
+  if (error || !data) return { success: false as const, error: 'No autorizado' }
   return { success: true as const }
 }
 

--- a/lib/support/support-labels.ts
+++ b/lib/support/support-labels.ts
@@ -1,0 +1,34 @@
+export const SUPPORT_STATUS_LABELS: Record<string, string> = {
+  received: 'Recibido',
+  in_review: 'En revision',
+  in_progress: 'En progreso',
+  resolved: 'Resuelto',
+  closed: 'Cerrado',
+}
+
+export const SUPPORT_CATEGORY_LABELS: Record<string, string> = {
+  bug: 'Error',
+  access: 'Acceso',
+  data: 'Datos',
+  billing: 'Facturacion',
+  other: 'Otro',
+}
+
+export const SUPPORT_SEVERITY_LABELS: Record<string, string> = {
+  low: 'Baja',
+  normal: 'Normal',
+  high: 'Alta',
+  urgent: 'Urgente',
+}
+
+export function formatSupportStatus(status: string) {
+  return SUPPORT_STATUS_LABELS[status] ?? status.replaceAll('_', ' ')
+}
+
+export function formatSupportCategory(category: string) {
+  return SUPPORT_CATEGORY_LABELS[category] ?? category
+}
+
+export function formatSupportSeverity(severity: string) {
+  return SUPPORT_SEVERITY_LABELS[severity] ?? severity
+}


### PR DESCRIPTION
## Linked Issue
Closes #144

## PR Type
- [x] Bug fix
- [ ] New feature
- [ ] Documentation only
- [ ] Code refactoring
- [ ] Maintenance/tooling
- [ ] Breaking change

## Summary
- Fixes the support admin queue Server Component render failure by making `SelectSistema` server-safe when used without interactive handlers.
- Switches the admin status filter to uncontrolled `defaultValue` form usage.
- Translates the support UI/action safe copy to Spanish and adds shared support label helpers.

## Changes
| File | Change |
|------|--------|
| `components/ui/sistema-diseno.tsx` | Avoids passing select event handlers unless interactive callbacks are provided. |
| `app/(auth)/ayuda/**` | Translates support UI copy and uses Spanish status/category/severity labels. |
| `lib/actions/support.actions.ts` | Maps safe support action errors to stable Spanish messages. |
| `lib/support/support-labels.ts` | Adds shared Spanish support labels. |
| `__tests__/app/support-pages.test.tsx` | Updates page expectations for Spanish UI and admin render behavior. |
| `__tests__/lib/actions/support.actions.test.ts` | Updates safe error expectations. |

## Test Plan
- [x] `pnpm test -- __tests__/app/support-pages.test.tsx`
- [x] `pnpm test -- __tests__/lib/actions/support.actions.test.ts`
- [x] `pnpm test:ci`
- [x] `NEXT_PUBLIC_SUPABASE_URL=http://127.0.0.1:54321 NEXT_PUBLIC_SUPABASE_ANON_KEY=placeholder SUPABASE_SERVICE_ROLE_KEY=placeholder pnpm build`
- [x] `pnpm lint`
- [x] `git diff --check`
- [x] Fresh review passed.
- [x] Preview validation confirmed `/ayuda/admin` loads, staff reply works, and reporter sees the public reply without raw errors or privacy leakage.

## Contributor Checklist
- [x] Linked an approved issue
- [x] Added exactly one `type:*` label
- [x] Ran shellcheck on modified scripts or confirmed no shell scripts changed
- [x] Skills tested in at least one agent or not applicable for app bugfix
- [x] Docs updated if behavior changed or not required
- [x] Conventional commit format
- [x] No `Co-Authored-By` trailers
