### PR TITLE
feat(support): harden support ticket production readiness

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,6 +28,7 @@ yarn-debug.log*
 yarn-error.log*
 
 # local env files
+.env
 .env*.local
 
 # vercel

--- a/.vercelignore
+++ b/.vercelignore
@@ -1,0 +1,4 @@
+.env
+.env.*
+.env*.local
+.env.sentry-build-plugin

--- a/__tests__/app/support-attachments-route.test.ts
+++ b/__tests__/app/support-attachments-route.test.ts
@@ -2,6 +2,7 @@ import {
   createAttachmentDownloadResponse,
   createAttachmentIntentResponse,
   finalizeAttachmentResponse,
+  supportAttachmentIntentRoute,
   supportAttachmentFinalizeRoute,
   supportAttachmentDownloadHeadRoute,
   supportAttachmentDownloadRoute,
@@ -12,17 +13,31 @@ const createSupabaseAdminClient = jest.fn()
 
 jest.mock('@/lib/supabase/server', () => ({ createSupabaseServerClient: () => createSupabaseServerClient() }))
 jest.mock('@/lib/supabase/admin', () => ({ createSupabaseAdminClient: () => createSupabaseAdminClient() }))
-jest.mock('next/server', () => ({ NextResponse: { json: (body: unknown, init?: ResponseInit) => ({ status: init?.status ?? 200, json: async () => body }) } }))
+jest.mock('next/server', () => ({
+  NextResponse: {
+    json: (body: unknown, init?: ResponseInit) => ({ status: init?.status ?? 200, json: async () => body, headers: new Map() }),
+    redirect: (url: string | URL, init?: number | ResponseInit) => ({
+      status: typeof init === 'number' ? init : init?.status ?? 307,
+      headers: new Map([['location', url.toString()]]),
+      json: async () => { throw new Error('Redirect responses must not expose JSON') },
+    }),
+  },
+}))
 
 class TestResponse {
   readonly status: number
+  readonly headers: Headers
 
-  constructor(private readonly body: string | null, init?: ResponseInit) {
+  constructor(private readonly body: BodyInit | null, init?: ResponseInit) {
     this.status = init?.status ?? 200
+    this.headers = new Headers(init?.headers)
   }
 
   async text() {
-    return this.body ?? ''
+    if (typeof this.body === 'string') return this.body
+    if (this.body instanceof ArrayBuffer) return Buffer.from(this.body).toString('utf8')
+    if (ArrayBuffer.isView(this.body)) return Buffer.from(this.body.buffer).toString('utf8')
+    return ''
   }
 }
 
@@ -65,6 +80,7 @@ describe('support attachment route handlers', () => {
     const attachments = result.body.attachments as Record<string, unknown>[]
     expect(attachments).toHaveLength(1)
     expect(attachments[0]).toMatchObject({ bucket: 'global-connect-support', method: 'PUT' })
+    expect(attachments[0]).not.toHaveProperty('objectKey')
     expect(insertAttachment).toHaveBeenCalledWith(expect.objectContaining({ status: 'pending_upload', object_key: expect.stringContaining('support/ticket-1/') }))
   })
 
@@ -77,6 +93,76 @@ describe('support attachment route handlers', () => {
     })
 
     expect(result).toEqual({ status: 400, body: { error: 'Videos must be 100MB or smaller' } })
+  })
+
+  it('rejects a stale pending video before creating a replacement retry intent', async () => {
+    const insertAttachment = jest.fn().mockResolvedValue(undefined)
+    const markRejected = jest.fn().mockResolvedValue(true)
+
+    const result = await createAttachmentIntentResponse({
+      ...baseContext,
+      body: { ticketId: 'ticket-1', replaceAttachmentId: 'attachment-1', files: [{ filename: 'retry.mp4', contentType: 'video/mp4', byteSize: 2048 }] },
+      existingAttachments: [{ id: 'attachment-1', kind: 'video', byte_size: 2048, status: 'pending_upload' }],
+      insertAttachment,
+      markRejected,
+    })
+
+    expect(result.status).toBe(200)
+    expect(result.body.attachments).toEqual([expect.objectContaining({ bucket: 'global-connect-support', method: 'PUT' })])
+    expect(markRejected).toHaveBeenCalledWith('attachment-1', 'replaced_by_retry')
+    expect(insertAttachment).toHaveBeenCalledWith(expect.objectContaining({ kind: 'video', status: 'pending_upload', original_filename: 'retry.mp4' }))
+  })
+
+  it('does not create a replacement retry intent when the prior pending row is no longer eligible', async () => {
+    const insertAttachment = jest.fn().mockResolvedValue(undefined)
+    const markRejected = jest.fn().mockResolvedValue(false)
+
+    const result = await createAttachmentIntentResponse({
+      ...baseContext,
+      body: { ticketId: 'ticket-1', replaceAttachmentId: 'attachment-1', files: [{ filename: 'retry.mp4', contentType: 'video/mp4', byteSize: 2048 }] },
+      existingAttachments: [{ id: 'attachment-1', kind: 'video', byte_size: 2048, status: 'pending_upload' }],
+      insertAttachment,
+      markRejected,
+    })
+
+    expect(result).toEqual({ status: 400, body: { error: 'Attachment retry is no longer available' } })
+    expect(markRejected).toHaveBeenCalledWith('attachment-1', 'replaced_by_retry')
+    expect(insertAttachment).not.toHaveBeenCalled()
+  })
+
+  it('does not insert replacement metadata when the admin retry rejection update returns no row', async () => {
+    const actorQuery = createMaybeSingleQuery({ id: 'usuario-1' })
+    const existingQuery = createSelectEqQuery([{ id: 'attachment-1', kind: 'video', byte_size: 2048, status: 'pending_upload' }])
+    const insertQuery = { insert: jest.fn().mockResolvedValue({ error: null }) }
+    const serverFrom = jest.fn((table: string) => table === 'support_ticket_attachments' ? existingQuery : insertQuery)
+    const rejectionBuilder = createUpdateSelectMaybeSingleQuery(null)
+
+    createSupabaseServerClient
+      .mockResolvedValueOnce({ auth: { getUser: jest.fn().mockResolvedValue({ data: { user: { id: 'auth-1' } } }) } })
+      .mockResolvedValueOnce({ from: serverFrom })
+    createSupabaseAdminClient
+      .mockReturnValueOnce({ from: jest.fn().mockReturnValue(actorQuery) })
+      .mockReturnValueOnce({ from: jest.fn().mockReturnValue({ update: jest.fn().mockReturnValue(rejectionBuilder) }) })
+
+    const response = await supportAttachmentIntentRoute({ json: async () => ({ ticketId: 'ticket-1', replaceAttachmentId: 'attachment-1', files: [{ filename: 'retry.mp4', contentType: 'video/mp4', byteSize: 2048 }] }) } as Request)
+
+    expect(response.status).toBe(400)
+    await expect(response.json()).resolves.toEqual({ error: 'Attachment retry is no longer available' })
+    expect(rejectionBuilder.select).toHaveBeenCalledWith('id')
+    expect(rejectionBuilder.maybeSingle).toHaveBeenCalled()
+    expect(insertQuery.insert).not.toHaveBeenCalled()
+  })
+
+  it('keeps a stale pending video active when retry does not identify the prior intent', async () => {
+    const result = await createAttachmentIntentResponse({
+      ...baseContext,
+      body: { ticketId: 'ticket-1', files: [{ filename: 'retry.mp4', contentType: 'video/mp4', byteSize: 2048 }] },
+      existingAttachments: [{ id: 'attachment-1', kind: 'video', byte_size: 2048, status: 'pending_upload' }],
+      insertAttachment: jest.fn(),
+      markRejected: jest.fn(),
+    })
+
+    expect(result).toEqual({ status: 400, body: { error: 'A ticket can include up to 1 video' } })
   })
 
   it('rejects finalize when R2 HEAD metadata or sniffed MIME does not match', async () => {
@@ -121,6 +207,24 @@ describe('support attachment route handlers', () => {
     })
 
     expect(result).toEqual({ status: 403, body: { error: 'Attachment not available' } })
+  })
+
+  it('streams authorized downloads without returning a signed URL JSON body', async () => {
+    const actorQuery = createMaybeSingleQuery({ id: 'usuario-1' })
+    const attachmentQuery = createMaybeSingleQuery({ ...pendingAttachment, status: 'uploaded' })
+    createSupabaseServerClient
+      .mockResolvedValueOnce({ auth: { getUser: jest.fn().mockResolvedValue({ data: { user: { id: 'auth-1' } } }) } })
+      .mockResolvedValueOnce({ from: jest.fn().mockReturnValue(attachmentQuery) })
+    createSupabaseAdminClient.mockReturnValueOnce({ from: jest.fn().mockReturnValue(actorQuery) })
+    Object.defineProperty(globalThis, 'fetch', { value: jest.fn().mockResolvedValue(createR2Response({ ok: true, headers: { 'content-type': 'image/png', 'content-length': '4' }, body: new Uint8Array([102, 105, 108, 101]) })), writable: true })
+
+    const response = await supportAttachmentDownloadRoute({} as Request, 'attachment-1')
+
+    expect(response.status).toBe(200)
+    expect(response.headers.get('content-type')).toBe('image/png')
+    expect(response.headers.get('content-disposition')).toBe('attachment')
+    expect(response.headers.get('location')).toBeNull()
+    await expect(response.text()).resolves.toBe('file')
   })
 
   it('returns 401 from the download route when the user is not authenticated', async () => {
@@ -171,12 +275,28 @@ function createUpdateQuery() {
   return { update: jest.fn().mockReturnValue({ eq: jest.fn().mockResolvedValue({ error: null }) }) }
 }
 
+function createSelectEqQuery(data: unknown) {
+  return { select: jest.fn().mockReturnValue({ eq: jest.fn().mockResolvedValue({ data, error: null }) }) }
+}
+
+function createUpdateSelectMaybeSingleQuery(data: unknown) {
+  const builder = {
+    eq: jest.fn(),
+    select: jest.fn(),
+    maybeSingle: jest.fn().mockResolvedValue({ data, error: null }),
+  }
+  builder.eq.mockReturnValue(builder)
+  builder.select.mockReturnValue(builder)
+  return builder
+}
+
 function createR2Response(input: { ok: boolean; status?: number; statusText?: string; headers?: Record<string, string>; body?: Uint8Array }) {
+  const body = input.body?.slice().buffer ?? new ArrayBuffer(0)
   return {
     ok: input.ok,
     status: input.status ?? 200,
     statusText: input.statusText ?? 'OK',
     headers: { get: (name: string) => input.headers?.[name] ?? null },
-    arrayBuffer: async () => input.body?.buffer ?? new ArrayBuffer(0),
+    arrayBuffer: async () => body,
   }
 }

--- a/__tests__/app/support-external-route.test.ts
+++ b/__tests__/app/support-external-route.test.ts
@@ -1,0 +1,82 @@
+import { supportExternalInboundRoute } from '@/lib/support/external-bridge'
+
+const createSupabaseAdminClient = jest.fn()
+
+jest.mock('@/lib/supabase/admin', () => ({ createSupabaseAdminClient: () => createSupabaseAdminClient() }))
+
+class TestResponseClass {
+  status: number
+
+  private readonly body: unknown
+
+  constructor(body: unknown, init?: ResponseInit) {
+    this.body = body
+    this.status = init?.status ?? 200
+  }
+
+  static json(body: unknown, init?: ResponseInit) {
+    return new TestResponseClass(body, init)
+  }
+
+  async json() {
+    return this.body
+  }
+}
+
+const TestResponse = TestResponseClass as unknown as typeof Response
+
+describe('support external inbound route', () => {
+  beforeAll(() => {
+    if (typeof Response === 'undefined') {
+      Object.defineProperty(globalThis, 'Response', { value: TestResponse, configurable: true })
+    }
+  })
+
+  beforeEach(() => {
+    createSupabaseAdminClient.mockReset()
+    process.env.SUPPORT_EXTERNAL_BRIDGE_TOKEN = 'bridge-secret'
+    process.env.SUPPORT_EXTERNAL_BRIDGE_AUTHOR_USUARIO_ID = '00000000-0000-0000-0000-000000000001'
+  })
+
+  it('rejects unauthenticated inbound bridge updates', async () => {
+    const response = await supportExternalInboundRoute({ headers: new Headers(), json: async () => ({}) } as Request)
+
+    expect(response.status).toBe(401)
+    await expect(response.json()).resolves.toEqual({ error: 'Unauthorized external support update' })
+    expect(createSupabaseAdminClient).not.toHaveBeenCalled()
+  })
+
+  it('persists sanitized authenticated inbound updates through Supabase admin without exposing raw bridge payloads', async () => {
+    const rpc = jest.fn().mockResolvedValue({ data: { event_id: 'event-1', message_id: 'message-1', duplicate: false }, error: null })
+    createSupabaseAdminClient.mockReturnValue({
+      rpc,
+    })
+
+    const response = await supportExternalInboundRoute({
+      headers: new Headers([['authorization', 'Bearer bridge-secret']]),
+      json: async () => ({
+        ticketId: '11111111-1111-1111-1111-111111111111',
+        idempotencyKey: 'external-update-1',
+        message: 'External fix is ready. token=secret https://r2.test/private?signature=secret',
+      }),
+    } as Request)
+
+    expect(response.status).toBe(200)
+    await expect(response.json()).resolves.toEqual({ success: true, duplicate: false, messageId: 'message-1', eventId: 'event-1' })
+    expect(rpc).toHaveBeenCalledWith('record_support_external_inbound_update', expect.objectContaining({
+      p_idempotency_key: 'external-update-1',
+      p_message_body: 'External fix is ready. [redacted] [redacted-url]',
+    }))
+  })
+
+  it('returns a controlled 400 response for malformed authenticated JSON payloads', async () => {
+    const response = await supportExternalInboundRoute({
+      headers: new Headers([['authorization', 'Bearer bridge-secret']]),
+      json: async () => { throw new SyntaxError('Unexpected token') },
+    } as unknown as Request)
+
+    expect(response.status).toBe(400)
+    await expect(response.json()).resolves.toEqual({ error: 'Malformed external support update' })
+    expect(createSupabaseAdminClient).not.toHaveBeenCalled()
+  })
+})

--- a/__tests__/app/support-inngest-route.test.ts
+++ b/__tests__/app/support-inngest-route.test.ts
@@ -1,0 +1,77 @@
+import { POST } from '@/app/api/inngest/route'
+
+class TestResponseClass {
+  status: number
+
+  private readonly body: unknown
+
+  constructor(body: unknown, init?: ResponseInit) {
+    this.body = body
+    this.status = init?.status ?? 200
+  }
+
+  static json(body: unknown, init?: ResponseInit) {
+    return new TestResponseClass(body, init)
+  }
+
+  async json() {
+    return this.body
+  }
+}
+
+const TestResponse = TestResponseClass as unknown as typeof Response
+
+describe('support Inngest route', () => {
+  beforeAll(() => {
+    if (typeof Response === 'undefined') {
+      Object.defineProperty(globalThis, 'Response', { value: TestResponse, configurable: true })
+    }
+  })
+
+  beforeEach(() => {
+    delete process.env.SUPPORT_INNGEST_WEBHOOK_SECRET
+  })
+
+  it('rejects unsigned provider requests when a webhook secret is configured', async () => {
+    process.env.SUPPORT_INNGEST_WEBHOOK_SECRET = 'secret-1'
+
+    const response = await POST({ headers: new Headers(), json: async () => ({}) } as Request)
+
+    expect(response.status).toBe(401)
+    await expect(response.json()).resolves.toEqual({ error: 'Unauthorized support event provider request' })
+  })
+
+  it('rejects unsigned provider requests when the webhook secret is not configured', async () => {
+    const response = await POST({ headers: new Headers(), json: async () => ({}) } as Request)
+
+    expect(response.status).toBe(503)
+    await expect(response.json()).resolves.toEqual({ error: 'Support event provider secret is not configured' })
+  })
+
+  it('accepts signed ID-only support events without exposing provider secrets or raw evidence', async () => {
+    process.env.SUPPORT_INNGEST_WEBHOOK_SECRET = 'secret-1'
+    const response = await POST({
+      headers: new Headers([['authorization', 'Bearer secret-1']]),
+      json: async () => ({
+        name: 'support/ticket.created',
+        id: 'support:event-1',
+        data: { eventId: 'event-1', ticketId: 'ticket-1', rawSentryPayload: { token: 'secret' } },
+      }),
+    } as Request)
+
+    expect(response.status).toBe(202)
+    await expect(response.json()).resolves.toEqual({ accepted: true, eventId: 'event-1', name: 'support/ticket.created' })
+  })
+
+  it('returns a controlled 400 response for malformed signed JSON payloads', async () => {
+    process.env.SUPPORT_INNGEST_WEBHOOK_SECRET = 'secret-1'
+
+    const response = await POST({
+      headers: new Headers([['authorization', 'Bearer secret-1']]),
+      json: async () => { throw new SyntaxError('Unexpected token') },
+    } as unknown as Request)
+
+    expect(response.status).toBe(400)
+    await expect(response.json()).resolves.toEqual({ error: 'Malformed support event provider payload' })
+  })
+})

--- a/__tests__/app/support-pages.test.tsx
+++ b/__tests__/app/support-pages.test.tsx
@@ -5,12 +5,21 @@ import SupportAdminPage from '@/app/(auth)/ayuda/admin/page'
 import ReportarPage from '@/app/(auth)/ayuda/reportar/page'
 import TicketsPage from '@/app/(auth)/ayuda/tickets/page'
 import TicketDetailPage from '@/app/(auth)/ayuda/tickets/[id]/page'
+import { buildAttachmentIntentRequestBody, createAttachmentUploadItems, shouldCreateFreshAttachmentIntent } from '@/app/(auth)/ayuda/reportar/support-ticket-create-form'
+import SupportCapabilitiesPage from '@/app/(auth)/configuracion/soporte/page'
 
-const listStaffSupportTickets = jest.fn().mockResolvedValue({ success: true, tickets: [{ id: 'ticket-2', ticketNumber: 43, title: 'Cannot submit attendance', status: 'in_progress', category: 'bug', severity: 'high', assigneeUsuarioId: 'assignee-1', campusId: 'campus-1', createdAt: '2026-06-10T00:00:00Z', updatedAt: '2026-06-10T00:05:00Z' }] })
+const staffQueueResult = { success: true, supportCapabilities: ['support.view'], tickets: [{ id: 'ticket-2', ticketNumber: 43, title: 'Cannot submit attendance', status: 'in_progress', category: 'bug', severity: 'high', assigneeUsuarioId: 'assignee-1', campusId: 'campus-1', createdAt: '2026-06-10T00:00:00Z', updatedAt: '2026-06-10T00:05:00Z' }] }
+const listStaffSupportTickets = jest.fn().mockResolvedValue(staffQueueResult)
+const createSupabaseServerClient = jest.fn()
+const getUserWithRoles = jest.fn()
+const redirect = jest.fn((path: string) => {
+  throw new Error(`NEXT_REDIRECT:${path}`)
+})
 
 jest.mock('@/lib/actions/support.actions', () => ({
   createSupportTicket: jest.fn(),
   createSupportTicketMessage: jest.fn(),
+  createStaffSupportTicketReply: jest.fn(),
   getSupportTicketDetail: jest.fn().mockResolvedValue({
     success: true,
     ticket: {
@@ -24,19 +33,31 @@ jest.mock('@/lib/actions/support.actions', () => ({
       createdAt: '2026-06-09T00:00:00Z',
       updatedAt: '2026-06-09T00:00:00Z',
       evidence: { currentRoute: '/dashboard', browserName: 'Chrome', osName: 'macOS', viewport: '1440x900', appBuildVersion: null, sentryEventId: null, diagnosticsConsent: true },
+      attachments: [{ id: 'attachment-1', filename: 'map-error.webp', kind: 'screenshot', contentType: 'image/webp', byteSize: 2048, status: 'uploaded' }],
       messages: [{ id: 'message-1', body: 'Public reply', createdAt: '2026-06-09T00:01:00Z' }],
+      supportCapabilities: [],
     },
   }),
+  assignSupportTicket: jest.fn(),
   listStaffSupportTickets: (filters: Record<string, string | undefined>) => listStaffSupportTickets(filters),
   listSupportTickets: jest.fn().mockResolvedValue({ success: true, tickets: [{ id: 'ticket-1', ticketNumber: 42, title: 'Map bug', status: 'received', category: 'bug', severity: 'normal', createdAt: '2026-06-09T00:00:00Z', updatedAt: '2026-06-09T00:00:00Z' }] }),
+  updateSupportTicketStatus: jest.fn(),
 }))
 jest.mock('@/hooks/useCurrentUser', () => ({ useCurrentUser: () => ({ usuario: null, roles: ['miembro'], loading: false }) }))
 jest.mock('@/hooks/useBranding', () => ({ useBranding: () => ({ logoLightUrl: null, logoDarkUrl: null }) }))
 jest.mock('@/hooks/use-notificaciones', () => ({ useNotificaciones: () => ({ info: jest.fn() }) }))
+jest.mock('@/lib/actions/support-capabilities.actions', () => ({ grantSupportCapability: jest.fn(), revokeSupportCapability: jest.fn() }))
+jest.mock('@/lib/supabase/server', () => ({ createSupabaseServerClient: () => createSupabaseServerClient() }))
+jest.mock('@/lib/getUserWithRoles', () => ({ getUserWithRoles: (...args: unknown[]) => getUserWithRoles(...args) }))
+jest.mock('next/navigation', () => ({ redirect: (path: string) => redirect(path), usePathname: () => '/ayuda' }))
 
 describe('reporter support pages', () => {
   beforeEach(() => {
     listStaffSupportTickets.mockClear()
+    listStaffSupportTickets.mockResolvedValue(staffQueueResult)
+    createSupabaseServerClient.mockReset()
+    getUserWithRoles.mockReset()
+    redirect.mockClear()
   })
 
   it('renders the /ayuda home with report and history links', async () => {
@@ -46,12 +67,55 @@ describe('reporter support pages', () => {
     expect(screen.getByRole('link', { name: /Ver mis tickets/i })).toHaveAttribute('href', '/ayuda/tickets')
   })
 
-  it('renders the report form with safe evidence fields', async () => {
+  it('renders the report form with only reporter-facing fields', async () => {
     render(await ReportarPage())
 
-    expect(screen.getByLabelText(/Titulo/i)).toHaveAttribute('name', 'title')
-    expect(screen.getByLabelText(/Permitir diagnosticos seguros/i)).toHaveAttribute('name', 'diagnosticsConsent')
+    expect(screen.getByLabelText(/Asunto/i)).toHaveAttribute('name', 'subject')
+    expect(screen.getByLabelText(/Descripcion/i)).toHaveAttribute('name', 'description')
+    expect(screen.getByLabelText(/Categoria/i)).toHaveAttribute('name', 'category')
+    expect(screen.getByLabelText(/Adjuntos/i)).not.toHaveAttribute('name')
+
+    expect(screen.queryByLabelText(/Severidad/i)).not.toBeInTheDocument()
+    expect(screen.queryByLabelText(/Ruta/i)).not.toBeInTheDocument()
+    expect(screen.queryByLabelText(/Viewport/i)).not.toBeInTheDocument()
+    expect(screen.queryByLabelText(/Navegador/i)).not.toBeInTheDocument()
+    expect(screen.queryByLabelText(/Sistema operativo/i)).not.toBeInTheDocument()
+    expect(screen.queryByLabelText(/ID de evento de Sentry/i)).not.toBeInTheDocument()
+    expect(screen.queryByLabelText(/Permitir diagnosticos seguros/i)).not.toBeInTheDocument()
+
+    expect(document.querySelector('[name="currentRoute"]')).toHaveAttribute('type', 'hidden')
+    expect(document.querySelector('[name="diagnosticsConsent"]')).toHaveAttribute('value', 'true')
     expect(document.querySelector('[name="cookies"]')).not.toBeInTheDocument()
+    expect(screen.getByText(/Sube hasta 5 capturas/i)).toBeInTheDocument()
+    expect(screen.getByTestId('support-attachment-status')).toHaveTextContent(/Esperando envio del ticket/i)
+    expect(screen.queryByText(/se habilitara en el siguiente corte de R2/i)).not.toBeInTheDocument()
+  })
+
+  it('keys attachment upload state by client id instead of filename', () => {
+    const firstFile = new File(['first'], 'evidence.png', { type: 'image/png' })
+    const secondFile = new File(['second'], 'evidence.png', { type: 'image/png' })
+
+    const uploads = createAttachmentUploadItems([firstFile, secondFile])
+
+    expect(uploads).toEqual([
+      { clientId: 'evidence.png:5:image/png:0', name: 'evidence.png', status: 'idle', progress: 0 },
+      { clientId: 'evidence.png:6:image/png:1', name: 'evidence.png', status: 'idle', progress: 0 },
+    ])
+  })
+
+  it('creates a fresh attachment intent when retrying a failed upload', () => {
+    expect(shouldCreateFreshAttachmentIntent({ clientId: 'upload-1', name: 'evidence.png', status: 'failed', progress: 40, attachmentId: 'attachment-1', uploadUrl: 'https://r2.example/upload?X-Amz-Expires=300' })).toBe(true)
+  })
+
+  it('includes the prior attachment id only when retrying an upload intent', () => {
+    const file = new File(['video'], 'retry.mp4', { type: 'video/mp4' })
+
+    expect(buildAttachmentIntentRequestBody('ticket-1', file, 'attachment-1')).toEqual({
+      ticketId: 'ticket-1',
+      replaceAttachmentId: 'attachment-1',
+      files: [{ filename: 'retry.mp4', contentType: 'video/mp4', byteSize: 5 }],
+    })
+    expect(buildAttachmentIntentRequestBody('ticket-1', file)).not.toHaveProperty('replaceAttachmentId')
   })
 
   it('renders the reporter ticket history', async () => {
@@ -64,8 +128,102 @@ describe('reporter support pages', () => {
     render(await TicketDetailPage({ params: Promise.resolve({ id: 'ticket-1' }) }))
 
     expect(screen.getByText('The group map does not load.')).toBeInTheDocument()
+    expect(screen.getByRole('link', { name: /Descargar map-error\.webp/i })).toHaveAttribute('href', '/api/support/attachments/attachment-1/download')
+    expect(screen.queryByText(/support\/ticket-1\/attachment-1/i)).not.toBeInTheDocument()
+    expect(screen.queryByText(/X-Amz-Signature/i)).not.toBeInTheDocument()
     expect(screen.getByText('Public reply')).toBeInTheDocument()
     expect(screen.getByLabelText(/Respuesta/i)).toHaveAttribute('name', 'body')
+    expect(screen.queryByLabelText(/Respuesta del equipo/i)).not.toBeInTheDocument()
+    expect(screen.queryByLabelText(/Nuevo estado/i)).not.toBeInTheDocument()
+  })
+
+  it('renders staff reply and lifecycle controls only when staff capabilities are present', async () => {
+    const { getSupportTicketDetail } = jest.requireMock('@/lib/actions/support.actions') as { getSupportTicketDetail: jest.Mock }
+    getSupportTicketDetail.mockResolvedValueOnce({
+      success: true,
+      ticket: {
+        id: 'ticket-2',
+        ticketNumber: 43,
+        title: 'Cannot submit attendance',
+        description: 'The attendance form fails.',
+        status: 'in_review',
+        category: 'bug',
+        severity: 'high',
+        createdAt: '2026-06-10T00:00:00Z',
+        updatedAt: '2026-06-10T00:05:00Z',
+        evidence: { currentRoute: '/dashboard', browserName: 'Chrome', osName: 'macOS', viewport: '1440x900', appBuildVersion: null, sentryEventId: null, diagnosticsConsent: true },
+        attachments: [],
+        messages: [],
+        supportCapabilities: ['support.reply', 'support.manage'],
+      },
+    })
+
+    render(await TicketDetailPage({ params: Promise.resolve({ id: 'ticket-2' }) }))
+
+    expect(screen.getByLabelText(/Respuesta del equipo/i)).toHaveAttribute('name', 'body')
+    expect(screen.getByRole('button', { name: /Enviar respuesta del equipo/i })).toBeInTheDocument()
+    expect(screen.getByLabelText(/Nuevo estado/i)).toHaveValue('in_review')
+    expect(screen.getByRole('button', { name: /Actualizar estado/i })).toBeInTheDocument()
+    expect(screen.getByLabelText(/Responsable/i)).toHaveAttribute('name', 'assigneeUsuarioId')
+  })
+
+  it('renders staff reply and lifecycle controls for pure support managers on ticket detail', async () => {
+    const { getSupportTicketDetail } = jest.requireMock('@/lib/actions/support.actions') as { getSupportTicketDetail: jest.Mock }
+    getSupportTicketDetail.mockResolvedValueOnce({
+      success: true,
+      ticket: {
+        id: 'ticket-3',
+        ticketNumber: 44,
+        title: 'Cannot access admin queue',
+        description: 'The admin queue is blocked.',
+        status: 'in_progress',
+        category: 'access',
+        severity: 'normal',
+        createdAt: '2026-06-10T01:00:00Z',
+        updatedAt: '2026-06-10T01:05:00Z',
+        evidence: { currentRoute: '/ayuda/admin', browserName: 'Chrome', osName: 'macOS', viewport: '1440x900', appBuildVersion: null, sentryEventId: null, diagnosticsConsent: true },
+        attachments: [],
+        messages: [],
+        supportCapabilities: ['support.manage'],
+      },
+    })
+
+    render(await TicketDetailPage({ params: Promise.resolve({ id: 'ticket-3' }) }))
+
+    expect(screen.getByLabelText(/Respuesta del equipo/i)).toHaveAttribute('name', 'body')
+    expect(screen.getByRole('button', { name: /Enviar respuesta del equipo/i })).toBeInTheDocument()
+    expect(screen.getByLabelText(/Nuevo estado/i)).toHaveValue('in_progress')
+    expect(screen.getByRole('button', { name: /Actualizar estado/i })).toBeInTheDocument()
+    expect(screen.getByLabelText(/Responsable/i)).toHaveAttribute('name', 'assigneeUsuarioId')
+  })
+
+  it('keeps ticket detail staff reply and lifecycle controls hidden for view-only staff', async () => {
+    const { getSupportTicketDetail } = jest.requireMock('@/lib/actions/support.actions') as { getSupportTicketDetail: jest.Mock }
+    getSupportTicketDetail.mockResolvedValueOnce({
+      success: true,
+      ticket: {
+        id: 'ticket-4',
+        ticketNumber: 45,
+        title: 'View-only ticket',
+        description: 'The staff member can only inspect this ticket.',
+        status: 'received',
+        category: 'other',
+        severity: 'normal',
+        createdAt: '2026-06-10T02:00:00Z',
+        updatedAt: '2026-06-10T02:05:00Z',
+        evidence: { currentRoute: '/ayuda/admin', browserName: 'Chrome', osName: 'macOS', viewport: '1440x900', appBuildVersion: null, sentryEventId: null, diagnosticsConsent: true },
+        attachments: [],
+        messages: [],
+        supportCapabilities: ['support.view'],
+      },
+    })
+
+    render(await TicketDetailPage({ params: Promise.resolve({ id: 'ticket-4' }) }))
+
+    expect(screen.queryByLabelText(/Respuesta del equipo/i)).not.toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: /Enviar respuesta del equipo/i })).not.toBeInTheDocument()
+    expect(screen.queryByLabelText(/Nuevo estado/i)).not.toBeInTheDocument()
+    expect(screen.queryByLabelText(/Responsable/i)).not.toBeInTheDocument()
   })
 
   it('renders the staff queue with search and filter controls', async () => {
@@ -73,8 +231,81 @@ describe('reporter support pages', () => {
 
     expect(listStaffSupportTickets).toHaveBeenCalledWith({ search: 'attendance', status: 'in_progress', category: 'bug', campusId: undefined, assigneeId: undefined })
     expect(screen.getByRole('searchbox', { name: /Buscar tickets/i })).toHaveValue('attendance')
-    expect(screen.getByLabelText(/Estado/i)).toHaveValue('in_progress')
+    expect(screen.getByLabelText(/^Estado$/i)).toHaveValue('in_progress')
     expect(screen.getByRole('link', { name: /#43 Cannot submit attendance/i })).toHaveAttribute('href', '/ayuda/tickets/ticket-2')
     expect(screen.getAllByText('En progreso')).toHaveLength(2)
   })
+
+  it('hides staff queue assignment and status transition controls for view-only staff', async () => {
+    render(await SupportAdminPage({ searchParams: Promise.resolve({}) }))
+
+    expect(screen.queryByLabelText(/Nuevo estado para #43/i)).not.toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: /Actualizar estado de #43/i })).not.toBeInTheDocument()
+    expect(screen.queryByLabelText(/Responsable para #43/i)).not.toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: /Asignar #43/i })).not.toBeInTheDocument()
+    expect(screen.getByRole('link', { name: /Responder #43/i })).toHaveAttribute('href', '/ayuda/tickets/ticket-2')
+  })
+
+  it('renders staff queue assignment and status transition controls for support managers', async () => {
+    listStaffSupportTickets.mockResolvedValueOnce({ ...staffQueueResult, supportCapabilities: ['support.view', 'support.manage'] })
+
+    render(await SupportAdminPage({ searchParams: Promise.resolve({}) }))
+
+    expect(screen.getByLabelText(/Nuevo estado para #43/i)).toHaveValue('in_progress')
+    expect(screen.getByRole('button', { name: /Actualizar estado de #43/i })).toBeInTheDocument()
+    expect(screen.getByLabelText(/Responsable para #43/i)).toHaveValue('assignee-1')
+    expect(screen.getByRole('button', { name: /Asignar #43/i })).toBeInTheDocument()
+    expect(screen.getByRole('link', { name: /Responder #43/i })).toHaveAttribute('href', '/ayuda/tickets/ticket-2')
+  })
+
+  it('redirects pure support.manage staff away from support capability configuration', async () => {
+    const supabase = createSupportCapabilitiesPageSupabase(true)
+    createSupabaseServerClient.mockResolvedValue(supabase)
+    getUserWithRoles.mockResolvedValue({ user: { id: 'auth-1' }, roles: ['miembro'] })
+
+    await expect(SupportCapabilitiesPage()).rejects.toThrow('NEXT_REDIRECT:/dashboard')
+    expect(redirect).toHaveBeenCalledWith('/dashboard')
+  })
+
+  it('renders support capability configuration for higher-role support managers', async () => {
+    const supabase = createSupportCapabilitiesPageSupabase(true)
+    createSupabaseServerClient.mockResolvedValue(supabase)
+    getUserWithRoles.mockResolvedValue({ user: { id: 'auth-1' }, roles: ['director-general'] })
+
+    render(await SupportCapabilitiesPage())
+
+    expect(screen.getByRole('heading', { name: /Capacidades permitidas/i })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /Otorgar capacidad/i })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /Revocar capacidad/i })).toBeInTheDocument()
+  })
 })
+
+function createSupportCapabilitiesPageSupabase(hasSupportManage: boolean) {
+  return {
+    from: jest.fn((table) => {
+      if (table === 'usuarios') {
+        return {
+          select: jest.fn().mockReturnValue({
+            eq: jest.fn().mockReturnValue({
+              maybeSingle: jest.fn().mockResolvedValue({ data: { id: 'usuario-1' }, error: null }),
+            }),
+          }),
+        }
+      }
+      if (table === 'support_user_capabilities') {
+        return {
+          select: jest.fn().mockReturnValue({
+            eq: jest.fn().mockReturnValue({
+              eq: jest.fn().mockReturnValue({
+                is: jest.fn().mockReturnValue({
+                  maybeSingle: jest.fn().mockResolvedValue({ data: hasSupportManage ? { capability: 'support.manage' } : null, error: null }),
+                }),
+              }),
+            }),
+          }),
+        }
+      }
+      throw new Error(`Unexpected table ${table}`)
+    }),
+  }
+}

--- a/__tests__/app/support-pages.test.tsx
+++ b/__tests__/app/support-pages.test.tsx
@@ -38,7 +38,10 @@ jest.mock('@/lib/actions/support.actions', () => ({
       updatedAt: '2026-06-09T00:00:00Z',
       evidence: { currentRoute: '/dashboard', browserName: 'Chrome', osName: 'macOS', viewport: '1440x900', appBuildVersion: null, sentryEventId: null, diagnosticsConsent: true },
       attachments: [{ id: 'attachment-1', filename: 'map-error.webp', kind: 'screenshot', contentType: 'image/webp', byteSize: 2048, status: 'uploaded' }],
-      messages: [{ id: 'message-1', body: 'Public reply', authorUsuarioId: 'reporter-1', author: { id: 'reporter-1', nombre: 'Ana', apellido: 'Pérez', photoUrl: null }, createdAt: '2026-06-09T00:01:00Z' }],
+      messages: [
+        { id: 'message-1', body: 'Public reply', authorUsuarioId: 'reporter-1', author: { id: 'reporter-1', nombre: 'Ana', apellido: 'Pérez', photoUrl: null }, createdAt: '2026-06-09T00:01:00Z' },
+        { id: 'message-2', body: 'Support reply', authorUsuarioId: 'staff-1', author: { id: 'staff-1', nombre: 'Soporte', apellido: 'Central', photoUrl: null }, createdAt: '2026-06-09T00:02:00Z' },
+      ],
       supportCapabilities: [],
     },
   }),
@@ -141,6 +144,9 @@ describe('reporter support pages', () => {
     expect(screen.queryByText(/support\/ticket-1\/attachment-1/i)).not.toBeInTheDocument()
     expect(screen.queryByText(/X-Amz-Signature/i)).not.toBeInTheDocument()
     expect(screen.getByText('Public reply')).toBeInTheDocument()
+    expect(screen.getByText('Support reply')).toBeInTheDocument()
+    expect(screen.getByText('Soporte Central')).toBeInTheDocument()
+    expect(screen.getByText('Equipo de soporte')).toBeInTheDocument()
     expect(screen.getByLabelText(/Respuesta/i)).toHaveAttribute('name', 'body')
     expect(screen.queryByLabelText(/Respuesta del equipo/i)).not.toBeInTheDocument()
     expect(screen.queryByLabelText(/Nuevo estado/i)).not.toBeInTheDocument()
@@ -173,8 +179,8 @@ describe('reporter support pages', () => {
 
     render(await TicketDetailPage({ params: Promise.resolve({ id: 'ticket-2' }) }))
 
-    expect(screen.getByLabelText(/Respuesta del equipo/i)).toHaveAttribute('name', 'body')
-    expect(screen.getByRole('button', { name: /Enviar respuesta del equipo/i })).toBeInTheDocument()
+    expect(screen.getByLabelText(/Respuesta de soporte/i)).toHaveAttribute('name', 'body')
+    expect(screen.getByRole('button', { name: /Enviar respuesta al solicitante/i })).toBeInTheDocument()
     expect(screen.getByLabelText(/Nuevo estado/i)).toHaveValue('in_review')
     expect(screen.getByRole('button', { name: /Actualizar estado/i })).toBeInTheDocument()
     expect(screen.queryByLabelText(/Responsable/i)).not.toBeInTheDocument()
@@ -207,8 +213,8 @@ describe('reporter support pages', () => {
 
     render(await TicketDetailPage({ params: Promise.resolve({ id: 'ticket-3' }) }))
 
-    expect(screen.getByLabelText(/Respuesta del equipo/i)).toHaveAttribute('name', 'body')
-    expect(screen.getByRole('button', { name: /Enviar respuesta del equipo/i })).toBeInTheDocument()
+    expect(screen.getByLabelText(/Respuesta de soporte/i)).toHaveAttribute('name', 'body')
+    expect(screen.getByRole('button', { name: /Enviar respuesta al solicitante/i })).toBeInTheDocument()
     expect(screen.getByLabelText(/Nuevo estado/i)).toHaveValue('in_progress')
     expect(screen.getByRole('button', { name: /Actualizar estado/i })).toBeInTheDocument()
     expect(screen.queryByLabelText(/Responsable/i)).not.toBeInTheDocument()
@@ -241,8 +247,8 @@ describe('reporter support pages', () => {
 
     render(await TicketDetailPage({ params: Promise.resolve({ id: 'ticket-4' }) }))
 
-    expect(screen.queryByLabelText(/Respuesta del equipo/i)).not.toBeInTheDocument()
-    expect(screen.queryByRole('button', { name: /Enviar respuesta del equipo/i })).not.toBeInTheDocument()
+    expect(screen.queryByLabelText(/Respuesta de soporte/i)).not.toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: /Enviar respuesta al solicitante/i })).not.toBeInTheDocument()
     expect(screen.queryByLabelText(/Nuevo estado/i)).not.toBeInTheDocument()
     expect(screen.queryByLabelText(/Responsable/i)).not.toBeInTheDocument()
   })

--- a/__tests__/app/support-pages.test.tsx
+++ b/__tests__/app/support-pages.test.tsx
@@ -45,11 +45,11 @@ jest.mock('@/lib/actions/support.actions', () => ({
 }))
 jest.mock('@/hooks/useCurrentUser', () => ({ useCurrentUser: () => ({ usuario: null, roles: ['miembro'], loading: false }) }))
 jest.mock('@/hooks/useBranding', () => ({ useBranding: () => ({ logoLightUrl: null, logoDarkUrl: null }) }))
-jest.mock('@/hooks/use-notificaciones', () => ({ useNotificaciones: () => ({ info: jest.fn() }) }))
+jest.mock('@/hooks/use-notificaciones', () => ({ useNotificaciones: () => ({ error: jest.fn(), info: jest.fn(), success: jest.fn() }) }))
 jest.mock('@/lib/actions/support-capabilities.actions', () => ({ grantSupportCapability: jest.fn(), revokeSupportCapability: jest.fn() }))
 jest.mock('@/lib/supabase/server', () => ({ createSupabaseServerClient: () => createSupabaseServerClient() }))
 jest.mock('@/lib/getUserWithRoles', () => ({ getUserWithRoles: (...args: unknown[]) => getUserWithRoles(...args) }))
-jest.mock('next/navigation', () => ({ redirect: (path: string) => redirect(path), usePathname: () => '/ayuda' }))
+jest.mock('next/navigation', () => ({ redirect: (path: string) => redirect(path), usePathname: () => '/ayuda', useRouter: () => ({ push: jest.fn() }) }))
 
 describe('reporter support pages', () => {
   beforeEach(() => {
@@ -164,7 +164,7 @@ describe('reporter support pages', () => {
     expect(screen.getByRole('button', { name: /Enviar respuesta del equipo/i })).toBeInTheDocument()
     expect(screen.getByLabelText(/Nuevo estado/i)).toHaveValue('in_review')
     expect(screen.getByRole('button', { name: /Actualizar estado/i })).toBeInTheDocument()
-    expect(screen.getByLabelText(/Responsable/i)).toHaveAttribute('name', 'assigneeUsuarioId')
+    expect(screen.queryByLabelText(/Responsable/i)).not.toBeInTheDocument()
   })
 
   it('renders staff reply and lifecycle controls for pure support managers on ticket detail', async () => {
@@ -194,7 +194,7 @@ describe('reporter support pages', () => {
     expect(screen.getByRole('button', { name: /Enviar respuesta del equipo/i })).toBeInTheDocument()
     expect(screen.getByLabelText(/Nuevo estado/i)).toHaveValue('in_progress')
     expect(screen.getByRole('button', { name: /Actualizar estado/i })).toBeInTheDocument()
-    expect(screen.getByLabelText(/Responsable/i)).toHaveAttribute('name', 'assigneeUsuarioId')
+    expect(screen.queryByLabelText(/Responsable/i)).not.toBeInTheDocument()
   })
 
   it('keeps ticket detail staff reply and lifecycle controls hidden for view-only staff', async () => {
@@ -253,18 +253,21 @@ describe('reporter support pages', () => {
 
     expect(screen.getByLabelText(/Nuevo estado para #43/i)).toHaveValue('in_progress')
     expect(screen.getByRole('button', { name: /Actualizar estado de #43/i })).toBeInTheDocument()
-    expect(screen.getByLabelText(/Responsable para #43/i)).toHaveValue('assignee-1')
-    expect(screen.getByRole('button', { name: /Asignar #43/i })).toBeInTheDocument()
+    expect(screen.queryByLabelText(/Responsable para #43/i)).not.toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: /Asignar #43/i })).not.toBeInTheDocument()
     expect(screen.getByRole('link', { name: /Responder #43/i })).toHaveAttribute('href', '/ayuda/tickets/ticket-2')
   })
 
-  it('redirects pure support.manage staff away from support capability configuration', async () => {
+  it('explains the required access for denied support capability configuration', async () => {
     const supabase = createSupportCapabilitiesPageSupabase(true)
     createSupabaseServerClient.mockResolvedValue(supabase)
     getUserWithRoles.mockResolvedValue({ user: { id: 'auth-1' }, roles: ['miembro'] })
 
-    await expect(SupportCapabilitiesPage()).rejects.toThrow('NEXT_REDIRECT:/dashboard')
-    expect(redirect).toHaveBeenCalledWith('/dashboard')
+    render(await SupportCapabilitiesPage())
+
+    expect(screen.getByRole('heading', { name: /Acceso requerido/i })).toBeInTheDocument()
+    expect(screen.getByText(/requiere un rol de administracion alto y la capacidad support.manage/i)).toBeInTheDocument()
+    expect(redirect).not.toHaveBeenCalledWith('/dashboard')
   })
 
   it('renders support capability configuration for higher-role support managers', async () => {

--- a/__tests__/app/support-pages.test.tsx
+++ b/__tests__/app/support-pages.test.tsx
@@ -135,7 +135,7 @@ describe('reporter support pages', () => {
     expect(screen.getByRole('columnheader', { name: /Severidad/i })).toBeInTheDocument()
     expect(screen.getByRole('columnheader', { name: /Estado/i })).toBeInTheDocument()
     expect(screen.getByRole('columnheader', { name: /Fecha/i })).toBeInTheDocument()
-    expect(screen.getByRole('link', { name: /#42 Map bug/i })).toHaveAttribute('href', '/ayuda/tickets/ticket-1')
+    expect(screen.getAllByRole('link', { name: /#42 Map bug/i })[0]).toHaveAttribute('href', '/ayuda/tickets/ticket-1')
   })
 
   it('renders the reporter ticket history empty state', async () => {
@@ -145,7 +145,7 @@ describe('reporter support pages', () => {
     render(await TicketsPage())
 
     expect(screen.getByRole('table')).toBeInTheDocument()
-    expect(screen.getByText('Todavia no has enviado tickets de soporte.')).toBeInTheDocument()
+    expect(screen.getAllByText('Todavia no has enviado tickets de soporte.')[0]).toBeInTheDocument()
     expect(screen.queryByRole('link', { name: /#/ })).not.toBeInTheDocument()
   })
 
@@ -277,8 +277,12 @@ describe('reporter support pages', () => {
     expect(listStaffSupportTickets).toHaveBeenCalledWith({ search: 'attendance', status: 'in_progress', category: 'bug', campusId: undefined, assigneeId: undefined })
     expect(screen.getByRole('searchbox', { name: /Buscar tickets/i })).toHaveValue('attendance')
     expect(screen.getByLabelText(/^Estado$/i)).toHaveValue('in_progress')
-    expect(screen.getByRole('link', { name: /#43 Cannot submit attendance/i })).toHaveAttribute('href', '/ayuda/tickets/ticket-2')
-    expect(screen.getAllByText('En progreso')).toHaveLength(2)
+    expect(screen.getByRole('table')).toBeInTheDocument()
+    expect(screen.getByText('Cola de tickets de soporte autorizados para el equipo.')).toBeInTheDocument()
+    expect(screen.getByRole('columnheader', { name: /Ticket/i })).toBeInTheDocument()
+    expect(screen.getByRole('columnheader', { name: /Acciones/i })).toBeInTheDocument()
+    expect(screen.getAllByRole('link', { name: /#43 Cannot submit attendance/i })[0]).toHaveAttribute('href', '/ayuda/tickets/ticket-2')
+    expect(screen.getAllByText('En progreso')).toHaveLength(3)
   })
 
   it('hides staff queue assignment and status transition controls for view-only staff', async () => {
@@ -288,7 +292,7 @@ describe('reporter support pages', () => {
     expect(screen.queryByRole('button', { name: /Actualizar estado de #43/i })).not.toBeInTheDocument()
     expect(screen.queryByLabelText(/Responsable para #43/i)).not.toBeInTheDocument()
     expect(screen.queryByRole('button', { name: /Asignar #43/i })).not.toBeInTheDocument()
-    expect(screen.getByRole('link', { name: /Responder #43/i })).toHaveAttribute('href', '/ayuda/tickets/ticket-2')
+    expect(screen.getAllByRole('link', { name: /Responder #43/i })[0]).toHaveAttribute('href', '/ayuda/tickets/ticket-2')
   })
 
   it('renders staff queue assignment and status transition controls for support managers', async () => {
@@ -296,11 +300,11 @@ describe('reporter support pages', () => {
 
     render(await SupportAdminPage({ searchParams: Promise.resolve({}) }))
 
-    expect(screen.getByLabelText(/Nuevo estado para #43/i)).toHaveValue('in_progress')
-    expect(screen.getByRole('button', { name: /Actualizar estado de #43/i })).toBeInTheDocument()
+    expect(screen.getAllByLabelText(/Nuevo estado para #43/i)[0]).toHaveValue('in_progress')
+    expect(screen.getAllByRole('button', { name: /Actualizar estado de #43/i })[0]).toBeInTheDocument()
     expect(screen.queryByLabelText(/Responsable para #43/i)).not.toBeInTheDocument()
     expect(screen.queryByRole('button', { name: /Asignar #43/i })).not.toBeInTheDocument()
-    expect(screen.getByRole('link', { name: /Responder #43/i })).toHaveAttribute('href', '/ayuda/tickets/ticket-2')
+    expect(screen.getAllByRole('link', { name: /Responder #43/i })[0]).toHaveAttribute('href', '/ayuda/tickets/ticket-2')
   })
 
   it('explains the required access for denied support capability configuration', async () => {

--- a/__tests__/app/support-pages.test.tsx
+++ b/__tests__/app/support-pages.test.tsx
@@ -130,7 +130,8 @@ describe('reporter support pages', () => {
 
     expect(screen.getByRole('table')).toBeInTheDocument()
     expect(screen.getByText('Historial de tickets de soporte enviados por ti.')).toBeInTheDocument()
-    expect(screen.getByRole('columnheader', { name: /Ticket/i })).toBeInTheDocument()
+    expect(screen.queryByRole('checkbox', { name: /Seleccionar/i })).not.toBeInTheDocument()
+    expect(screen.getByRole('columnheader', { name: /^Ticket$/i })).toBeInTheDocument()
     expect(screen.getByRole('columnheader', { name: /Categoria/i })).toBeInTheDocument()
     expect(screen.getByRole('columnheader', { name: /Severidad/i })).toBeInTheDocument()
     expect(screen.getByRole('columnheader', { name: /Estado/i })).toBeInTheDocument()
@@ -279,7 +280,8 @@ describe('reporter support pages', () => {
     expect(screen.getByLabelText(/^Estado$/i)).toHaveValue('in_progress')
     expect(screen.getByRole('table')).toBeInTheDocument()
     expect(screen.getByText('Cola de tickets de soporte autorizados para el equipo.')).toBeInTheDocument()
-    expect(screen.getByRole('columnheader', { name: /Ticket/i })).toBeInTheDocument()
+    expect(screen.queryByRole('checkbox', { name: /Seleccionar/i })).not.toBeInTheDocument()
+    expect(screen.getByRole('columnheader', { name: /^Ticket$/i })).toBeInTheDocument()
     expect(screen.getByRole('columnheader', { name: /Acciones/i })).toBeInTheDocument()
     expect(screen.getAllByRole('link', { name: /#43 Cannot submit attendance/i })[0]).toHaveAttribute('href', '/ayuda/tickets/ticket-2')
     expect(screen.getAllByText('En progreso')).toHaveLength(3)
@@ -289,7 +291,7 @@ describe('reporter support pages', () => {
     render(await SupportAdminPage({ searchParams: Promise.resolve({}) }))
 
     expect(screen.queryByLabelText(/Nuevo estado para #43/i)).not.toBeInTheDocument()
-    expect(screen.queryByRole('button', { name: /Actualizar estado de #43/i })).not.toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: /Actualizar #43/i })).not.toBeInTheDocument()
     expect(screen.queryByLabelText(/Responsable para #43/i)).not.toBeInTheDocument()
     expect(screen.queryByRole('button', { name: /Asignar #43/i })).not.toBeInTheDocument()
     expect(screen.getAllByRole('link', { name: /Responder #43/i })[0]).toHaveAttribute('href', '/ayuda/tickets/ticket-2')
@@ -301,7 +303,7 @@ describe('reporter support pages', () => {
     render(await SupportAdminPage({ searchParams: Promise.resolve({}) }))
 
     expect(screen.getAllByLabelText(/Nuevo estado para #43/i)[0]).toHaveValue('in_progress')
-    expect(screen.getAllByRole('button', { name: /Actualizar estado de #43/i })[0]).toBeInTheDocument()
+    expect(screen.getAllByRole('button', { name: /Actualizar #43/i })[0]).toBeInTheDocument()
     expect(screen.queryByLabelText(/Responsable para #43/i)).not.toBeInTheDocument()
     expect(screen.queryByRole('button', { name: /Asignar #43/i })).not.toBeInTheDocument()
     expect(screen.getAllByRole('link', { name: /Responder #43/i })[0]).toHaveAttribute('href', '/ayuda/tickets/ticket-2')

--- a/__tests__/app/support-pages.test.tsx
+++ b/__tests__/app/support-pages.test.tsx
@@ -128,7 +128,25 @@ describe('reporter support pages', () => {
   it('renders the reporter ticket history', async () => {
     render(await TicketsPage())
 
+    expect(screen.getByRole('table')).toBeInTheDocument()
+    expect(screen.getByText('Historial de tickets de soporte enviados por ti.')).toBeInTheDocument()
+    expect(screen.getByRole('columnheader', { name: /Ticket/i })).toBeInTheDocument()
+    expect(screen.getByRole('columnheader', { name: /Categoria/i })).toBeInTheDocument()
+    expect(screen.getByRole('columnheader', { name: /Severidad/i })).toBeInTheDocument()
+    expect(screen.getByRole('columnheader', { name: /Estado/i })).toBeInTheDocument()
+    expect(screen.getByRole('columnheader', { name: /Fecha/i })).toBeInTheDocument()
     expect(screen.getByRole('link', { name: /#42 Map bug/i })).toHaveAttribute('href', '/ayuda/tickets/ticket-1')
+  })
+
+  it('renders the reporter ticket history empty state', async () => {
+    const { listSupportTickets } = jest.requireMock('@/lib/actions/support.actions') as { listSupportTickets: jest.Mock }
+    listSupportTickets.mockResolvedValueOnce({ success: true, tickets: [] })
+
+    render(await TicketsPage())
+
+    expect(screen.getByRole('table')).toBeInTheDocument()
+    expect(screen.getByText('Todavia no has enviado tickets de soporte.')).toBeInTheDocument()
+    expect(screen.queryByRole('link', { name: /#/ })).not.toBeInTheDocument()
   })
 
   it('renders reporter-visible ticket details and reply form', async () => {

--- a/__tests__/app/support-pages.test.tsx
+++ b/__tests__/app/support-pages.test.tsx
@@ -30,11 +30,15 @@ jest.mock('@/lib/actions/support.actions', () => ({
       status: 'received',
       category: 'bug',
       severity: 'normal',
+      reporterUsuarioId: 'reporter-1',
+      assigneeUsuarioId: null,
+      reporter: { id: 'reporter-1', nombre: 'Ana', apellido: 'Pérez', photoUrl: null },
+      assignee: null,
       createdAt: '2026-06-09T00:00:00Z',
       updatedAt: '2026-06-09T00:00:00Z',
       evidence: { currentRoute: '/dashboard', browserName: 'Chrome', osName: 'macOS', viewport: '1440x900', appBuildVersion: null, sentryEventId: null, diagnosticsConsent: true },
       attachments: [{ id: 'attachment-1', filename: 'map-error.webp', kind: 'screenshot', contentType: 'image/webp', byteSize: 2048, status: 'uploaded' }],
-      messages: [{ id: 'message-1', body: 'Public reply', createdAt: '2026-06-09T00:01:00Z' }],
+      messages: [{ id: 'message-1', body: 'Public reply', authorUsuarioId: 'reporter-1', author: { id: 'reporter-1', nombre: 'Ana', apellido: 'Pérez', photoUrl: null }, createdAt: '2026-06-09T00:01:00Z' }],
       supportCapabilities: [],
     },
   }),
@@ -128,6 +132,11 @@ describe('reporter support pages', () => {
     render(await TicketDetailPage({ params: Promise.resolve({ id: 'ticket-1' }) }))
 
     expect(screen.getByText('The group map does not load.')).toBeInTheDocument()
+    expect(screen.getByRole('heading', { name: /Solicitante/i })).toBeInTheDocument()
+    expect(screen.getByRole('heading', { name: /Conversación/i })).toBeInTheDocument()
+    expect(screen.getByRole('heading', { name: /Adjuntos/i })).toBeInTheDocument()
+    expect(screen.getAllByText('Ana Pérez').length).toBeGreaterThan(0)
+    expect(screen.getByText('map-error.webp')).toBeInTheDocument()
     expect(screen.getByRole('link', { name: /Descargar map-error\.webp/i })).toHaveAttribute('href', '/api/support/attachments/attachment-1/download')
     expect(screen.queryByText(/support\/ticket-1\/attachment-1/i)).not.toBeInTheDocument()
     expect(screen.queryByText(/X-Amz-Signature/i)).not.toBeInTheDocument()
@@ -149,6 +158,10 @@ describe('reporter support pages', () => {
         status: 'in_review',
         category: 'bug',
         severity: 'high',
+        reporterUsuarioId: 'reporter-2',
+        assigneeUsuarioId: 'staff-1',
+        reporter: { id: 'reporter-2', nombre: 'Luis', apellido: 'Ramos', photoUrl: null },
+        assignee: { id: 'staff-1', nombre: 'Soporte', apellido: 'Central', photoUrl: null },
         createdAt: '2026-06-10T00:00:00Z',
         updatedAt: '2026-06-10T00:05:00Z',
         evidence: { currentRoute: '/dashboard', browserName: 'Chrome', osName: 'macOS', viewport: '1440x900', appBuildVersion: null, sentryEventId: null, diagnosticsConsent: true },
@@ -179,6 +192,10 @@ describe('reporter support pages', () => {
         status: 'in_progress',
         category: 'access',
         severity: 'normal',
+        reporterUsuarioId: 'reporter-3',
+        assigneeUsuarioId: null,
+        reporter: { id: 'reporter-3', nombre: 'Marta', apellido: 'Núñez', photoUrl: null },
+        assignee: null,
         createdAt: '2026-06-10T01:00:00Z',
         updatedAt: '2026-06-10T01:05:00Z',
         evidence: { currentRoute: '/ayuda/admin', browserName: 'Chrome', osName: 'macOS', viewport: '1440x900', appBuildVersion: null, sentryEventId: null, diagnosticsConsent: true },
@@ -209,6 +226,10 @@ describe('reporter support pages', () => {
         status: 'received',
         category: 'other',
         severity: 'normal',
+        reporterUsuarioId: 'reporter-4',
+        assigneeUsuarioId: null,
+        reporter: { id: 'reporter-4', nombre: 'Diego', apellido: 'Soto', photoUrl: null },
+        assignee: null,
         createdAt: '2026-06-10T02:00:00Z',
         updatedAt: '2026-06-10T02:05:00Z',
         evidence: { currentRoute: '/ayuda/admin', browserName: 'Chrome', osName: 'macOS', viewport: '1440x900', appBuildVersion: null, sentryEventId: null, diagnosticsConsent: true },

--- a/__tests__/components/support-navigation.test.tsx
+++ b/__tests__/components/support-navigation.test.tsx
@@ -1,19 +1,30 @@
 import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
 
+import { HeaderMovil } from '@/components/ui/header-movil'
 import { MenuInferiorMovil } from '@/components/ui/menu-inferior-movil'
 import { SidebarModerna } from '@/components/ui/sidebar-moderna'
+
+let currentRoles = ['miembro']
+let currentSupportCapabilities: string[] = []
 
 jest.mock('next/navigation', () => ({
   usePathname: () => '/dashboard',
   useRouter: () => ({ push: jest.fn() }),
 }))
-jest.mock('@/hooks/useCurrentUser', () => ({ useCurrentUser: () => ({ usuario: null, roles: ['miembro'], loading: false }) }))
+jest.mock('@/hooks/useCurrentUser', () => ({ useCurrentUser: () => ({ usuario: null, roles: currentRoles, supportCapabilities: currentSupportCapabilities, loading: false }) }))
 jest.mock('@/hooks/useBranding', () => ({ useBranding: () => ({ logoLightUrl: null, logoDarkUrl: null }) }))
 jest.mock('@/hooks/use-notificaciones', () => ({ useNotificaciones: () => ({ info: jest.fn() }) }))
 jest.mock('@/hooks/useCampus', () => ({ useCampus: () => ({ campusActivo: null, localidadActiva: null, campusDisponibles: [], localidadesDisponibles: [], campusId: null, localidadId: null, esSuperadmin: false, loading: false, seleccionarCampus: jest.fn(), seleccionarLocalidad: jest.fn() }) }))
 jest.mock('@/lib/actions/auth.actions', () => ({ logout: jest.fn() }))
+jest.mock('next-themes', () => ({ useTheme: () => ({ theme: 'light', setTheme: jest.fn() }) }))
 
 describe('support navigation links', () => {
+  beforeEach(() => {
+    currentRoles = ['miembro']
+    currentSupportCapabilities = []
+  })
+
   it('renders the mobile bottom Ayuda item as a real /ayuda link', () => {
     render(<MenuInferiorMovil />)
 
@@ -24,5 +35,61 @@ describe('support navigation links', () => {
     render(<SidebarModerna />)
 
     expect(screen.getByRole('link', { name: 'Ayuda' })).toHaveAttribute('href', '/ayuda')
+  })
+
+  it('hides the support admin entry when the user has no support capability', () => {
+    render(<SidebarModerna />)
+
+    expect(screen.queryByRole('link', { name: 'Soporte' })).not.toBeInTheDocument()
+  })
+
+  it('shows the support admin entry in the desktop sidebar for support-capable staff', () => {
+    currentRoles = ['admin']
+    currentSupportCapabilities = ['support.view']
+
+    render(<SidebarModerna />)
+
+    expect(screen.getByRole('link', { name: 'Soporte' })).toHaveAttribute('href', '/ayuda/admin')
+  })
+
+  it('does not show support admin when capability-like strings are only present in roles', () => {
+    currentRoles = ['admin', 'support.view']
+
+    render(<SidebarModerna />)
+
+    expect(screen.queryByRole('link', { name: 'Soporte' })).not.toBeInTheDocument()
+  })
+
+  it('shows the support admin entry in the mobile drawer for support-capable staff', async () => {
+    currentRoles = ['admin']
+    currentSupportCapabilities = ['support.reply']
+
+    render(<HeaderMovil />)
+    await userEvent.click(screen.getByLabelText('Abrir menú'))
+
+    expect(screen.getByRole('link', { name: 'Soporte' })).toHaveAttribute('href', '/ayuda/admin')
+  })
+
+  it('shows the support configuration entry only for higher-role support.manage capability holders', async () => {
+    currentRoles = ['admin']
+    currentSupportCapabilities = ['support.manage']
+
+    render(<HeaderMovil />)
+    await userEvent.click(screen.getByLabelText('Abrir menú'))
+    await userEvent.click(screen.getByRole('button', { name: /Abrir Configuración/i }))
+
+    expect(screen.getAllByRole('link', { name: 'Soporte' }).map((link) => link.getAttribute('href'))).toContain('/configuracion/soporte')
+  })
+
+  it('hides the support configuration entry for pure support.manage staff without higher role context', async () => {
+    currentRoles = ['miembro']
+    currentSupportCapabilities = ['support.manage']
+
+    render(<HeaderMovil />)
+    await userEvent.click(screen.getByLabelText('Abrir menú'))
+
+    expect(screen.queryByRole('button', { name: /Abrir Configuración/i })).not.toBeInTheDocument()
+    expect(screen.getByRole('link', { name: 'Soporte' })).toHaveAttribute('href', '/ayuda/admin')
+    expect(screen.getAllByRole('link', { name: 'Soporte' }).map((link) => link.getAttribute('href'))).not.toContain('/configuracion/soporte')
   })
 })

--- a/__tests__/docs/support-operations.test.ts
+++ b/__tests__/docs/support-operations.test.ts
@@ -1,0 +1,27 @@
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
+
+describe('support operations runbook', () => {
+  const runbook = readFileSync(join(process.cwd(), 'docs', 'support-operations.md'), 'utf8')
+
+  it('documents production release gates and safe degraded behavior', () => {
+    expect(runbook).toContain('## Production Readiness Gates')
+    expect(runbook).toContain('DB gate')
+    expect(runbook).toContain('provider gate')
+    expect(runbook).toContain('environment gate')
+    expect(runbook).toContain('RLS/privacy gate')
+    expect(runbook).toContain('smoke gate')
+    expect(runbook).toContain('rollback gate')
+    expect(runbook).toContain('safe degraded')
+  })
+
+  it('requires staff-approved sanitized external escalation before outbound delivery', () => {
+    expect(runbook).toContain('staff-approved')
+    expect(runbook).toContain('sanitized external escalation')
+    expect(runbook).toContain('must not be treated as a general PII scrubber')
+  })
+
+  it('documents the external inbound support event name', () => {
+    expect(runbook).toContain('support/external.update.received')
+  })
+})

--- a/__tests__/hooks/useCurrentUser.test.tsx
+++ b/__tests__/hooks/useCurrentUser.test.tsx
@@ -1,0 +1,51 @@
+import { renderHook, waitFor } from '@testing-library/react'
+
+import { useCurrentUser } from '@/hooks/useCurrentUser'
+
+const createClient = jest.fn()
+
+jest.mock('@/lib/supabase/client', () => ({ createClient: () => createClient() }))
+
+describe('useCurrentUser', () => {
+  beforeEach(() => {
+    createClient.mockReset()
+  })
+
+  it('loads support capabilities separately from role names', async () => {
+    const user = { id: 'auth-1' }
+    const usuario = { id: 'usuario-1', auth_id: 'auth-1', nombre: 'Staff User' }
+    const rolesRpc = jest.fn().mockResolvedValue({ data: ['admin'], error: null })
+    const supportCapabilitiesQuery = {
+      select: jest.fn().mockReturnThis(),
+      eq: jest.fn().mockReturnThis(),
+      is: jest.fn().mockResolvedValue({ data: [{ capability: 'support.view' }, { capability: 'support.reply' }], error: null }),
+    }
+    const usuariosQuery = {
+      select: jest.fn().mockReturnThis(),
+      eq: jest.fn().mockReturnThis(),
+      maybeSingle: jest.fn().mockResolvedValue({ data: usuario, error: null }),
+    }
+    const client = {
+      auth: {
+        getUser: jest.fn().mockResolvedValue({ data: { user }, error: null }),
+        onAuthStateChange: jest.fn().mockReturnValue({ data: { subscription: { unsubscribe: jest.fn() } } }),
+      },
+      from: jest.fn((table: string) => {
+        if (table === 'usuarios') return usuariosQuery
+        if (table === 'support_user_capabilities') return supportCapabilitiesQuery
+        throw new Error(`Unexpected table ${table}`)
+      }),
+      rpc: rolesRpc,
+    }
+    createClient.mockReturnValue(client)
+
+    const { result } = renderHook(() => useCurrentUser())
+
+    await waitFor(() => expect(result.current.loading).toBe(false))
+    expect(result.current.roles).toEqual(['admin'])
+    expect(result.current.supportCapabilities).toEqual(['support.view', 'support.reply'])
+    expect(client.from).toHaveBeenCalledWith('support_user_capabilities')
+    expect(supportCapabilitiesQuery.eq).toHaveBeenCalledWith('usuario_id', 'usuario-1')
+    expect(supportCapabilitiesQuery.is).toHaveBeenCalledWith('revoked_at', null)
+  })
+})

--- a/__tests__/lib/actions/support-capabilities.actions.test.ts
+++ b/__tests__/lib/actions/support-capabilities.actions.test.ts
@@ -1,0 +1,118 @@
+import {
+  grantSupportCapability,
+  revokeSupportCapability,
+} from '@/lib/actions/support-capabilities.actions'
+
+const createSupabaseServerClient = jest.fn()
+const revalidatePath = jest.fn()
+
+jest.mock('@/lib/supabase/server', () => ({ createSupabaseServerClient: () => createSupabaseServerClient() }))
+jest.mock('next/cache', () => ({ revalidatePath: (path: string) => revalidatePath(path) }))
+
+describe('support capability admin actions', () => {
+  beforeEach(() => {
+    createSupabaseServerClient.mockReset()
+    revalidatePath.mockReset()
+  })
+
+  it('rejects unsupported support capabilities before invoking the audited RPC', async () => {
+    const rpc = jest.fn()
+    createSupabaseServerClient.mockResolvedValue({
+      auth: { getUser: jest.fn().mockResolvedValue({ data: { user: { id: 'auth-1' } } }) },
+      from: createStaffActionFromMock({ usuarioId: 'usuario-1', hasCapability: true }),
+      rpc,
+    })
+
+    const result = await grantSupportCapability('target-1', 'support.delete')
+
+    expect(result).toEqual({ success: false, error: 'Capacidad de soporte invalida' })
+    expect(rpc).not.toHaveBeenCalled()
+  })
+
+  it('denies capability changes without support.manage before invoking the audited RPC', async () => {
+    const rpc = jest.fn()
+    createSupabaseServerClient.mockResolvedValue({
+      auth: { getUser: jest.fn().mockResolvedValue({ data: { user: { id: 'auth-1' } } }) },
+      from: createStaffActionFromMock({ usuarioId: 'usuario-1', hasCapability: false }),
+      rpc,
+    })
+
+    const result = await grantSupportCapability('target-1', 'support.view')
+
+    expect(result).toEqual({ success: false, error: 'No autorizado' })
+    expect(rpc).not.toHaveBeenCalled()
+  })
+
+  it('denies pure support.manage staff without higher role context before invoking the audited RPC', async () => {
+    const rpc = createSupportCapabilityRpcMock(['miembro'])
+    createSupabaseServerClient.mockResolvedValue({
+      auth: { getUser: jest.fn().mockResolvedValue({ data: { user: { id: 'auth-1' } } }) },
+      from: createStaffActionFromMock({ usuarioId: 'usuario-1', hasCapability: true }),
+      rpc,
+    })
+
+    const result = await grantSupportCapability('target-1', 'support.view')
+
+    expect(result).toEqual({ success: false, error: 'No autorizado' })
+    expect(rpc).not.toHaveBeenCalledWith('grant_support_capability', expect.anything())
+  })
+
+  it('denies pure support.manage staff from revoking capabilities before invoking the audited RPC', async () => {
+    const rpc = createSupportCapabilityRpcMock(['miembro'])
+    createSupabaseServerClient.mockResolvedValue({
+      auth: { getUser: jest.fn().mockResolvedValue({ data: { user: { id: 'auth-1' } } }) },
+      from: createStaffActionFromMock({ usuarioId: 'usuario-1', hasCapability: true }),
+      rpc,
+    })
+
+    const result = await revokeSupportCapability('target-1', 'support.reply')
+
+    expect(result).toEqual({ success: false, error: 'No autorizado' })
+    expect(rpc).not.toHaveBeenCalledWith('revoke_support_capability', expect.anything())
+  })
+
+  it('grants an allowed support capability through the audited RPC', async () => {
+    const rpc = createSupportCapabilityRpcMock(['admin'])
+    createSupabaseServerClient.mockResolvedValue({
+      auth: { getUser: jest.fn().mockResolvedValue({ data: { user: { id: 'auth-1' } } }) },
+      from: createStaffActionFromMock({ usuarioId: 'usuario-1', hasCapability: true }),
+      rpc,
+    })
+
+    const result = await grantSupportCapability('target-1', 'support.reply')
+
+    expect(result).toEqual({ success: true })
+    expect(rpc).toHaveBeenCalledWith('grant_support_capability', { p_target_usuario_id: 'target-1', p_capability: 'support.reply' })
+    expect(revalidatePath).toHaveBeenCalledWith('/configuracion/soporte')
+  })
+
+  it('revokes an allowed support capability through the audited RPC', async () => {
+    const rpc = createSupportCapabilityRpcMock(['pastor'])
+    createSupabaseServerClient.mockResolvedValue({
+      auth: { getUser: jest.fn().mockResolvedValue({ data: { user: { id: 'auth-1' } } }) },
+      from: createStaffActionFromMock({ usuarioId: 'usuario-1', hasCapability: true }),
+      rpc,
+    })
+
+    const result = await revokeSupportCapability('target-1', 'support.manage')
+
+    expect(result).toEqual({ success: true })
+    expect(rpc).toHaveBeenCalledWith('revoke_support_capability', { p_target_usuario_id: 'target-1', p_capability: 'support.manage' })
+    expect(revalidatePath).toHaveBeenCalledWith('/configuracion/soporte')
+  })
+})
+
+function createStaffActionFromMock(input: { usuarioId: string; hasCapability: boolean }) {
+  return jest.fn((table) => {
+    if (table === 'usuarios') return { select: jest.fn().mockReturnValue({ eq: jest.fn().mockReturnValue({ maybeSingle: jest.fn().mockResolvedValue({ data: { id: input.usuarioId }, error: null }) }) }) }
+    if (table === 'support_user_capabilities') return { select: jest.fn().mockReturnValue({ eq: jest.fn().mockReturnValue({ eq: jest.fn().mockReturnValue({ is: jest.fn().mockReturnValue({ maybeSingle: jest.fn().mockResolvedValue({ data: input.hasCapability ? { capability: 'support.manage' } : null, error: null }) }) }) }) }) }
+    throw new Error(`Unexpected table ${table}`)
+  })
+}
+
+function createSupportCapabilityRpcMock(roles: string[]) {
+  return jest.fn((rpcName) => {
+    if (rpcName === 'obtener_roles_usuario') return Promise.resolve({ data: roles, error: null })
+    return Promise.resolve({ error: null })
+  })
+}

--- a/__tests__/lib/actions/support.actions.test.ts
+++ b/__tests__/lib/actions/support.actions.test.ts
@@ -9,16 +9,28 @@ import {
   updateSupportTicketStatus,
 } from '@/lib/actions/support.actions'
 import { sanitizeSupportEvidence } from '@/lib/support/support-evidence'
+import { dispatchSupportInngestEvent } from '@/lib/support/inngest'
 
 const createSupabaseServerClient = jest.fn()
 const revalidatePath = jest.fn()
 
 jest.mock('@/lib/supabase/server', () => ({ createSupabaseServerClient: () => createSupabaseServerClient() }))
 jest.mock('next/cache', () => ({ revalidatePath: (path: string) => revalidatePath(path) }))
+jest.mock('@/lib/support/inngest', () => ({
+  createSupportTicketCreatedEvent: (payload: { eventId: string; ticketId: string; actorUserId?: string }) => ({
+    name: 'support/ticket.created',
+    id: `support:${payload.eventId}`,
+    data: payload,
+  }),
+  dispatchSupportInngestEvent: jest.fn(),
+}))
+
+const dispatchSupportInngestEventMock = jest.mocked(dispatchSupportInngestEvent)
 
 describe('support reporter actions', () => {
   beforeEach(() => {
     createSupabaseServerClient.mockReset()
+    dispatchSupportInngestEventMock.mockReset()
     revalidatePath.mockReset()
   })
 
@@ -65,6 +77,25 @@ describe('support reporter actions', () => {
     })
   })
 
+  it('captures safe diagnostics by default', () => {
+    expect(sanitizeSupportEvidence({
+      currentRoute: '/dashboard?token=secret#section',
+      browserName: 'Chrome',
+      osName: 'macOS',
+      viewport: '1440x900',
+      appBuildVersion: 'build-123',
+      sentryEventId: 'event-1',
+    })).toEqual({
+      current_route: '/dashboard',
+      browser_name: 'Chrome',
+      os_name: 'macOS',
+      viewport: '1440x900',
+      app_build_version: 'build-123',
+      sentry_event_id: 'event-1',
+      diagnostics_consent: true,
+    })
+  })
+
   it('rejects anonymous ticket creation before inserting', async () => {
     const insert = jest.fn()
     createSupabaseServerClient.mockResolvedValue({
@@ -92,10 +123,38 @@ describe('support reporter actions', () => {
       reporter_usuario_id: 'usuario-1',
       status: 'received',
       title: 'Cannot open group map',
+      severity: 'normal',
       diagnostics_consent: true,
     }))
     expect(insert.mock.calls[0][0]).not.toHaveProperty('cookies')
     expect(revalidatePath).toHaveBeenCalledWith('/ayuda/tickets')
+  })
+
+  it('audits reporter ticket creation and dispatches an ID-only ticket-created event after commit', async () => {
+    dispatchSupportInngestEventMock.mockResolvedValue({ success: true, skipped: true, reason: 'Provider not configured' })
+    const ticketInsert = jest.fn().mockReturnValue({ select: jest.fn().mockReturnValue({ single: jest.fn().mockResolvedValue({ data: { id: 'ticket-1', ticket_number: 42 }, error: null }) }) })
+    const eventInsert = jest.fn().mockReturnValue({ select: jest.fn().mockReturnValue({ single: jest.fn().mockResolvedValue({ data: { id: 'event-1' }, error: null }) }) })
+    createSupabaseServerClient.mockResolvedValue({
+      auth: { getUser: jest.fn().mockResolvedValue({ data: { user: { id: 'auth-1' } } }) },
+      from: createReporterMutationFromMock({ usuarioId: 'usuario-1', ticketInsert, eventInsert }),
+    })
+
+    const result = await createSupportTicket(createTicketFormData())
+
+    expect(result).toEqual({ success: true, ticketId: 'ticket-1', ticketNumber: 42 })
+    expect(eventInsert).toHaveBeenCalledWith({
+      ticket_id: 'ticket-1',
+      actor_usuario_id: 'usuario-1',
+      action: 'support.ticket.created',
+      target_type: 'support_ticket',
+      target_id: 'ticket-1',
+      metadata: { source: 'reporter' },
+    })
+    expect(dispatchSupportInngestEventMock).toHaveBeenCalledWith({
+      name: 'support/ticket.created',
+      id: 'support:event-1',
+      data: { eventId: 'event-1', ticketId: 'ticket-1', actorUserId: 'usuario-1' },
+    })
   })
 
   it('lists only public reporter fields from RLS-filtered tickets', async () => {
@@ -107,23 +166,42 @@ describe('support reporter actions', () => {
     await expect(listSupportTickets()).resolves.toEqual({ success: true, tickets: [{ id: 'ticket-1', ticketNumber: 42, title: 'Map bug', status: 'received', category: 'bug', severity: 'normal', createdAt: '2026-06-09T00:00:00Z', updatedAt: '2026-06-09T00:00:00Z' }] })
   })
 
-  it('returns ticket detail with public messages and no internal evidence', async () => {
-    const ticketQuery = { select: jest.fn().mockReturnValue({ eq: jest.fn().mockReturnValue({ maybeSingle: jest.fn().mockResolvedValue({ data: { id: 'ticket-1', ticket_number: 42, title: 'Map bug', description: 'Steps', status: 'received', category: 'bug', severity: 'normal', current_route: '/dashboard', browser_name: 'Chrome', os_name: 'macOS', viewport: '1440x900', app_build_version: 'build-123', sentry_event_id: 'event-1', diagnostics_consent: true, created_at: '2026-06-09T00:00:00Z', updated_at: '2026-06-09T00:00:00Z' }, error: null }) }) }) }
+  it('returns ticket detail with public messages, safe attachments, and no internal evidence', async () => {
+    const ticketQuery = { select: jest.fn().mockReturnValue({ eq: jest.fn().mockReturnValue({ maybeSingle: jest.fn().mockResolvedValue({ data: { id: 'ticket-1', ticket_number: 42, title: 'Map bug', description: 'Steps', status: 'received', category: 'bug', severity: 'normal', assignee_usuario_id: null, current_route: '/dashboard', browser_name: 'Chrome', os_name: 'macOS', viewport: '1440x900', app_build_version: 'build-123', sentry_event_id: 'event-1', diagnostics_consent: true, created_at: '2026-06-09T00:00:00Z', updated_at: '2026-06-09T00:00:00Z' }, error: null }) }) }) }
     const messagesFilter = { eq: jest.fn(), order: jest.fn().mockResolvedValue({ data: [{ id: 'message-1', body: 'Public reply', is_internal: false, created_at: '2026-06-09T00:01:00Z' }], error: null }) }
     messagesFilter.eq.mockReturnValue(messagesFilter)
     const messagesQuery = { select: jest.fn().mockReturnValue(messagesFilter) }
+    const attachmentsFilter = { eq: jest.fn(), order: jest.fn().mockResolvedValue({ data: [{ id: 'attachment-1', original_filename: 'map-error.webp', kind: 'screenshot', content_type: 'image/webp', byte_size: 2048, status: 'uploaded', object_key: 'support/ticket-1/attachment-1/map-error.webp' }], error: null }) }
+    attachmentsFilter.eq.mockReturnValue(attachmentsFilter)
+    const attachmentsQuery = { select: jest.fn().mockReturnValue(attachmentsFilter) }
+    const capabilitiesFilter = { eq: jest.fn(), is: jest.fn().mockResolvedValue({ data: [], error: null }) }
+    capabilitiesFilter.eq.mockReturnValue(capabilitiesFilter)
+    const capabilitiesQuery = { select: jest.fn().mockReturnValue(capabilitiesFilter) }
     createSupabaseServerClient.mockResolvedValue({
       auth: { getUser: jest.fn().mockResolvedValue({ data: { user: { id: 'auth-1' } } }) },
-      from: jest.fn((table) => table === 'support_tickets' ? ticketQuery : messagesQuery),
+      from: jest.fn((table) => {
+        if (table === 'usuarios') return { select: jest.fn().mockReturnValue({ eq: jest.fn().mockReturnValue({ maybeSingle: jest.fn().mockResolvedValue({ data: { id: 'usuario-1' }, error: null }) }) }) }
+        if (table === 'support_tickets') return ticketQuery
+        if (table === 'support_ticket_messages') return messagesQuery
+        if (table === 'support_user_capabilities') return capabilitiesQuery
+        return attachmentsQuery
+      }),
     })
 
     const result = await getSupportTicketDetail('ticket-1')
 
     expect(result.success).toBe(true)
     expect(result.ticket?.messages).toEqual([{ id: 'message-1', body: 'Public reply', createdAt: '2026-06-09T00:01:00Z' }])
+    expect(result.ticket?.attachments).toEqual([{ id: 'attachment-1', filename: 'map-error.webp', kind: 'screenshot', contentType: 'image/webp', byteSize: 2048, status: 'uploaded' }])
+    expect(result.ticket?.assigneeUsuarioId).toBeNull()
+    expect(result.ticket?.supportCapabilities).toEqual([])
+    expect(result.ticket?.attachments[0]).not.toHaveProperty('objectKey')
+    expect(result.ticket?.attachments[0]).not.toHaveProperty('downloadUrl')
     expect(result.ticket).not.toHaveProperty('rawSentryPayload')
     expect(messagesFilter.eq).toHaveBeenCalledWith('ticket_id', 'ticket-1')
     expect(messagesFilter.eq).toHaveBeenCalledWith('is_internal', false)
+    expect(attachmentsQuery.select).toHaveBeenCalledWith('id,original_filename,kind,content_type,byte_size,status')
+    expect(attachmentsFilter.eq).toHaveBeenCalledWith('ticket_id', 'ticket-1')
   })
 
   it('maps Supabase list errors to a stable user-safe message', async () => {
@@ -149,11 +227,32 @@ describe('support reporter actions', () => {
     expect(revalidatePath).toHaveBeenCalledWith('/ayuda/tickets/ticket-1')
   })
 
-  it('denies staff queue access without support.view', async () => {
+  it('audits reporter public replies after the message commit', async () => {
+    const messageInsert = jest.fn().mockReturnValue({ select: jest.fn().mockReturnValue({ single: jest.fn().mockResolvedValue({ data: { id: 'message-1' }, error: null }) }) })
+    const eventInsert = jest.fn().mockResolvedValue({ error: null })
+    createSupabaseServerClient.mockResolvedValue({
+      auth: { getUser: jest.fn().mockResolvedValue({ data: { user: { id: 'auth-1' } } }) },
+      from: createReporterMutationFromMock({ usuarioId: 'usuario-1', messageInsert, eventInsert }),
+    })
+
+    const result = await createSupportTicketMessage('ticket-1', createMessageFormData())
+
+    expect(result).toEqual({ success: true })
+    expect(eventInsert).toHaveBeenCalledWith({
+      ticket_id: 'ticket-1',
+      actor_usuario_id: 'usuario-1',
+      action: 'support.reporter_message.created',
+      target_type: 'support_ticket_message',
+      target_id: 'message-1',
+      metadata: { source: 'reporter' },
+    })
+  })
+
+  it('denies staff queue access without support.view-equivalent capability', async () => {
     const supportTicketsQuery = createStaffTicketQuery([])
     createSupabaseServerClient.mockResolvedValue({
       auth: { getUser: jest.fn().mockResolvedValue({ data: { user: { id: 'auth-1' } } }) },
-      from: createStaffFromMock({ usuarioId: 'usuario-1', hasCapability: false, supportTicketsQuery }),
+      from: createStaffFromMock({ usuarioId: 'usuario-1', supportCapabilities: [], supportTicketsQuery }),
     })
 
     const result = await listStaffSupportTickets({})
@@ -166,12 +265,12 @@ describe('support reporter actions', () => {
     const supportTicketsQuery = createStaffTicketQuery([{ id: 'ticket-2', ticket_number: 43, title: 'Cannot submit attendance', status: 'in_progress', category: 'bug', severity: 'high', assignee_usuario_id: 'assignee-1', campus_id: 'campus-1', created_at: '2026-06-10T00:00:00Z', updated_at: '2026-06-10T00:05:00Z' }])
     createSupabaseServerClient.mockResolvedValue({
       auth: { getUser: jest.fn().mockResolvedValue({ data: { user: { id: 'auth-1' } } }) },
-      from: createStaffFromMock({ usuarioId: 'usuario-1', hasCapability: true, supportTicketsQuery }),
+      from: createStaffFromMock({ usuarioId: 'usuario-1', supportCapabilities: ['support.view'], supportTicketsQuery }),
     })
 
     const result = await listStaffSupportTickets({ search: 'attendance', status: 'in_progress', category: 'bug', campusId: 'campus-1', assigneeId: 'assignee-1' })
 
-    expect(result).toEqual({ success: true, tickets: [{ id: 'ticket-2', ticketNumber: 43, title: 'Cannot submit attendance', status: 'in_progress', category: 'bug', severity: 'high', assigneeUsuarioId: 'assignee-1', campusId: 'campus-1', createdAt: '2026-06-10T00:00:00Z', updatedAt: '2026-06-10T00:05:00Z' }] })
+    expect(result).toEqual({ success: true, supportCapabilities: ['support.view'], tickets: [{ id: 'ticket-2', ticketNumber: 43, title: 'Cannot submit attendance', status: 'in_progress', category: 'bug', severity: 'high', assigneeUsuarioId: 'assignee-1', campusId: 'campus-1', createdAt: '2026-06-10T00:00:00Z', updatedAt: '2026-06-10T00:05:00Z' }] })
     expect(supportTicketsQuery.textSearch).toHaveBeenCalledWith('search_vector', 'attendance', { type: 'plain', config: 'simple' })
     expect(supportTicketsQuery.eq).toHaveBeenCalledWith('status', 'in_progress')
     expect(supportTicketsQuery.eq).toHaveBeenCalledWith('category', 'bug')
@@ -185,10 +284,36 @@ describe('support reporter actions', () => {
     const supportTicketsQuery = createStaffTicketQuery([], { message: 'permission denied for table support_tickets' })
     createSupabaseServerClient.mockResolvedValue({
       auth: { getUser: jest.fn().mockResolvedValue({ data: { user: { id: 'auth-1' } } }) },
-      from: createStaffFromMock({ usuarioId: 'usuario-1', hasCapability: true, supportTicketsQuery }),
+      from: createStaffFromMock({ usuarioId: 'usuario-1', supportCapabilities: ['support.view'], supportTicketsQuery }),
     })
 
     await expect(listStaffSupportTickets({})).resolves.toEqual({ success: false, error: 'No se pudo cargar la cola de soporte', tickets: [] })
+  })
+
+  it('allows pure support.reply staff to load the staff queue', async () => {
+    const supportTicketsQuery = createStaffTicketQuery([{ id: 'ticket-2', ticket_number: 43, title: 'Cannot submit attendance', status: 'in_progress', category: 'bug', severity: 'high', assignee_usuario_id: null, campus_id: null, created_at: '2026-06-10T00:00:00Z', updated_at: '2026-06-10T00:05:00Z' }])
+    createSupabaseServerClient.mockResolvedValue({
+      auth: { getUser: jest.fn().mockResolvedValue({ data: { user: { id: 'auth-1' } } }) },
+      from: createStaffFromMock({ usuarioId: 'usuario-1', supportCapabilities: ['support.reply'], supportTicketsQuery }),
+    })
+
+    const result = await listStaffSupportTickets({})
+
+    expect(result).toEqual({ success: true, supportCapabilities: ['support.reply'], tickets: [{ id: 'ticket-2', ticketNumber: 43, title: 'Cannot submit attendance', status: 'in_progress', category: 'bug', severity: 'high', assigneeUsuarioId: null, campusId: null, createdAt: '2026-06-10T00:00:00Z', updatedAt: '2026-06-10T00:05:00Z' }] })
+    expect(supportTicketsQuery.select).toHaveBeenCalled()
+  })
+
+  it('allows pure support.manage staff to load and manage the staff queue', async () => {
+    const supportTicketsQuery = createStaffTicketQuery([{ id: 'ticket-3', ticket_number: 44, title: 'Cannot access admin queue', status: 'received', category: 'access', severity: 'normal', assignee_usuario_id: null, campus_id: null, created_at: '2026-06-10T01:00:00Z', updated_at: '2026-06-10T01:05:00Z' }])
+    createSupabaseServerClient.mockResolvedValue({
+      auth: { getUser: jest.fn().mockResolvedValue({ data: { user: { id: 'auth-1' } } }) },
+      from: createStaffFromMock({ usuarioId: 'usuario-1', supportCapabilities: ['support.manage'], supportTicketsQuery }),
+    })
+
+    const result = await listStaffSupportTickets({})
+
+    expect(result).toEqual({ success: true, supportCapabilities: ['support.manage'], tickets: [{ id: 'ticket-3', ticketNumber: 44, title: 'Cannot access admin queue', status: 'received', category: 'access', severity: 'normal', assigneeUsuarioId: null, campusId: null, createdAt: '2026-06-10T01:00:00Z', updatedAt: '2026-06-10T01:05:00Z' }] })
+    expect(supportTicketsQuery.select).toHaveBeenCalled()
   })
 
   it('denies direct staff replies without support.reply before invoking the atomic RPC', async () => {
@@ -279,10 +404,9 @@ describe('support reporter actions', () => {
 
 function createTicketFormData() {
   const formData = new FormData()
-  formData.set('title', 'Cannot open group map')
+  formData.set('subject', 'Cannot open group map')
   formData.set('description', 'The map stays blank after I open the dashboard.')
   formData.set('category', 'bug')
-  formData.set('severity', 'normal')
   formData.set('currentRoute', '/dashboard')
   formData.set('browserName', 'Chrome')
   formData.set('osName', 'macOS')
@@ -308,12 +432,42 @@ function createFromMock(input: { usuarioId: string; insert: jest.Mock }) {
   })
 }
 
-function createStaffFromMock(input: { usuarioId: string; hasCapability: boolean; supportTicketsQuery: ReturnType<typeof createStaffTicketQuery> }) {
+function createReporterMutationFromMock(input: { usuarioId: string; ticketInsert?: jest.Mock; messageInsert?: jest.Mock; eventInsert: jest.Mock }) {
   return jest.fn((table) => {
     if (table === 'usuarios') return { select: jest.fn().mockReturnValue({ eq: jest.fn().mockReturnValue({ maybeSingle: jest.fn().mockResolvedValue({ data: { id: input.usuarioId }, error: null }) }) }) }
-    if (table === 'support_user_capabilities') return { select: jest.fn().mockReturnValue({ eq: jest.fn().mockReturnValue({ eq: jest.fn().mockReturnValue({ is: jest.fn().mockReturnValue({ maybeSingle: jest.fn().mockResolvedValue({ data: input.hasCapability ? { capability: 'support.view' } : null, error: null }) }) }) }) }) }
+    if (table === 'support_tickets') return { insert: input.ticketInsert }
+    if (table === 'support_ticket_messages') return { insert: input.messageInsert }
+    if (table === 'support_ticket_events') return { insert: input.eventInsert }
+    throw new Error(`Unexpected table ${table}`)
+  })
+}
+
+function createStaffFromMock(input: { usuarioId: string; supportCapabilities: string[]; supportTicketsQuery: ReturnType<typeof createStaffTicketQuery> }) {
+  return jest.fn((table) => {
+    if (table === 'usuarios') return { select: jest.fn().mockReturnValue({ eq: jest.fn().mockReturnValue({ maybeSingle: jest.fn().mockResolvedValue({ data: { id: input.usuarioId }, error: null }) }) }) }
+    if (table === 'support_user_capabilities') return createSupportCapabilityQuery(input.supportCapabilities)
     return input.supportTicketsQuery
   })
+}
+
+function createSupportCapabilityQuery(supportCapabilities: string[]) {
+  let requestedCapability: string | null = null
+  const query = {
+    select: jest.fn().mockReturnThis(),
+    eq: jest.fn().mockImplementation((column: string, value: string) => {
+      if (column === 'capability') requestedCapability = value
+      return query
+    }),
+    is: jest.fn().mockImplementation(() => {
+      if (requestedCapability) {
+        return { maybeSingle: jest.fn().mockResolvedValue({ data: supportCapabilities.includes(requestedCapability) ? { capability: requestedCapability } : null, error: null }) }
+      }
+
+      return Promise.resolve({ data: supportCapabilities.map((capability) => ({ capability })), error: null })
+    }),
+  }
+
+  return query
 }
 
 function createStaffTicketQuery(rows: Array<Record<string, string | number | null>>, error: { message: string } | null = null) {
@@ -334,7 +488,7 @@ function createStaffTicketQuery(rows: Array<Record<string, string | number | nul
 function createStaffActionFromMock(input: { usuarioId: string; hasCapability: boolean; capability?: string }) {
   return jest.fn((table) => {
     if (table === 'usuarios') return { select: jest.fn().mockReturnValue({ eq: jest.fn().mockReturnValue({ maybeSingle: jest.fn().mockResolvedValue({ data: { id: input.usuarioId }, error: null }) }) }) }
-    if (table === 'support_user_capabilities') return { select: jest.fn().mockReturnValue({ eq: jest.fn().mockReturnValue({ eq: jest.fn().mockReturnValue({ is: jest.fn().mockReturnValue({ maybeSingle: jest.fn().mockResolvedValue({ data: input.hasCapability ? { capability: input.capability } : null, error: null }) }) }) }) }) }
+    if (table === 'support_user_capabilities') return createSupportCapabilityQuery(input.hasCapability ? [input.capability ?? 'support.view'] : [])
     throw new Error(`Unexpected table ${table}`)
   })
 }

--- a/__tests__/lib/actions/support.actions.test.ts
+++ b/__tests__/lib/actions/support.actions.test.ts
@@ -348,6 +348,33 @@ describe('support reporter actions', () => {
     expect(revalidatePath).toHaveBeenCalledWith('/ayuda/admin')
   })
 
+  it('assigns an unassigned ticket to the managing staff responder after replying', async () => {
+    const rpc = jest.fn().mockResolvedValue({ error: null })
+    createSupabaseServerClient.mockResolvedValue({
+      auth: { getUser: jest.fn().mockResolvedValue({ data: { user: { id: 'auth-1' } } }) },
+      from: createStaffActionFromMock({ usuarioId: 'usuario-1', hasCapability: true, capability: 'support.manage' }),
+      rpc,
+    })
+
+    const result = await createStaffSupportTicketReply('ticket-1', createMessageFormData(), { autoAssignIfUnassigned: true })
+
+    expect(result).toEqual({ success: true })
+    expect(rpc).toHaveBeenCalledWith('create_staff_support_ticket_reply', { p_ticket_id: 'ticket-1', p_body: 'I can reproduce it on mobile.' })
+    expect(rpc).toHaveBeenCalledWith('auto_assign_support_ticket_if_unassigned', { p_ticket_id: 'ticket-1' })
+  })
+
+  it('keeps staff replies successful when best-effort auto-assignment fails', async () => {
+    const rpc = jest.fn((functionName: string) => Promise.resolve({ error: functionName === 'auto_assign_support_ticket_if_unassigned' ? { message: 'assignment failed' } : null }))
+    createSupabaseServerClient.mockResolvedValue({
+      auth: { getUser: jest.fn().mockResolvedValue({ data: { user: { id: 'auth-1' } } }) },
+      from: createStaffActionFromMock({ usuarioId: 'usuario-1', hasCapability: true, capability: 'support.manage' }),
+      rpc,
+    })
+
+    await expect(createStaffSupportTicketReply('ticket-1', createMessageFormData(), { autoAssignIfUnassigned: true })).resolves.toEqual({ success: true })
+    expect(rpc).toHaveBeenCalledWith('auto_assign_support_ticket_if_unassigned', { p_ticket_id: 'ticket-1' })
+  })
+
   it('assigns a support ticket through the atomic audit RPC', async () => {
     const rpc = jest.fn().mockResolvedValue({ error: null })
     createSupabaseServerClient.mockResolvedValue({

--- a/__tests__/lib/actions/support.actions.test.ts
+++ b/__tests__/lib/actions/support.actions.test.ts
@@ -167,8 +167,8 @@ describe('support reporter actions', () => {
   })
 
   it('returns ticket detail with public messages, safe attachments, and no internal evidence', async () => {
-    const ticketQuery = { select: jest.fn().mockReturnValue({ eq: jest.fn().mockReturnValue({ maybeSingle: jest.fn().mockResolvedValue({ data: { id: 'ticket-1', ticket_number: 42, title: 'Map bug', description: 'Steps', status: 'received', category: 'bug', severity: 'normal', assignee_usuario_id: null, current_route: '/dashboard', browser_name: 'Chrome', os_name: 'macOS', viewport: '1440x900', app_build_version: 'build-123', sentry_event_id: 'event-1', diagnostics_consent: true, created_at: '2026-06-09T00:00:00Z', updated_at: '2026-06-09T00:00:00Z' }, error: null }) }) }) }
-    const messagesFilter = { eq: jest.fn(), order: jest.fn().mockResolvedValue({ data: [{ id: 'message-1', body: 'Public reply', is_internal: false, created_at: '2026-06-09T00:01:00Z' }], error: null }) }
+    const ticketQuery = { select: jest.fn().mockReturnValue({ eq: jest.fn().mockReturnValue({ maybeSingle: jest.fn().mockResolvedValue({ data: { id: 'ticket-1', ticket_number: 42, title: 'Map bug', description: 'Steps', status: 'received', category: 'bug', severity: 'normal', reporter_usuario_id: 'usuario-1', assignee_usuario_id: null, reporter: { id: 'usuario-1', nombre: 'Ana', apellido: 'Pérez', foto_perfil_url: null }, assignee: null, current_route: '/dashboard', browser_name: 'Chrome', os_name: 'macOS', viewport: '1440x900', app_build_version: 'build-123', sentry_event_id: 'event-1', diagnostics_consent: true, created_at: '2026-06-09T00:00:00Z', updated_at: '2026-06-09T00:00:00Z' }, error: null }) }) }) }
+    const messagesFilter = { eq: jest.fn(), order: jest.fn().mockResolvedValue({ data: [{ id: 'message-1', body: 'Public reply', author_usuario_id: 'usuario-1', author: { id: 'usuario-1', nombre: 'Ana', apellido: 'Pérez', foto_perfil_url: null }, is_internal: false, created_at: '2026-06-09T00:01:00Z' }], error: null }) }
     messagesFilter.eq.mockReturnValue(messagesFilter)
     const messagesQuery = { select: jest.fn().mockReturnValue(messagesFilter) }
     const attachmentsFilter = { eq: jest.fn(), order: jest.fn().mockResolvedValue({ data: [{ id: 'attachment-1', original_filename: 'map-error.webp', kind: 'screenshot', content_type: 'image/webp', byte_size: 2048, status: 'uploaded', object_key: 'support/ticket-1/attachment-1/map-error.webp' }], error: null }) }
@@ -191,8 +191,9 @@ describe('support reporter actions', () => {
     const result = await getSupportTicketDetail('ticket-1')
 
     expect(result.success).toBe(true)
-    expect(result.ticket?.messages).toEqual([{ id: 'message-1', body: 'Public reply', createdAt: '2026-06-09T00:01:00Z' }])
+    expect(result.ticket?.messages).toEqual([{ id: 'message-1', body: 'Public reply', authorUsuarioId: 'usuario-1', author: { id: 'usuario-1', nombre: 'Ana', apellido: 'Pérez', photoUrl: null }, createdAt: '2026-06-09T00:01:00Z' }])
     expect(result.ticket?.attachments).toEqual([{ id: 'attachment-1', filename: 'map-error.webp', kind: 'screenshot', contentType: 'image/webp', byteSize: 2048, status: 'uploaded' }])
+    expect(result.ticket?.reporter).toEqual({ id: 'usuario-1', nombre: 'Ana', apellido: 'Pérez', photoUrl: null })
     expect(result.ticket?.assigneeUsuarioId).toBeNull()
     expect(result.ticket?.supportCapabilities).toEqual([])
     expect(result.ticket?.attachments[0]).not.toHaveProperty('objectKey')
@@ -202,6 +203,7 @@ describe('support reporter actions', () => {
     expect(messagesFilter.eq).toHaveBeenCalledWith('is_internal', false)
     expect(attachmentsQuery.select).toHaveBeenCalledWith('id,original_filename,kind,content_type,byte_size,status')
     expect(attachmentsFilter.eq).toHaveBeenCalledWith('ticket_id', 'ticket-1')
+    expect(attachmentsFilter.eq).toHaveBeenCalledWith('status', 'uploaded')
   })
 
   it('maps Supabase list errors to a stable user-safe message', async () => {

--- a/__tests__/lib/support/external-bridge.test.ts
+++ b/__tests__/lib/support/external-bridge.test.ts
@@ -1,0 +1,86 @@
+import {
+  createExternalEscalationPayload,
+  processExternalBridgeInboundUpdate,
+  sanitizeExternalBridgeMessage,
+  verifyExternalBridgeAuthorization,
+} from '@/lib/support/external-bridge'
+
+describe('support external bridge', () => {
+  it('creates sanitized outbound escalation payloads without diagnostics, attachments, signed URLs, object keys, or GitHub sync fields', () => {
+    const payload = createExternalEscalationPayload({
+      ticketId: 'ticket-1',
+      ticketNumber: 42,
+      title: 'Map fails after login',
+      summary: 'Steps: open map, receive 500. token=secret should be removed.',
+      recipient: 'engineering-escalation',
+      diagnostics: { browser: 'Chrome', localStorage: 'secret' },
+      attachments: [{ objectKey: 'support/ticket-1/attachment-1/file.png', signedUrl: 'https://r2.test/private?signature=secret' }],
+      githubIssueUrl: 'https://github.com/org/repo/issues/1',
+    })
+
+    expect(payload).toEqual({
+      ticketId: 'ticket-1',
+      ticketNumber: 42,
+      title: 'Map fails after login',
+      summary: 'Steps: open map, receive 500. [redacted] should be removed.',
+      recipient: 'engineering-escalation',
+      internalTicketUrl: '/ayuda/tickets/ticket-1',
+    })
+    expect(JSON.stringify(payload)).not.toMatch(/diagnostics|attachment|objectKey|signedUrl|support\/ticket-1|signature=secret|github|token=secret|Chrome|localStorage/i)
+  })
+
+  it('authenticates inbound updates with a constant bearer token comparison', () => {
+    expect(verifyExternalBridgeAuthorization('Bearer bridge-secret', 'bridge-secret')).toBe(true)
+    expect(verifyExternalBridgeAuthorization('Bearer wrong-secret', 'bridge-secret')).toBe(false)
+    expect(verifyExternalBridgeAuthorization(null, 'bridge-secret')).toBe(false)
+  })
+
+  it('sanitizes inbound messages before storage', () => {
+    expect(sanitizeExternalBridgeMessage('Vendor replied with https://r2.test/private?signature=secret and token=secret')).toBe(
+      'Vendor replied with [redacted-url] and [redacted]'
+    )
+  })
+
+  it('stores authenticated inbound updates once through an atomic persistence boundary', async () => {
+    const persistInboundUpdate = jest.fn().mockResolvedValue({ duplicate: false, eventId: 'event-1', messageId: 'message-1' })
+
+    const result = await processExternalBridgeInboundUpdate({
+      authorizationHeader: 'Bearer bridge-secret',
+      expectedToken: 'bridge-secret',
+      authorUsuarioId: '00000000-0000-0000-0000-000000000001',
+      body: {
+        ticketId: '11111111-1111-1111-1111-111111111111',
+        idempotencyKey: 'external-update-1',
+        message: 'Vendor fixed the upstream data mapping. signedUrl=https://r2.test/private?signature=secret',
+      },
+      persistInboundUpdate,
+    })
+
+    expect(result).toEqual({ success: true, duplicate: false, messageId: 'message-1', eventId: 'event-1' })
+    expect(persistInboundUpdate).toHaveBeenCalledWith(expect.objectContaining({
+      ticketId: '11111111-1111-1111-1111-111111111111',
+      idempotencyKey: 'external-update-1',
+      action: 'external.update.received',
+      body: 'Vendor fixed the upstream data mapping. [redacted]',
+      isInternal: false,
+    }))
+  })
+
+  it('prevents duplicate inbound updates by idempotency key without inserting another message', async () => {
+    const persistInboundUpdate = jest.fn().mockResolvedValue({ duplicate: true, eventId: 'event-1' })
+    const result = await processExternalBridgeInboundUpdate({
+      authorizationHeader: 'Bearer bridge-secret',
+      expectedToken: 'bridge-secret',
+      authorUsuarioId: '00000000-0000-0000-0000-000000000001',
+      body: {
+        ticketId: '11111111-1111-1111-1111-111111111111',
+        idempotencyKey: 'external-update-1',
+        message: 'Duplicate update',
+      },
+      persistInboundUpdate,
+    })
+
+    expect(result).toEqual({ success: true, duplicate: true, eventId: 'event-1' })
+    expect(persistInboundUpdate).toHaveBeenCalledTimes(1)
+  })
+})

--- a/__tests__/lib/support/inngest.test.ts
+++ b/__tests__/lib/support/inngest.test.ts
@@ -2,9 +2,12 @@ import {
   SUPPORT_INNGEST_EVENTS,
   createSupportAttachmentFinalizedEvent,
   createSupportEmailIdempotencyKey,
+  createSupportExternalUpdateReceivedEvent,
   createSupportTicketCreatedEvent,
   createSupportTicketMessageCreatedEvent,
   createSupportTicketStatusChangedEvent,
+  deliverSupportNotificationEvent,
+  dispatchSupportInngestEvent,
   sendSupportNotificationEmails,
   sendSupportNotificationEmail,
 } from '@/lib/support/inngest'
@@ -61,11 +64,19 @@ describe('support Inngest events', () => {
       actorUserId: 'user-4',
       r2ObjectKey: 'support/ticket-1/attachment-1/file.png',
     }
+    const externalUpdateInput = {
+      eventId: 'event-external-1',
+      ticketId: 'ticket-1',
+      actorUserId: 'user-5',
+      externalMessage: 'Private external details must not enter the payload',
+      externalSystemUrl: 'https://vendor.test/tickets/123',
+    }
 
     const ticketCreated = createSupportTicketCreatedEvent(ticketCreatedInput)
     const messageCreated = createSupportTicketMessageCreatedEvent(messageCreatedInput)
     const statusChanged = createSupportTicketStatusChangedEvent(statusChangedInput)
     const attachmentFinalized = createSupportAttachmentFinalizedEvent(attachmentFinalizedInput)
+    const externalUpdate = createSupportExternalUpdateReceivedEvent(externalUpdateInput)
 
     expect(ticketCreated).toEqual({
       name: SUPPORT_INNGEST_EVENTS.ticketCreated,
@@ -85,9 +96,14 @@ describe('support Inngest events', () => {
       attachmentId: 'attachment-1',
       actorUserId: 'user-4',
     })
+    expect(externalUpdate).toEqual({
+      name: SUPPORT_INNGEST_EVENTS.externalUpdateReceived,
+      id: 'support:event-external-1',
+      data: { eventId: 'event-external-1', ticketId: 'ticket-1', actorUserId: 'user-5' },
+    })
 
-    const queuedPayload = JSON.stringify([ticketCreated, messageCreated, statusChanged, attachmentFinalized])
-    expect(queuedPayload).not.toMatch(/Unsafe text|rawSentry|secret|attachmentKey|r2ObjectKey|support\/ticket-1|github|messageBody|Resolved/i)
+    const queuedPayload = JSON.stringify([ticketCreated, messageCreated, statusChanged, attachmentFinalized, externalUpdate])
+    expect(queuedPayload).not.toMatch(/Unsafe text|rawSentry|secret|attachmentKey|r2ObjectKey|support\/ticket-1|github|messageBody|Resolved|Private external|vendor\.test/i)
   })
 
   it('creates one deterministic email idempotency key per event and normalized recipient', () => {
@@ -210,4 +226,91 @@ describe('support Inngest events', () => {
     expect(messageEmailMock).not.toHaveBeenCalled()
     expect(statusEmailMock).not.toHaveBeenCalled()
   })
+
+  it('does not send email for external update events because inbound updates are audited in-app', async () => {
+    const result = await sendSupportNotificationEmail(
+      createSupportExternalUpdateReceivedEvent({ eventId: 'event-external', ticketId: 'ticket-1' }),
+      {
+        recipientEmail: 'reporter@example.com',
+        ticketId: 'ticket-1',
+        ticketNumber: 42,
+        title: 'External bridge update',
+        status: 'in_review',
+      }
+    )
+
+    expect(result).toEqual({ success: true, skipped: true, reason: 'No support email for support/external.update.received' })
+    expect(createdEmailMock).not.toHaveBeenCalled()
+    expect(messageEmailMock).not.toHaveBeenCalled()
+    expect(statusEmailMock).not.toHaveBeenCalled()
+  })
+
+  it('dispatches support events to a configured provider endpoint without sending when the provider is disabled', async () => {
+    const fetchMock = jest.fn()
+    const event = createSupportTicketCreatedEvent({ eventId: 'event-created', ticketId: 'ticket-1', actorUserId: 'user-1' })
+
+    await expect(dispatchSupportInngestEvent(event, { fetch: fetchMock, endpoint: '', secret: '' })).resolves.toEqual({ success: true, skipped: true, reason: 'Support event provider not configured' })
+    expect(fetchMock).not.toHaveBeenCalled()
+
+    fetchMock.mockResolvedValue({ ok: true, status: 202 })
+    await expect(dispatchSupportInngestEvent(event, { fetch: fetchMock, endpoint: 'https://events.example.test/api/inngest', secret: 'secret-1' })).resolves.toEqual({ success: true, status: 202 })
+    expect(fetchMock).toHaveBeenCalledWith('https://events.example.test/api/inngest', {
+      method: 'POST',
+      headers: { authorization: 'Bearer secret-1', 'content-type': 'application/json' },
+      body: JSON.stringify(event),
+    })
+  })
+
+  it('loads all active support staff recipients and sends one safe ticket-created notification to each recipient', async () => {
+    createdEmailMock.mockResolvedValue({ success: true, id: 'email-created' })
+    const supabase = createSupportNotificationSupabaseMock()
+
+    const result = await deliverSupportNotificationEvent(
+      createSupportTicketCreatedEvent({ eventId: 'event-created', ticketId: 'ticket-1', actorUserId: 'reporter-1' }),
+      supabase
+    )
+
+    expect(result).toEqual([{ success: true, id: 'email-created' }, { success: true, id: 'email-created' }])
+    expect(createdEmailMock).toHaveBeenCalledTimes(2)
+    expect(createdEmailMock).toHaveBeenNthCalledWith(1, expect.objectContaining({
+      recipientEmail: 'staff-view@example.com',
+      recipientName: 'View Staff',
+      ticketId: 'ticket-1',
+      ticketNumber: 42,
+      title: 'Cannot open group map',
+      status: 'received',
+      idempotencyKey: 'email:event-created:staff-view@example.com',
+    }))
+    expect(createdEmailMock).toHaveBeenNthCalledWith(2, expect.objectContaining({
+      recipientEmail: 'staff-reply@example.com',
+      recipientName: 'Reply Staff',
+      idempotencyKey: 'email:event-created:staff-reply@example.com',
+    }))
+    expect(JSON.stringify(createdEmailMock.mock.calls)).not.toMatch(/rawSentry|evidence|attachment|object_key|support\/ticket-1/i)
+  })
 })
+
+function createSupportNotificationSupabaseMock() {
+  const ticketQuery = { select: jest.fn().mockReturnValue({ eq: jest.fn().mockReturnValue({ single: jest.fn().mockResolvedValue({ data: { id: 'ticket-1', ticket_number: 42, title: 'Cannot open group map', status: 'received' }, error: null }) }) }) }
+  const capabilityQuery = {
+    select: jest.fn().mockReturnValue({
+      is: jest.fn().mockResolvedValue({
+        data: [
+          { usuario: { id: 'staff-view', nombre: 'View', apellido: 'Staff', email: 'staff-view@example.com' } },
+          { usuario: { id: 'staff-view', nombre: 'View', apellido: 'Staff', email: 'staff-view@example.com' } },
+          { usuario: { id: 'staff-reply', nombre: 'Reply', apellido: 'Staff', email: 'staff-reply@example.com' } },
+          { usuario: { id: 'staff-no-email', nombre: 'No', apellido: 'Email', email: null } },
+        ],
+        error: null,
+      }),
+    }),
+  }
+
+  return {
+    from: jest.fn((table: string) => {
+      if (table === 'support_tickets') return ticketQuery
+      if (table === 'support_user_capabilities') return capabilityQuery
+      throw new Error(`Unexpected table ${table}`)
+    }),
+  }
+}

--- a/__tests__/lib/support/sentry-privacy.test.ts
+++ b/__tests__/lib/support/sentry-privacy.test.ts
@@ -166,6 +166,8 @@ describe('Sentry privacy hardening', () => {
         supportEvidence: { route: '/ayuda?token=secret' },
         attachments: ['support/ticket-1/file.png'],
         r2ObjectKey: 'support/ticket-1/file.png',
+        signedUrl: 'https://r2.example.com/support/ticket-1/file.png?X-Amz-Signature=secret',
+        objectKey: 'support/ticket-1/file.png',
         sentryEventId: 'event-secret',
         githubIssueBody: 'private GitHub details',
         nested: {
@@ -181,7 +183,7 @@ describe('Sentry privacy hardening', () => {
         safeUrl: '/ayuda/tickets/ticket-1',
       },
     })
-    expect(JSON.stringify(scrubbed)).not.toMatch(/secret|localStorage|support\/ticket-1|github|private GitHub|event-secret|token=|reporter@example.com/i)
+    expect(JSON.stringify(scrubbed)).not.toMatch(/secret|localStorage|support\/ticket-1|github|private GitHub|event-secret|signed|objectKey|token=|reporter@example.com/i)
   })
 
   it('scrubs breadcrumbs already attached to events before sending', () => {

--- a/__tests__/supabase/support-ticket-system-migration.test.ts
+++ b/__tests__/supabase/support-ticket-system-migration.test.ts
@@ -13,7 +13,14 @@ function readSupportTicketSql(): string {
     readMigrationBySuffix('_add_support_staff_action_rpcs.sql'),
     readSupportStaffDirectMutationMigration(),
     readMigrationBySuffix('_harden_staff_reply_rpc_body.sql'),
+    readMigrationBySuffix('_add_support_capability_admin_rpcs.sql'),
+    readMigrationBySuffix('_add_support_external_inbound_rpc.sql'),
+    readMigrationBySuffix('_align_support_capability_hierarchy.sql'),
   ].join('\n')
+}
+
+function readDatabaseTypes(): string {
+  return readFileSync(join(process.cwd(), 'lib', 'supabase', 'database.types.ts'), 'utf8')
 }
 
 function readSupportStaffDirectMutationMigration(): string {
@@ -42,6 +49,17 @@ function policySql(sql: string, policyName: string): string {
   }
 
   return compactSql(match[0])
+}
+
+function latestPolicySqlByName(sql: string, policyName: string): string {
+  const start = sql.lastIndexOf(`CREATE POLICY ${policyName} ON`)
+
+  if (start === -1) {
+    throw new Error(`Missing policy ${policyName}`)
+  }
+
+  const end = sql.indexOf(';', start)
+  return compactSql(sql.slice(start, end + 1))
 }
 
 function functionSql(sql: string, functionName: string): string {
@@ -159,7 +177,7 @@ describe('support ticket system migration', () => {
     expect(insertPolicy).toContain('retention_expires_at IS NULL')
   })
 
-  it('requires global admin role plus explicit support capability', () => {
+  it('keeps the applied base helper unchanged before additive authorization fixes', () => {
     const sql = readSupportTicketMigration()
     const capabilityHelper = functionSql(sql, 'support_private.has_capability\\(required_capability text\\)')
 
@@ -170,6 +188,31 @@ describe('support ticket system migration', () => {
     expect(capabilityHelper).toContain('suc.capability = required_capability')
     expect(capabilityHelper).toContain('suc.revoked_at IS NULL')
     expect(capabilityHelper).not.toMatch(/\)\s+OR\s+EXISTS/i)
+  })
+
+  it('aligns the latest support capability helper with reply and manage hierarchy', () => {
+    const sql = readSupportTicketSql()
+    const capabilityHelper = latestFunctionSqlByPrefix(sql, 'support_private.has_capability(required_capability text)')
+
+    expect(capabilityHelper).toContain("suc.capability = 'support.manage'")
+    expect(capabilityHelper).toContain("required_capability IN ('support.view', 'support.reply', 'support.manage')")
+    expect(capabilityHelper).toContain("suc.capability = 'support.reply'")
+    expect(capabilityHelper).toContain("required_capability IN ('support.view', 'support.reply')")
+    expect(capabilityHelper).toContain('suc.capability = required_capability')
+    expect(capabilityHelper).not.toContain("rs.nombre_interno = 'admin'")
+    expect(capabilityHelper).not.toContain('JOIN public.roles_sistema')
+  })
+
+  it('keeps support capability configuration data gated by higher role plus support.manage', () => {
+    const sql = readSupportTicketSql()
+    const configHelper = latestFunctionSqlByPrefix(sql, 'support_private.has_support_configuration_access()')
+    const capabilityPolicy = latestPolicySqlByName(sql, 'support_capabilities_select')
+
+    expect(configHelper).toContain("support_private.has_capability('support.manage')")
+    expect(configHelper).toContain("rs.nombre_interno IN ('admin', 'pastor', 'director-general')")
+    expect(capabilityPolicy).toContain('usuario_id = support_private.current_usuario_id()')
+    expect(capabilityPolicy).toContain('support_private.has_support_configuration_access()')
+    expect(capabilityPolicy).not.toContain("support_private.has_capability('support.manage')")
   })
 
   it('adds atomic staff mutation RPCs with explicit capability gates and audit writes', () => {
@@ -220,6 +263,80 @@ describe('support ticket system migration', () => {
       expect(sql).toContain(`REVOKE ALL ON FUNCTION ${signature} FROM PUBLIC`)
       expect(sql).toContain(`GRANT EXECUTE ON FUNCTION ${signature} TO authenticated`)
     }
+  })
+
+  it('adds audited support capability admin RPCs with allowlist, higher-role, and support.manage gates', () => {
+    const sql = readSupportTicketSql()
+    const grantRpc = latestFunctionSqlByPrefix(sql, 'public.grant_support_capability(p_target_usuario_id uuid, p_capability text)')
+    const revokeRpc = latestFunctionSqlByPrefix(sql, 'public.revoke_support_capability(p_target_usuario_id uuid, p_capability text)')
+
+    expect(grantRpc).toContain('SECURITY DEFINER')
+    expect(grantRpc).toContain("SET search_path TO 'public', 'support_private'")
+    expect(grantRpc).toContain("support_private.has_capability('support.manage')")
+    expect(grantRpc).toContain("rs.nombre_interno IN ('admin', 'pastor', 'director-general')")
+    expect(grantRpc).toContain("p_capability NOT IN ('support.view', 'support.reply', 'support.manage')")
+    expect(grantRpc).toContain('INSERT INTO public.support_user_capabilities')
+    expect(grantRpc).toContain('INSERT INTO public.support_ticket_events')
+    expect(grantRpc).not.toMatch(/\bEXECUTE\b/i)
+
+    expect(revokeRpc).toContain("support_private.has_capability('support.manage')")
+    expect(revokeRpc).toContain("rs.nombre_interno IN ('admin', 'pastor', 'director-general')")
+    expect(revokeRpc).toContain("p_capability NOT IN ('support.view', 'support.reply', 'support.manage')")
+    expect(revokeRpc).toContain('UPDATE public.support_user_capabilities')
+    expect(revokeRpc).toContain('INSERT INTO public.support_ticket_events')
+    expect(revokeRpc).not.toMatch(/\bEXECUTE\b/i)
+  })
+
+  it('keeps nullable support capability audit events readable only to higher-role support managers', () => {
+    const sql = readSupportTicketSql()
+    const selectPolicy = latestPolicySqlByName(sql, 'support_events_select')
+
+    expect(sql).toContain('ALTER COLUMN ticket_id DROP NOT NULL')
+    expect(selectPolicy).toContain('ticket_id IS NULL')
+    expect(selectPolicy).toContain("target_type = 'support_user_capability'")
+    expect(selectPolicy).toContain('support_private.has_support_configuration_access()')
+    expect(selectPolicy).toContain('st.id = ticket_id')
+    expect(selectPolicy).toContain("support_private.has_capability('support.view')")
+  })
+
+  it('keeps support capability admin RPC execution limited to authenticated callers', () => {
+    const sql = readSupportTicketSql()
+
+    for (const signature of [
+      'public.grant_support_capability(uuid, text)',
+      'public.revoke_support_capability(uuid, text)',
+    ]) {
+      expect(sql).toContain(`REVOKE ALL ON FUNCTION ${signature} FROM PUBLIC`)
+      expect(sql).toContain(`GRANT EXECUTE ON FUNCTION ${signature} TO authenticated`)
+    }
+  })
+
+  it('adds an atomic service-role RPC for external inbound audit and message persistence', () => {
+    const sql = readSupportTicketSql()
+    const inboundRpc = latestFunctionSqlByPrefix(sql, 'public.record_support_external_inbound_update(')
+
+    expect(inboundRpc).toContain('SECURITY DEFINER')
+    expect(inboundRpc).toContain("SET search_path TO 'public', 'support_private'")
+    expect(inboundRpc).toContain('INSERT INTO public.support_ticket_events')
+    expect(inboundRpc).toContain('ON CONFLICT (idempotency_key) DO NOTHING')
+    expect(inboundRpc).toContain('ste.ticket_id = p_ticket_id')
+    expect(inboundRpc).toContain("ste.action = 'external.update.received'")
+    expect(inboundRpc).toContain("ste.target_type = 'support_external_update'")
+    expect(inboundRpc).toContain('INSERT INTO public.support_ticket_messages')
+    expect(inboundRpc.indexOf('INSERT INTO public.support_ticket_events')).toBeLessThan(inboundRpc.indexOf('INSERT INTO public.support_ticket_messages'))
+    expect(inboundRpc).not.toMatch(/\bEXECUTE\b/i)
+    expect(sql).toContain('REVOKE ALL ON FUNCTION public.record_support_external_inbound_update(uuid, uuid, text, text) FROM PUBLIC')
+    expect(sql).toContain('GRANT EXECUTE ON FUNCTION public.record_support_external_inbound_update(uuid, uuid, text, text) TO service_role')
+  })
+
+  it('keeps generated support ticket event types consistent with nullable ticket_id', () => {
+    const types = readDatabaseTypes()
+    const supportEventsStart = types.indexOf('support_ticket_events: {')
+    const supportMessagesStart = types.indexOf('support_ticket_messages: {')
+    const supportEventsTypes = types.slice(supportEventsStart, supportMessagesStart)
+
+    expect(supportEventsTypes).toContain('ticket_id: string | null')
+    expect(supportEventsTypes).toContain('ticket_id?: string | null')
   })
 
   it('closes direct staff ticket updates so audited fields require RPCs', () => {

--- a/__tests__/supabase/support-ticket-system-migration.test.ts
+++ b/__tests__/supabase/support-ticket-system-migration.test.ts
@@ -16,6 +16,7 @@ function readSupportTicketSql(): string {
     readMigrationBySuffix('_add_support_capability_admin_rpcs.sql'),
     readMigrationBySuffix('_add_support_external_inbound_rpc.sql'),
     readMigrationBySuffix('_align_support_capability_hierarchy.sql'),
+    readMigrationBySuffix('_add_safe_support_ticket_auto_assignment_rpc.sql'),
   ].join('\n')
 }
 
@@ -219,6 +220,7 @@ describe('support ticket system migration', () => {
     const sql = readSupportTicketSql()
     const staffReplyRpc = latestFunctionSqlByPrefix(sql, 'public.create_staff_support_ticket_reply(p_ticket_id uuid, p_body text)')
     const assignmentRpc = latestFunctionSqlByPrefix(sql, 'public.assign_support_ticket(p_ticket_id uuid, p_assignee_usuario_id uuid)')
+    const autoAssignmentRpc = latestFunctionSqlByPrefix(sql, 'public.auto_assign_support_ticket_if_unassigned(p_ticket_id uuid)')
     const statusRpc = latestFunctionSqlByPrefix(sql, 'public.update_support_ticket_status(p_ticket_id uuid, p_status text)')
 
     expect(staffReplyRpc).toContain('SECURITY DEFINER')
@@ -233,6 +235,15 @@ describe('support ticket system migration', () => {
     expect(assignmentRpc).toContain('UPDATE public.support_tickets')
     expect(assignmentRpc).toContain('INSERT INTO public.support_ticket_events')
     expect(assignmentRpc).not.toMatch(/\bEXECUTE\b/i)
+
+    expect(autoAssignmentRpc).toContain('SECURITY DEFINER')
+    expect(autoAssignmentRpc).toContain("support_private.has_capability('support.manage')")
+    expect(autoAssignmentRpc).toContain("SET search_path TO 'public', 'support_private'")
+    expect(autoAssignmentRpc).toContain('WHERE id = p_ticket_id AND assignee_usuario_id IS NULL')
+    expect(autoAssignmentRpc).not.toMatch(/SET\s+assignee_usuario_id\s*=\s*v_actor_usuario_id[\s\S]*WHERE\s+id\s*=\s*p_ticket_id\s*;/i)
+    expect(autoAssignmentRpc).toContain('GET DIAGNOSTICS v_updated_count = ROW_COUNT')
+    expect(autoAssignmentRpc).toContain('IF v_updated_count > 0 THEN INSERT INTO public.support_ticket_events')
+    expect(autoAssignmentRpc).not.toMatch(/\bEXECUTE\b/i)
 
     expect(statusRpc).toContain("support_private.has_capability('support.manage')")
     expect(statusRpc).toContain("SET search_path TO 'public', 'support_private'")
@@ -258,6 +269,7 @@ describe('support ticket system migration', () => {
     for (const signature of [
       'public.create_staff_support_ticket_reply(uuid, text)',
       'public.assign_support_ticket(uuid, uuid)',
+      'public.auto_assign_support_ticket_if_unassigned(uuid)',
       'public.update_support_ticket_status(uuid, text)',
     ]) {
       expect(sql).toContain(`REVOKE ALL ON FUNCTION ${signature} FROM PUBLIC`)

--- a/app/(auth)/ayuda/admin/page.tsx
+++ b/app/(auth)/ayuda/admin/page.tsx
@@ -1,6 +1,6 @@
 import Link from 'next/link'
 
-import { listStaffSupportTickets } from '@/lib/actions/support.actions'
+import { assignSupportTicket, listStaffSupportTickets, updateSupportTicketStatus } from '@/lib/actions/support.actions'
 import { formatSupportCategory, formatSupportSeverity, formatSupportStatus } from '@/lib/support/support-labels'
 import { BadgeSistema, BotonSistema, ContenedorDashboard, InputSistema, SelectSistema, TarjetaSistema, TextoSistema } from '@/components/ui/sistema-diseno'
 
@@ -34,6 +34,19 @@ export default async function SupportAdminPage({ searchParams }: SupportAdminPag
   }
   const result = await listStaffSupportTickets(filters)
   const tickets = result.success ? result.tickets : []
+  const supportCapabilities = result.success ? result.supportCapabilities ?? [] : []
+  const canManage = supportCapabilities.includes('support.manage')
+
+  async function statusAction(formData: FormData) {
+    'use server'
+    await updateSupportTicketStatus(String(formData.get('ticketId') ?? ''), String(formData.get('status') ?? ''))
+  }
+
+  async function assignmentAction(formData: FormData) {
+    'use server'
+    const assigneeUsuarioId = String(formData.get('assigneeUsuarioId') ?? '').trim() || null
+    await assignSupportTicket(String(formData.get('ticketId') ?? ''), assigneeUsuarioId)
+  }
 
   return (
     <ContenedorDashboard titulo="Cola de soporte" descripcion="Busca y prioriza tickets autorizados sin exponer vistas exclusivas del reportante.">
@@ -53,15 +66,34 @@ export default async function SupportAdminPage({ searchParams }: SupportAdminPag
       ) : (
         <div className="space-y-3">
           {tickets.map((ticket) => (
-            <Link key={ticket.id} href={`/ayuda/tickets/${ticket.id}`} className="block focus-ring rounded-2xl">
-              <TarjetaSistema className="flex items-center justify-between gap-4">
-                <div>
-                  <p className="font-semibold text-foreground">#{ticket.ticketNumber} {ticket.title}</p>
+            <TarjetaSistema key={ticket.id} className="space-y-4">
+              <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
+                <div className="space-y-1">
+                  <Link href={`/ayuda/tickets/${ticket.id}`} className="font-semibold text-foreground hover:text-[var(--brand-primary)] focus-ring rounded-md">#{ticket.ticketNumber} {ticket.title}</Link>
                   <TextoSistema variante="sutil" tamaño="sm">{formatSupportCategory(ticket.category)} · {formatSupportSeverity(ticket.severity)}</TextoSistema>
                 </div>
                 <BadgeSistema variante="info">{formatSupportStatus(ticket.status)}</BadgeSistema>
-              </TarjetaSistema>
-            </Link>
+              </div>
+              <div className={canManage ? "grid gap-3 md:grid-cols-[minmax(0,1fr)_minmax(0,1fr)_auto]" : "flex justify-end"}>
+                {canManage && (
+                  <>
+                    <form action={statusAction} className="space-y-2">
+                      <input type="hidden" name="ticketId" value={ticket.id} />
+                      <SelectSistema label={`Nuevo estado para #${ticket.ticketNumber}`} name="status" defaultValue={ticket.status} opciones={STATUS_OPTIONS.filter((option) => option.valor)} />
+                      <BotonSistema type="submit" tamaño="sm">Actualizar estado de #{ticket.ticketNumber}</BotonSistema>
+                    </form>
+                    <form action={assignmentAction} className="space-y-2">
+                      <input type="hidden" name="ticketId" value={ticket.id} />
+                      <InputSistema label={`Responsable para #${ticket.ticketNumber}`} name="assigneeUsuarioId" defaultValue={ticket.assigneeUsuarioId ?? ''} placeholder="UUID del responsable" />
+                      <BotonSistema type="submit" tamaño="sm" variante="outline">Asignar #{ticket.ticketNumber}</BotonSistema>
+                    </form>
+                  </>
+                )}
+                <div className="flex items-end">
+                  <Link href={`/ayuda/tickets/${ticket.id}`} className="inline-flex min-h-[44px] items-center rounded-xl px-4 py-2 text-sm font-medium text-[var(--brand-primary)] hover:bg-[var(--brand-accent)] focus-ring">Responder #{ticket.ticketNumber}</Link>
+                </div>
+              </div>
+            </TarjetaSistema>
           ))}
         </div>
       )}

--- a/app/(auth)/ayuda/admin/page.tsx
+++ b/app/(auth)/ayuda/admin/page.tsx
@@ -1,8 +1,10 @@
 import Link from 'next/link'
+import { TicketIcon } from 'lucide-react'
 
 import { listStaffSupportTickets, updateSupportTicketStatus } from '@/lib/actions/support.actions'
 import { formatSupportCategory, formatSupportSeverity, formatSupportStatus } from '@/lib/support/support-labels'
 import { DashboardLayout } from '@/components/layout/dashboard-layout'
+import { DataTable, type DataTableColumn } from '@/components/ui/data-table'
 import { BadgeSistema, BotonSistema, ContenedorDashboard, InputSistema, SelectSistema, TarjetaSistema, TextoSistema } from '@/components/ui/sistema-diseno'
 import { SupportTicketQueueStatusForm } from './support-ticket-admin-actions'
 
@@ -36,6 +38,7 @@ export default async function SupportAdminPage({ searchParams }: SupportAdminPag
   }
   const result = await listStaffSupportTickets(filters)
   const tickets = result.success ? result.tickets : []
+  type StaffTicket = (typeof tickets)[number]
   const supportCapabilities = result.success ? result.supportCapabilities ?? [] : []
   const canManage = supportCapabilities.includes('support.manage')
 
@@ -44,51 +47,167 @@ export default async function SupportAdminPage({ searchParams }: SupportAdminPag
     return updateSupportTicketStatus(String(formData.get('ticketId') ?? ''), String(formData.get('status') ?? ''))
   }
 
+  const statusOptions = STATUS_OPTIONS.filter((option) => option.valor)
+  const columns: DataTableColumn<StaffTicket>[] = [
+    {
+      key: 'ticket',
+      header: 'Ticket',
+      cell: (ticket) => <TicketIdentity ticket={ticket} />,
+      className: 'min-w-[320px] whitespace-nowrap',
+    },
+    {
+      key: 'category',
+      header: 'Categoria',
+      cell: (ticket) => formatSupportCategory(ticket.category),
+      className: 'text-sm text-muted-foreground',
+    },
+    {
+      key: 'severity',
+      header: 'Severidad',
+      cell: (ticket) => formatSupportSeverity(ticket.severity),
+      className: 'text-sm text-muted-foreground',
+    },
+    {
+      key: 'status',
+      header: 'Estado',
+      cell: (ticket) => <BadgeSistema variante="info">{formatSupportStatus(ticket.status)}</BadgeSistema>,
+    },
+    {
+      key: 'actions',
+      header: 'Acciones',
+      cell: (ticket) => (
+        <div className="flex items-end justify-end gap-3">
+          {canManage && (
+            <SupportTicketQueueStatusForm action={statusAction} ticketId={ticket.id} ticketNumber={ticket.ticketNumber} currentStatus={ticket.status} options={statusOptions} />
+          )}
+          <Link href={`/ayuda/tickets/${ticket.id}`} className="inline-flex min-h-[44px] items-center rounded-xl px-4 py-2 text-sm font-medium text-[var(--brand-primary)] hover:bg-[var(--brand-accent)] focus-ring">
+            Responder #{ticket.ticketNumber}
+          </Link>
+        </div>
+      ),
+      className: 'min-w-[220px] text-right',
+      headerClassName: 'text-right',
+    },
+  ]
+
   return (
     <DashboardLayout>
       <ContenedorDashboard titulo="Cola de soporte" descripcion="Busca y prioriza tickets autorizados sin exponer vistas exclusivas del reportante.">
-      <form className="grid gap-3 md:grid-cols-[minmax(0,1fr)_180px_180px_auto]" action="/ayuda/admin">
-        <InputSistema label="Buscar tickets" name="search" type="search" role="searchbox" defaultValue={filters.search ?? ''} placeholder="Numero de ticket, titulo, descripcion" />
-        <SelectSistema label="Estado" name="status" defaultValue={filters.status ?? ''} opciones={STATUS_OPTIONS} />
-        <InputSistema label="Categoria" name="category" defaultValue={filters.category ?? ''} placeholder="bug, access, billing" />
-        <div className="flex items-end">
-          <BotonSistema type="submit" className="w-full">Filtrar</BotonSistema>
-        </div>
-      </form>
+        <form className="grid gap-3 md:grid-cols-[minmax(0,1fr)_180px_180px_auto]" action="/ayuda/admin">
+          <InputSistema label="Buscar tickets" name="search" type="search" role="searchbox" defaultValue={filters.search ?? ''} placeholder="Numero de ticket, titulo, descripcion" />
+          <SelectSistema label="Estado" name="status" defaultValue={filters.status ?? ''} opciones={STATUS_OPTIONS} />
+          <InputSistema label="Categoria" name="category" defaultValue={filters.category ?? ''} placeholder="bug, access, billing" />
+          <div className="flex items-end">
+            <BotonSistema type="submit" className="w-full">Filtrar</BotonSistema>
+          </div>
+        </form>
 
-      {!result.success ? (
-        <TarjetaSistema><TextoSistema variante="sutil">{result.error}</TextoSistema></TarjetaSistema>
-      ) : tickets.length === 0 ? (
-        <TarjetaSistema><TextoSistema variante="sutil">Ningun ticket de soporte coincide con estos filtros.</TextoSistema></TarjetaSistema>
-      ) : (
-        <div className="space-y-3">
-          {tickets.map((ticket) => (
-            <TarjetaSistema key={ticket.id} className="space-y-4">
-              <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
-                <div className="space-y-1">
-                  <Link href={`/ayuda/tickets/${ticket.id}`} className="font-semibold text-foreground hover:text-[var(--brand-primary)] focus-ring rounded-md">#{ticket.ticketNumber} {ticket.title}</Link>
-                  <TextoSistema variante="sutil" tamaño="sm">{formatSupportCategory(ticket.category)} · {formatSupportSeverity(ticket.severity)}</TextoSistema>
-                </div>
-                <BadgeSistema variante="info">{formatSupportStatus(ticket.status)}</BadgeSistema>
-              </div>
-              <div className={canManage ? "grid gap-3 md:grid-cols-[minmax(0,1fr)_auto]" : "flex justify-end"}>
-                {canManage && (
-                  <SupportTicketQueueStatusForm action={statusAction} ticketId={ticket.id} ticketNumber={ticket.ticketNumber} currentStatus={ticket.status} options={STATUS_OPTIONS.filter((option) => option.valor)} />
-                )}
-                <div className="flex items-end">
-                  <Link href={`/ayuda/tickets/${ticket.id}`} className="inline-flex min-h-[44px] items-center rounded-xl px-4 py-2 text-sm font-medium text-[var(--brand-primary)] hover:bg-[var(--brand-accent)] focus-ring">Responder #{ticket.ticketNumber}</Link>
-                </div>
-              </div>
-            </TarjetaSistema>
-          ))}
-        </div>
-      )}
+        {!result.success ? (
+          <TarjetaSistema><TextoSistema variante="sutil">{result.error}</TextoSistema></TarjetaSistema>
+        ) : (
+          <>
+            <DataTable
+              rows={tickets}
+              columns={columns}
+              getRowKey={(ticket) => ticket.id}
+              caption="Cola de tickets de soporte autorizados para el equipo."
+              getRowHref={(ticket) => `/ayuda/tickets/${ticket.id}`}
+              getRowLabel={(ticket) => `#${ticket.ticketNumber} ${ticket.title}`}
+              emptyState={<TextoSistema variante="sutil">Ningun ticket de soporte coincide con estos filtros.</TextoSistema>}
+              className="hidden overflow-hidden md:block"
+              tableClassName="w-full divide-y divide-border"
+              bodyClassName="divide-y divide-border"
+            />
+            <TicketsMobileList tickets={tickets} canManage={canManage} statusAction={statusAction} statusOptions={statusOptions} />
+          </>
+        )}
       </ContenedorDashboard>
     </DashboardLayout>
   )
+}
+
+function TicketIdentity({ ticket }: { ticket: StaffTicketRow }) {
+  return (
+    <div className="flex items-center gap-3">
+      <div className="flex h-10 w-16 flex-shrink-0 items-center justify-center rounded-lg bg-gradient-to-r from-orange-400 to-orange-500">
+        <TicketIcon className="h-4 w-4 text-white" aria-hidden="true" />
+      </div>
+      <div className="min-w-0">
+        <div className="flex items-center gap-2 font-medium text-foreground">
+          <span>#{ticket.ticketNumber}</span>
+          <span className="truncate">{ticket.title}</span>
+        </div>
+        <div className="mt-0.5 text-xs text-muted-foreground">Creado {formatTicketDate(ticket.createdAt)}</div>
+      </div>
+    </div>
+  )
+}
+
+function TicketsMobileList({ tickets, canManage, statusAction, statusOptions }: { tickets: StaffTicketRow[]; canManage: boolean; statusAction: (formData: FormData) => Promise<{ success: boolean; error?: string }>; statusOptions: { valor: string; etiqueta: string }[] }) {
+  if (tickets.length === 0) {
+    return (
+      <TarjetaSistema className="p-8 text-center md:hidden">
+        <TicketIcon className="mx-auto mb-3 h-12 w-12 text-muted-foreground/40" aria-hidden="true" />
+        <TextoSistema variante="sutil">Ningun ticket de soporte coincide con estos filtros.</TextoSistema>
+      </TarjetaSistema>
+    )
+  }
+
+  return (
+    <div className="space-y-4 md:hidden">
+      {tickets.map((ticket) => (
+        <TarjetaSistema key={ticket.id} className="space-y-4 p-4">
+          <div className="flex items-start gap-3">
+            <div className="mt-0.5 flex h-8 w-12 flex-shrink-0 items-center justify-center rounded-lg bg-gradient-to-r from-orange-400 to-orange-500">
+              <TicketIcon className="h-4 w-4 text-white" aria-hidden="true" />
+            </div>
+            <div className="min-w-0 flex-1">
+              <div className="mb-2 flex items-start justify-between gap-2">
+                <Link href={`/ayuda/tickets/${ticket.id}`} className="min-w-0 flex-1 truncate rounded-md font-semibold text-foreground hover:text-[var(--brand-primary)] focus-ring" aria-label={`#${ticket.ticketNumber} ${ticket.title}`}>
+                  #{ticket.ticketNumber} {ticket.title}
+                </Link>
+                <BadgeSistema variante="info" tamaño="sm" className="flex-shrink-0">
+                  {formatSupportStatus(ticket.status)}
+                </BadgeSistema>
+              </div>
+              <div className="space-y-1 text-sm text-muted-foreground">
+                <div>
+                  <span className="font-medium">Categoria:</span> {formatSupportCategory(ticket.category)}
+                </div>
+                <div>
+                  <span className="font-medium">Severidad:</span> {formatSupportSeverity(ticket.severity)}
+                </div>
+                <div className="text-xs text-muted-foreground/70">{formatTicketDate(ticket.createdAt)}</div>
+              </div>
+            </div>
+          </div>
+          <div className={canManage ? 'grid gap-3' : 'flex justify-end'}>
+            {canManage && (
+              <SupportTicketQueueStatusForm action={statusAction} ticketId={ticket.id} ticketNumber={ticket.ticketNumber} currentStatus={ticket.status} options={statusOptions} />
+            )}
+            <div className="flex justify-end">
+              <Link href={`/ayuda/tickets/${ticket.id}`} className="inline-flex min-h-[44px] items-center rounded-xl px-4 py-2 text-sm font-medium text-[var(--brand-primary)] hover:bg-[var(--brand-accent)] focus-ring">
+                Responder #{ticket.ticketNumber}
+              </Link>
+            </div>
+          </div>
+        </TarjetaSistema>
+      ))}
+    </div>
+  )
+}
+
+function formatTicketDate(value: string) {
+  return new Intl.DateTimeFormat('es-MX', { dateStyle: 'medium' }).format(new Date(value))
 }
 
 function emptyToUndefined(value: string | string[] | undefined) {
   const trimmed = (Array.isArray(value) ? value[0] : value)?.trim()
   return trimmed ? trimmed : undefined
 }
+
+type StaffTicketRow = Awaited<ReturnType<typeof listStaffSupportTickets>> extends { tickets: infer Tickets }
+  ? Tickets extends Array<infer Ticket>
+    ? Ticket
+    : never
+  : never

--- a/app/(auth)/ayuda/admin/page.tsx
+++ b/app/(auth)/ayuda/admin/page.tsx
@@ -1,11 +1,11 @@
 import Link from 'next/link'
-import { TicketIcon } from 'lucide-react'
+import { Filter, MessageSquare, TicketIcon } from 'lucide-react'
 
 import { listStaffSupportTickets, updateSupportTicketStatus } from '@/lib/actions/support.actions'
 import { formatSupportCategory, formatSupportSeverity, formatSupportStatus } from '@/lib/support/support-labels'
 import { DashboardLayout } from '@/components/layout/dashboard-layout'
 import { DataTable, type DataTableColumn } from '@/components/ui/data-table'
-import { BadgeSistema, BotonSistema, ContenedorDashboard, InputSistema, SelectSistema, TarjetaSistema, TextoSistema } from '@/components/ui/sistema-diseno'
+import { BadgeSistema, BotonSistema, ContenedorDashboard, TarjetaSistema, TextoSistema } from '@/components/ui/sistema-diseno'
 import { SupportTicketQueueStatusForm } from './support-ticket-admin-actions'
 
 type SupportAdminPageProps = {
@@ -48,6 +48,7 @@ export default async function SupportAdminPage({ searchParams }: SupportAdminPag
   }
 
   const statusOptions = STATUS_OPTIONS.filter((option) => option.valor)
+  const activeFiltersCount = Object.values(filters).filter(Boolean).length
   const columns: DataTableColumn<StaffTicket>[] = [
     {
       key: 'ticket',
@@ -76,16 +77,17 @@ export default async function SupportAdminPage({ searchParams }: SupportAdminPag
       key: 'actions',
       header: 'Acciones',
       cell: (ticket) => (
-        <div className="flex items-end justify-end gap-3">
+        <div className="flex items-center justify-end gap-3">
           {canManage && (
             <SupportTicketQueueStatusForm action={statusAction} ticketId={ticket.id} ticketNumber={ticket.ticketNumber} currentStatus={ticket.status} options={statusOptions} />
           )}
-          <Link href={`/ayuda/tickets/${ticket.id}`} className="inline-flex min-h-[44px] items-center rounded-xl px-4 py-2 text-sm font-medium text-[var(--brand-primary)] hover:bg-[var(--brand-accent)] focus-ring">
+          <Link href={`/ayuda/tickets/${ticket.id}`} className="inline-flex items-center gap-1 text-xs font-medium text-orange-600 hover:text-orange-700 focus-ring">
+            <MessageSquare className="h-4 w-4" aria-hidden="true" />
             Responder #{ticket.ticketNumber}
           </Link>
         </div>
       ),
-      className: 'min-w-[220px] text-right',
+      className: 'min-w-[260px] whitespace-nowrap text-right text-sm',
       headerClassName: 'text-right',
     },
   ]
@@ -93,14 +95,40 @@ export default async function SupportAdminPage({ searchParams }: SupportAdminPag
   return (
     <DashboardLayout>
       <ContenedorDashboard titulo="Cola de soporte" descripcion="Busca y prioriza tickets autorizados sin exponer vistas exclusivas del reportante.">
-        <form className="grid gap-3 md:grid-cols-[minmax(0,1fr)_180px_180px_auto]" action="/ayuda/admin">
-          <InputSistema label="Buscar tickets" name="search" type="search" role="searchbox" defaultValue={filters.search ?? ''} placeholder="Numero de ticket, titulo, descripcion" />
-          <SelectSistema label="Estado" name="status" defaultValue={filters.status ?? ''} opciones={STATUS_OPTIONS} />
-          <InputSistema label="Categoria" name="category" defaultValue={filters.category ?? ''} placeholder="bug, access, billing" />
-          <div className="flex items-end">
-            <BotonSistema type="submit" className="w-full">Filtrar</BotonSistema>
-          </div>
-        </form>
+        <details className="group">
+          <summary className="mb-4 flex cursor-pointer list-none items-center justify-end gap-2 rounded-xl focus-ring [&::-webkit-details-marker]:hidden">
+            <span className="inline-flex min-h-[44px] items-center rounded-xl border-2 border-border px-3 py-2 text-sm font-medium text-foreground transition-colors hover:bg-accent">
+              <Filter className="h-4 w-4 flex-shrink-0" aria-hidden="true" />
+              <span className="ml-2">Filtros</span>
+              {activeFiltersCount > 0 && (
+                <span className="ml-2 inline-flex h-4 w-4 items-center justify-center rounded-full bg-orange-600 text-[10px] text-white">
+                  {activeFiltersCount}
+                </span>
+              )}
+            </span>
+          </summary>
+          <form className="mt-4 grid gap-3 rounded-2xl border border-border bg-card/50 p-4 md:grid-cols-[minmax(0,1fr)_180px_180px_auto]" action="/ayuda/admin">
+            <label className="space-y-2 text-sm font-medium text-foreground">
+              <span>Buscar tickets</span>
+              <input className="block min-h-[44px] w-full rounded-xl border border-border bg-card/50 px-3 py-3 text-foreground placeholder:text-muted-foreground focus:border-[var(--brand-primary)] focus:outline-none focus:ring-2 focus:ring-[var(--brand-primary)]/20" name="search" type="search" role="searchbox" defaultValue={filters.search ?? ''} placeholder="Numero de ticket, titulo, descripcion" />
+            </label>
+            <label className="space-y-2 text-sm font-medium text-foreground">
+              <span>Estado</span>
+              <select className="block min-h-[44px] w-full rounded-xl border border-border bg-card/50 px-3 py-3 text-foreground focus:border-[var(--brand-primary)] focus:outline-none focus:ring-2 focus:ring-[var(--brand-primary)]/20" name="status" defaultValue={filters.status ?? ''}>
+                {STATUS_OPTIONS.map((option) => (
+                  <option key={option.valor} value={option.valor}>{option.etiqueta}</option>
+                ))}
+              </select>
+            </label>
+            <label className="space-y-2 text-sm font-medium text-foreground">
+              <span>Categoria</span>
+              <input className="block min-h-[44px] w-full rounded-xl border border-border bg-card/50 px-3 py-3 text-foreground placeholder:text-muted-foreground focus:border-[var(--brand-primary)] focus:outline-none focus:ring-2 focus:ring-[var(--brand-primary)]/20" name="category" defaultValue={filters.category ?? ''} placeholder="bug, access, billing" />
+            </label>
+            <div className="flex items-end">
+              <BotonSistema type="submit" tamaño="sm" className="w-full">Filtrar</BotonSistema>
+            </div>
+          </form>
+        </details>
 
         {!result.success ? (
           <TarjetaSistema><TextoSistema variante="sutil">{result.error}</TextoSistema></TarjetaSistema>
@@ -114,9 +142,7 @@ export default async function SupportAdminPage({ searchParams }: SupportAdminPag
               getRowHref={(ticket) => `/ayuda/tickets/${ticket.id}`}
               getRowLabel={(ticket) => `#${ticket.ticketNumber} ${ticket.title}`}
               emptyState={<TextoSistema variante="sutil">Ningun ticket de soporte coincide con estos filtros.</TextoSistema>}
-              className="hidden overflow-hidden md:block"
-              tableClassName="w-full divide-y divide-border"
-              bodyClassName="divide-y divide-border"
+              className="hidden md:block"
             />
             <TicketsMobileList tickets={tickets} canManage={canManage} statusAction={statusAction} statusOptions={statusOptions} />
           </>
@@ -181,12 +207,13 @@ function TicketsMobileList({ tickets, canManage, statusAction, statusOptions }: 
               </div>
             </div>
           </div>
-          <div className={canManage ? 'grid gap-3' : 'flex justify-end'}>
+          <div className={canManage ? 'flex flex-wrap items-center justify-end gap-3' : 'flex justify-end'}>
             {canManage && (
               <SupportTicketQueueStatusForm action={statusAction} ticketId={ticket.id} ticketNumber={ticket.ticketNumber} currentStatus={ticket.status} options={statusOptions} />
             )}
             <div className="flex justify-end">
-              <Link href={`/ayuda/tickets/${ticket.id}`} className="inline-flex min-h-[44px] items-center rounded-xl px-4 py-2 text-sm font-medium text-[var(--brand-primary)] hover:bg-[var(--brand-accent)] focus-ring">
+              <Link href={`/ayuda/tickets/${ticket.id}`} className="inline-flex items-center gap-1 text-xs font-medium text-orange-600 hover:text-orange-700 focus-ring">
+                <MessageSquare className="h-4 w-4" aria-hidden="true" />
                 Responder #{ticket.ticketNumber}
               </Link>
             </div>

--- a/app/(auth)/ayuda/admin/page.tsx
+++ b/app/(auth)/ayuda/admin/page.tsx
@@ -1,8 +1,10 @@
 import Link from 'next/link'
 
-import { assignSupportTicket, listStaffSupportTickets, updateSupportTicketStatus } from '@/lib/actions/support.actions'
+import { listStaffSupportTickets, updateSupportTicketStatus } from '@/lib/actions/support.actions'
 import { formatSupportCategory, formatSupportSeverity, formatSupportStatus } from '@/lib/support/support-labels'
+import { DashboardLayout } from '@/components/layout/dashboard-layout'
 import { BadgeSistema, BotonSistema, ContenedorDashboard, InputSistema, SelectSistema, TarjetaSistema, TextoSistema } from '@/components/ui/sistema-diseno'
+import { SupportTicketQueueStatusForm } from './support-ticket-admin-actions'
 
 type SupportAdminPageProps = {
   searchParams: Promise<{
@@ -39,17 +41,12 @@ export default async function SupportAdminPage({ searchParams }: SupportAdminPag
 
   async function statusAction(formData: FormData) {
     'use server'
-    await updateSupportTicketStatus(String(formData.get('ticketId') ?? ''), String(formData.get('status') ?? ''))
-  }
-
-  async function assignmentAction(formData: FormData) {
-    'use server'
-    const assigneeUsuarioId = String(formData.get('assigneeUsuarioId') ?? '').trim() || null
-    await assignSupportTicket(String(formData.get('ticketId') ?? ''), assigneeUsuarioId)
+    return updateSupportTicketStatus(String(formData.get('ticketId') ?? ''), String(formData.get('status') ?? ''))
   }
 
   return (
-    <ContenedorDashboard titulo="Cola de soporte" descripcion="Busca y prioriza tickets autorizados sin exponer vistas exclusivas del reportante.">
+    <DashboardLayout>
+      <ContenedorDashboard titulo="Cola de soporte" descripcion="Busca y prioriza tickets autorizados sin exponer vistas exclusivas del reportante.">
       <form className="grid gap-3 md:grid-cols-[minmax(0,1fr)_180px_180px_auto]" action="/ayuda/admin">
         <InputSistema label="Buscar tickets" name="search" type="search" role="searchbox" defaultValue={filters.search ?? ''} placeholder="Numero de ticket, titulo, descripcion" />
         <SelectSistema label="Estado" name="status" defaultValue={filters.status ?? ''} opciones={STATUS_OPTIONS} />
@@ -74,20 +71,9 @@ export default async function SupportAdminPage({ searchParams }: SupportAdminPag
                 </div>
                 <BadgeSistema variante="info">{formatSupportStatus(ticket.status)}</BadgeSistema>
               </div>
-              <div className={canManage ? "grid gap-3 md:grid-cols-[minmax(0,1fr)_minmax(0,1fr)_auto]" : "flex justify-end"}>
+              <div className={canManage ? "grid gap-3 md:grid-cols-[minmax(0,1fr)_auto]" : "flex justify-end"}>
                 {canManage && (
-                  <>
-                    <form action={statusAction} className="space-y-2">
-                      <input type="hidden" name="ticketId" value={ticket.id} />
-                      <SelectSistema label={`Nuevo estado para #${ticket.ticketNumber}`} name="status" defaultValue={ticket.status} opciones={STATUS_OPTIONS.filter((option) => option.valor)} />
-                      <BotonSistema type="submit" tamaño="sm">Actualizar estado de #{ticket.ticketNumber}</BotonSistema>
-                    </form>
-                    <form action={assignmentAction} className="space-y-2">
-                      <input type="hidden" name="ticketId" value={ticket.id} />
-                      <InputSistema label={`Responsable para #${ticket.ticketNumber}`} name="assigneeUsuarioId" defaultValue={ticket.assigneeUsuarioId ?? ''} placeholder="UUID del responsable" />
-                      <BotonSistema type="submit" tamaño="sm" variante="outline">Asignar #{ticket.ticketNumber}</BotonSistema>
-                    </form>
-                  </>
+                  <SupportTicketQueueStatusForm action={statusAction} ticketId={ticket.id} ticketNumber={ticket.ticketNumber} currentStatus={ticket.status} options={STATUS_OPTIONS.filter((option) => option.valor)} />
                 )}
                 <div className="flex items-end">
                   <Link href={`/ayuda/tickets/${ticket.id}`} className="inline-flex min-h-[44px] items-center rounded-xl px-4 py-2 text-sm font-medium text-[var(--brand-primary)] hover:bg-[var(--brand-accent)] focus-ring">Responder #{ticket.ticketNumber}</Link>
@@ -97,7 +83,8 @@ export default async function SupportAdminPage({ searchParams }: SupportAdminPag
           ))}
         </div>
       )}
-    </ContenedorDashboard>
+      </ContenedorDashboard>
+    </DashboardLayout>
   )
 }
 

--- a/app/(auth)/ayuda/admin/support-ticket-admin-actions.tsx
+++ b/app/(auth)/ayuda/admin/support-ticket-admin-actions.tsx
@@ -1,0 +1,35 @@
+'use client'
+
+import { useActionState, useEffect } from 'react'
+
+import { BotonSistema, SelectSistema } from '@/components/ui/sistema-diseno'
+import { useNotificaciones } from '@/hooks/use-notificaciones'
+
+type SupportFormState = { success: boolean; error?: string } | null
+type SupportFormAction = (formData: FormData) => Promise<Exclude<SupportFormState, null>>
+
+export function SupportTicketQueueStatusForm({ action, ticketId, ticketNumber, currentStatus, options }: { action: SupportFormAction; ticketId: string; ticketNumber: number; currentStatus: string; options: { valor: string; etiqueta: string }[] }) {
+  const toast = useNotificaciones()
+  const [state, formAction, isPending] = useActionState(async (_previousState: SupportFormState, formData: FormData) => action(formData), null)
+
+  useEffect(() => {
+    if (isPending) toast.info(`Actualizando estado de #${ticketNumber}...`)
+  }, [isPending, ticketNumber, toast])
+
+  useEffect(() => {
+    if (!state) return
+    if (state.success) {
+      toast.success(`Estado de #${ticketNumber} actualizado`)
+      return
+    }
+    toast.error(state.error ?? `No se pudo actualizar el estado de #${ticketNumber}`)
+  }, [state, ticketNumber, toast])
+
+  return (
+    <form action={formAction} className="space-y-2">
+      <input type="hidden" name="ticketId" value={ticketId} />
+      <SelectSistema label={`Nuevo estado para #${ticketNumber}`} name="status" defaultValue={currentStatus} opciones={options} />
+      <BotonSistema type="submit" tamaño="sm" disabled={isPending}>{isPending ? 'Actualizando...' : `Actualizar estado de #${ticketNumber}`}</BotonSistema>
+    </form>
+  )
+}

--- a/app/(auth)/ayuda/admin/support-ticket-admin-actions.tsx
+++ b/app/(auth)/ayuda/admin/support-ticket-admin-actions.tsx
@@ -2,7 +2,6 @@
 
 import { useActionState, useEffect } from 'react'
 
-import { BotonSistema, SelectSistema } from '@/components/ui/sistema-diseno'
 import { useNotificaciones } from '@/hooks/use-notificaciones'
 
 type SupportFormState = { success: boolean; error?: string } | null
@@ -26,10 +25,22 @@ export function SupportTicketQueueStatusForm({ action, ticketId, ticketNumber, c
   }, [state, ticketNumber, toast])
 
   return (
-    <form action={formAction} className="space-y-2">
+    <form action={formAction} className="inline-flex items-center gap-2">
       <input type="hidden" name="ticketId" value={ticketId} />
-      <SelectSistema label={`Nuevo estado para #${ticketNumber}`} name="status" defaultValue={currentStatus} opciones={options} />
-      <BotonSistema type="submit" tamaño="sm" disabled={isPending}>{isPending ? 'Actualizando...' : `Actualizar estado de #${ticketNumber}`}</BotonSistema>
+      <label className="sr-only" htmlFor={`ticket-${ticketId}-status`}>Nuevo estado para #{ticketNumber}</label>
+      <select
+        id={`ticket-${ticketId}-status`}
+        name="status"
+        defaultValue={currentStatus}
+        className="h-8 rounded-lg border border-border bg-card/50 px-2 text-xs text-foreground focus:border-orange-500 focus:outline-none focus:ring-2 focus:ring-orange-500/20"
+      >
+        {options.map((option) => (
+          <option key={option.valor} value={option.valor}>{option.etiqueta}</option>
+        ))}
+      </select>
+      <button type="submit" disabled={isPending} className="inline-flex items-center gap-1 text-xs font-medium text-orange-600 hover:text-orange-700 disabled:cursor-not-allowed disabled:opacity-50 focus-ring">
+        {isPending ? 'Actualizando...' : `Actualizar #${ticketNumber}`}
+      </button>
     </form>
   )
 }

--- a/app/(auth)/ayuda/page.tsx
+++ b/app/(auth)/ayuda/page.tsx
@@ -1,34 +1,37 @@
 import Link from 'next/link'
 import { FileText, History } from 'lucide-react'
 
+import { DashboardLayout } from '@/components/layout/dashboard-layout'
 import { BotonSistema, ContenedorDashboard, TarjetaSistema, TextoSistema, TituloSistema } from '@/components/ui/sistema-diseno'
 
 export default async function AyudaPage() {
   return (
-    <ContenedorDashboard titulo="Ayuda" descripcion="Reporta problemas y da seguimiento a tus solicitudes desde un solo lugar.">
-      <div className="grid gap-4 md:grid-cols-2">
-        <TarjetaSistema className="space-y-4">
-          <FileText className="h-8 w-8 text-[var(--brand-primary)]" />
-          <div className="space-y-2">
-            <TituloSistema nivel={2}>Reportar un problema</TituloSistema>
-            <TextoSistema variante="sutil">Envia al equipo de soporte los pasos y diagnosticos seguros sin exponer datos privados del navegador.</TextoSistema>
-          </div>
-          <Link href="/ayuda/reportar">
-            <BotonSistema>Reportar un problema</BotonSistema>
-          </Link>
-        </TarjetaSistema>
+    <DashboardLayout>
+      <ContenedorDashboard titulo="Ayuda" descripcion="Reporta problemas y da seguimiento a tus solicitudes desde un solo lugar.">
+        <div className="grid gap-4 md:grid-cols-2">
+          <TarjetaSistema className="space-y-4">
+            <FileText className="h-8 w-8 text-[var(--brand-primary)]" />
+            <div className="space-y-2">
+              <TituloSistema nivel={2}>Reportar un problema</TituloSistema>
+              <TextoSistema variante="sutil">Envia al equipo de soporte los pasos y diagnosticos seguros sin exponer datos privados del navegador.</TextoSistema>
+            </div>
+            <Link href="/ayuda/reportar">
+              <BotonSistema>Reportar un problema</BotonSistema>
+            </Link>
+          </TarjetaSistema>
 
-        <TarjetaSistema className="space-y-4">
-          <History className="h-8 w-8 text-[var(--brand-primary)]" />
-          <div className="space-y-2">
-            <TituloSistema nivel={2}>Historial de tickets</TituloSistema>
-            <TextoSistema variante="sutil">Revisa el estado de tus reportes y responde cuando soporte necesite mas informacion.</TextoSistema>
-          </div>
-          <Link href="/ayuda/tickets">
-            <BotonSistema variante="outline">Ver mis tickets</BotonSistema>
-          </Link>
-        </TarjetaSistema>
-      </div>
-    </ContenedorDashboard>
+          <TarjetaSistema className="space-y-4">
+            <History className="h-8 w-8 text-[var(--brand-primary)]" />
+            <div className="space-y-2">
+              <TituloSistema nivel={2}>Historial de tickets</TituloSistema>
+              <TextoSistema variante="sutil">Revisa el estado de tus reportes y responde cuando soporte necesite mas informacion.</TextoSistema>
+            </div>
+            <Link href="/ayuda/tickets">
+              <BotonSistema variante="outline">Ver mis tickets</BotonSistema>
+            </Link>
+          </TarjetaSistema>
+        </div>
+      </ContenedorDashboard>
+    </DashboardLayout>
   )
 }

--- a/app/(auth)/ayuda/reportar/page.tsx
+++ b/app/(auth)/ayuda/reportar/page.tsx
@@ -1,12 +1,15 @@
+import { DashboardLayout } from '@/components/layout/dashboard-layout'
 import { ContenedorDashboard, TarjetaSistema } from '@/components/ui/sistema-diseno'
 import { SupportTicketCreateForm } from './support-ticket-create-form'
 
 export default async function ReportarPage() {
   return (
-    <ContenedorDashboard titulo="Reportar un problema" botonRegreso={{ href: '/ayuda', texto: 'Volver a Ayuda' }}>
-      <TarjetaSistema>
-        <SupportTicketCreateForm appBuildVersion={process.env.NEXT_PUBLIC_APP_VERSION ?? ''} />
-      </TarjetaSistema>
-    </ContenedorDashboard>
+    <DashboardLayout>
+      <ContenedorDashboard titulo="Reportar un problema" botonRegreso={{ href: '/ayuda', texto: 'Volver a Ayuda' }}>
+        <TarjetaSistema>
+          <SupportTicketCreateForm appBuildVersion={process.env.NEXT_PUBLIC_APP_VERSION ?? ''} />
+        </TarjetaSistema>
+      </ContenedorDashboard>
+    </DashboardLayout>
   )
 }

--- a/app/(auth)/ayuda/reportar/page.tsx
+++ b/app/(auth)/ayuda/reportar/page.tsx
@@ -1,47 +1,11 @@
-import { createSupportTicket } from '@/lib/actions/support.actions'
-import { BotonSistema, ContenedorDashboard, InputSistema, TarjetaSistema, TextareaSistema, TextoSistema } from '@/components/ui/sistema-diseno'
+import { ContenedorDashboard, TarjetaSistema } from '@/components/ui/sistema-diseno'
+import { SupportTicketCreateForm } from './support-ticket-create-form'
 
 export default async function ReportarPage() {
-  async function submitTicket(formData: FormData) {
-    'use server'
-    await createSupportTicket(formData)
-  }
-
   return (
     <ContenedorDashboard titulo="Reportar un problema" botonRegreso={{ href: '/ayuda', texto: 'Volver a Ayuda' }}>
       <TarjetaSistema>
-        <form action={submitTicket} className="space-y-5">
-          <InputSistema name="title" label="Titulo" minLength={5} maxLength={160} required placeholder="Ejemplo: No puedo abrir el mapa del grupo" />
-          <TextareaSistema name="description" label="Pasos y resultado esperado" filas={6} minLength={10} maxLength={8000} required placeholder="Cuentanos que ocurrio, que esperabas y como reproducirlo." />
-          <div className="grid gap-4 md:grid-cols-2">
-            <label className="space-y-2 text-sm font-medium text-foreground">
-              <span>Categoria</span>
-              <select name="category" defaultValue="bug" className="block w-full min-h-[44px] rounded-xl border border-border bg-card/50 px-3 py-3 text-foreground focus:outline-none focus:ring-2 focus:ring-[var(--brand-primary)]/20">
-                <option value="bug">Error</option><option value="access">Acceso</option><option value="data">Datos</option><option value="other">Otro</option>
-              </select>
-            </label>
-            <label className="space-y-2 text-sm font-medium text-foreground">
-              <span>Severidad</span>
-              <select name="severity" defaultValue="normal" className="block w-full min-h-[44px] rounded-xl border border-border bg-card/50 px-3 py-3 text-foreground focus:outline-none focus:ring-2 focus:ring-[var(--brand-primary)]/20">
-                <option value="low">Baja</option><option value="normal">Normal</option><option value="high">Alta</option><option value="urgent">Urgente</option>
-              </select>
-            </label>
-          </div>
-          <div className="grid gap-4 md:grid-cols-2">
-            <InputSistema name="currentRoute" label="Ruta" placeholder="/dashboard" />
-            <InputSistema name="viewport" label="Viewport" placeholder="390x844" />
-            <InputSistema name="browserName" label="Navegador" placeholder="Chrome, Safari, Edge" />
-            <InputSistema name="osName" label="Sistema operativo" placeholder="macOS, iOS, Android" />
-          </div>
-          <InputSistema name="sentryEventId" label="ID de evento de Sentry" placeholder="Referencia opcional" />
-          <input type="hidden" name="appBuildVersion" value={process.env.NEXT_PUBLIC_APP_VERSION ?? ''} />
-          <label className="flex items-start gap-3 text-sm text-foreground">
-            <input type="checkbox" name="diagnosticsConsent" value="true" className="mt-1 h-4 w-4 rounded border-border" />
-            <span><strong>Permitir diagnosticos seguros</strong><br /><span className="text-muted-foreground">Solo se guardan ruta, navegador, sistema operativo, viewport, version de la app y referencia de Sentry. Nunca recopilamos cookies, contrasenas, localStorage ni payloads sin procesar.</span></span>
-          </label>
-          <TextoSistema variante="muted" tamaño="sm">Los adjuntos se suben despues de crear el ticket desde el flujo privado de adjuntos.</TextoSistema>
-          <BotonSistema type="submit">Enviar ticket</BotonSistema>
-        </form>
+        <SupportTicketCreateForm appBuildVersion={process.env.NEXT_PUBLIC_APP_VERSION ?? ''} />
       </TarjetaSistema>
     </ContenedorDashboard>
   )

--- a/app/(auth)/ayuda/reportar/support-ticket-create-form.tsx
+++ b/app/(auth)/ayuda/reportar/support-ticket-create-form.tsx
@@ -1,9 +1,10 @@
 'use client'
 
-import { useActionState, useEffect, useRef, useState } from 'react'
+import { useActionState, useCallback, useEffect, useRef, useState } from 'react'
 
 import { createSupportTicketFromForm } from '@/lib/actions/support.actions'
 import { BotonSistema, InputSistema, TextareaSistema, TextoSistema } from '@/components/ui/sistema-diseno'
+import { useNotificaciones } from '@/hooks/use-notificaciones'
 import { SupportTicketDiagnosticsFields } from './support-ticket-diagnostics-fields'
 
 type UploadStatus = 'idle' | 'uploading' | 'finalizing' | 'uploaded' | 'failed'
@@ -11,27 +12,17 @@ type AttachmentUpload = { clientId: string; name: string; status: UploadStatus; 
 type IntentAttachment = { id: string; uploadUrl: string }
 
 export function SupportTicketCreateForm({ appBuildVersion }: { appBuildVersion: string }) {
+  const toast = useNotificaciones()
   const [state, formAction, isPending] = useActionState(createSupportTicketFromForm, null)
   const [files, setFiles] = useState<File[]>([])
   const [uploads, setUploads] = useState<AttachmentUpload[]>([])
   const uploadStartedFor = useRef<string | null>(null)
 
-  useEffect(() => {
-    if (!state?.success || uploadStartedFor.current === state.ticketId) return
-    uploadStartedFor.current = state.ticketId
-    if (files.length === 0) return
-    void uploadFiles(state.ticketId, files)
-  }, [files, state])
+  const updateUpload = useCallback((clientId: string, patch: Partial<AttachmentUpload>) => {
+    setUploads((currentUploads) => currentUploads.map((upload) => upload.clientId === clientId ? { ...upload, ...patch } : upload))
+  }, [])
 
-  const uploadFiles = async (ticketId: string, selectedFiles: File[]) => {
-    for (const [index, file] of selectedFiles.entries()) {
-      const upload = uploads[index]
-      if (!upload) continue
-      await uploadFile(ticketId, file, upload)
-    }
-  }
-
-  const uploadFile = async (ticketId: string, file: File, upload: AttachmentUpload) => {
+  const uploadFile = useCallback(async (ticketId: string, file: File, upload: AttachmentUpload) => {
     try {
       const intent = await createAttachmentIntent(ticketId, file, upload.attachmentId)
       updateUpload(upload.clientId, { status: 'uploading', progress: 0, error: undefined, attachmentId: intent.id, uploadUrl: intent.uploadUrl })
@@ -42,7 +33,31 @@ export function SupportTicketCreateForm({ appBuildVersion }: { appBuildVersion: 
     } catch (error) {
       updateUpload(upload.clientId, { status: 'failed', error: error instanceof Error ? error.message : 'No se pudo subir el adjunto' })
     }
-  }
+  }, [updateUpload])
+
+  const uploadFiles = useCallback(async (ticketId: string, selectedFiles: File[]) => {
+    for (const [index, file] of selectedFiles.entries()) {
+      const upload = uploads[index]
+      if (!upload) continue
+      await uploadFile(ticketId, file, upload)
+    }
+  }, [uploadFile, uploads])
+
+  useEffect(() => {
+    if (!state?.success || uploadStartedFor.current === state.ticketId) return
+    uploadStartedFor.current = state.ticketId
+    toast.success(`Ticket #${state.ticketNumber} creado`)
+    if (files.length === 0) return
+    queueMicrotask(() => { void uploadFiles(state.ticketId, files) })
+  }, [files, state, toast, uploadFiles])
+
+  useEffect(() => {
+    if (isPending) toast.info('Enviando ticket de soporte...')
+  }, [isPending, toast])
+
+  useEffect(() => {
+    if (state && !state.success) toast.error(state.error)
+  }, [state, toast])
 
   const retryUpload = (clientId: string) => {
     if (!state?.success) return
@@ -93,9 +108,6 @@ export function SupportTicketCreateForm({ appBuildVersion }: { appBuildVersion: 
     </form>
   )
 
-  function updateUpload(clientId: string, patch: Partial<AttachmentUpload>) {
-    setUploads((currentUploads) => currentUploads.map((upload) => upload.clientId === clientId ? { ...upload, ...patch } : upload))
-  }
 }
 
 export function createAttachmentUploadItems(files: File[]): AttachmentUpload[] {

--- a/app/(auth)/ayuda/reportar/support-ticket-create-form.tsx
+++ b/app/(auth)/ayuda/reportar/support-ticket-create-form.tsx
@@ -1,0 +1,178 @@
+'use client'
+
+import { useActionState, useEffect, useRef, useState } from 'react'
+
+import { createSupportTicketFromForm } from '@/lib/actions/support.actions'
+import { BotonSistema, InputSistema, TextareaSistema, TextoSistema } from '@/components/ui/sistema-diseno'
+import { SupportTicketDiagnosticsFields } from './support-ticket-diagnostics-fields'
+
+type UploadStatus = 'idle' | 'uploading' | 'finalizing' | 'uploaded' | 'failed'
+type AttachmentUpload = { clientId: string; name: string; status: UploadStatus; progress: number; error?: string; attachmentId?: string; uploadUrl?: string }
+type IntentAttachment = { id: string; uploadUrl: string }
+
+export function SupportTicketCreateForm({ appBuildVersion }: { appBuildVersion: string }) {
+  const [state, formAction, isPending] = useActionState(createSupportTicketFromForm, null)
+  const [files, setFiles] = useState<File[]>([])
+  const [uploads, setUploads] = useState<AttachmentUpload[]>([])
+  const uploadStartedFor = useRef<string | null>(null)
+
+  useEffect(() => {
+    if (!state?.success || uploadStartedFor.current === state.ticketId) return
+    uploadStartedFor.current = state.ticketId
+    if (files.length === 0) return
+    void uploadFiles(state.ticketId, files)
+  }, [files, state])
+
+  const uploadFiles = async (ticketId: string, selectedFiles: File[]) => {
+    for (const [index, file] of selectedFiles.entries()) {
+      const upload = uploads[index]
+      if (!upload) continue
+      await uploadFile(ticketId, file, upload)
+    }
+  }
+
+  const uploadFile = async (ticketId: string, file: File, upload: AttachmentUpload) => {
+    try {
+      const intent = await createAttachmentIntent(ticketId, file, upload.attachmentId)
+      updateUpload(upload.clientId, { status: 'uploading', progress: 0, error: undefined, attachmentId: intent.id, uploadUrl: intent.uploadUrl })
+      await uploadToR2(intent.uploadUrl, file, (progress) => updateUpload(upload.clientId, { progress }))
+      updateUpload(upload.clientId, { status: 'finalizing', progress: 100 })
+      await finalizeAttachment(intent.id)
+      updateUpload(upload.clientId, { status: 'uploaded', progress: 100 })
+    } catch (error) {
+      updateUpload(upload.clientId, { status: 'failed', error: error instanceof Error ? error.message : 'No se pudo subir el adjunto' })
+    }
+  }
+
+  const retryUpload = (clientId: string) => {
+    if (!state?.success) return
+    const uploadIndex = uploads.findIndex((upload) => upload.clientId === clientId)
+    const upload = uploads[uploadIndex]
+    const file = files[uploadIndex]
+    if (!upload || !file || !shouldCreateFreshAttachmentIntent(upload)) return
+    void uploadFile(state.ticketId, file, upload)
+  }
+
+  const handleFiles = (event: React.ChangeEvent<HTMLInputElement>) => {
+    const selectedFiles = Array.from(event.target.files ?? [])
+    setFiles(selectedFiles)
+    setUploads(createAttachmentUploadItems(selectedFiles))
+    uploadStartedFor.current = null
+  }
+
+  const statusText = uploads.length === 0
+    ? 'Esperando envio del ticket para iniciar adjuntos.'
+    : uploads.map((upload) => `${upload.name}: ${formatUploadStatus(upload)}`).join(' | ')
+
+  return (
+    <form action={formAction} className="space-y-5">
+      <InputSistema name="subject" label="Asunto" minLength={5} maxLength={160} required placeholder="Ejemplo: No puedo abrir el mapa del grupo" />
+      <TextareaSistema name="description" label="Descripcion" filas={6} minLength={10} maxLength={8000} required placeholder="Cuentanos que ocurrio, que esperabas y como reproducirlo." />
+      <label className="space-y-2 text-sm font-medium text-foreground">
+        <span>Categoria</span>
+        <select name="category" defaultValue="bug" className="block w-full min-h-[44px] rounded-xl border border-border bg-card/50 px-3 py-3 text-foreground focus:outline-none focus:ring-2 focus:ring-[var(--brand-primary)]/20">
+          <option value="bug">Error</option><option value="access">Acceso</option><option value="data">Datos</option><option value="other">Otro</option>
+        </select>
+      </label>
+      <label className="space-y-2 text-sm font-medium text-foreground">
+        <span>Adjuntos</span>
+        <input type="file" multiple accept="image/png,image/jpeg,image/webp,video/mp4,video/webm,video/quicktime" onChange={handleFiles} className="block w-full min-h-[44px] rounded-xl border border-border bg-card/50 px-3 py-3 text-foreground file:mr-4 file:rounded-lg file:border-0 file:bg-[var(--brand-primary)] file:px-3 file:py-2 file:text-sm file:font-medium file:text-white focus:outline-none focus:ring-2 focus:ring-[var(--brand-primary)]/20" />
+      </label>
+      <SupportTicketDiagnosticsFields appBuildVersion={appBuildVersion} />
+      <TextoSistema variante="muted" tamaño="sm">Recopilamos diagnosticos tecnicos seguros automaticamente: ruta sin parametros, navegador, sistema operativo, viewport, version de la app y referencia de Sentry. Nunca recopilamos cookies, contrasenas, localStorage, payloads sin procesar, URLs firmadas ni claves de objetos.</TextoSistema>
+      <TextoSistema variante="muted" tamaño="sm">Sube hasta 5 capturas PNG/JPG/WebP de 10MB o menos y hasta 1 video MP4/WebM/MOV de 100MB o menos. El total por ticket no puede superar 150MB.</TextoSistema>
+      <div data-testid="support-attachment-status" className="rounded-xl border border-border bg-card/50 p-3 text-sm text-muted-foreground" aria-live="polite">
+        {statusText}
+        {uploads.filter((upload) => upload.status === 'failed').map((upload) => (
+          <button key={upload.clientId} type="button" onClick={() => retryUpload(upload.clientId)} className="ml-3 font-medium text-[var(--brand-primary)]">Reintentar {upload.name}</button>
+        ))}
+      </div>
+      {state && !state.success && <p role="alert" className="text-sm text-destructive">{state.error}</p>}
+      {state?.success && <TextoSistema variante="muted" tamaño="sm">Ticket #{state.ticketNumber} creado. Los adjuntos finalizados quedan asociados al ticket de forma privada.</TextoSistema>}
+      <BotonSistema type="submit" disabled={isPending}>{isPending ? 'Enviando...' : 'Enviar ticket'}</BotonSistema>
+    </form>
+  )
+
+  function updateUpload(clientId: string, patch: Partial<AttachmentUpload>) {
+    setUploads((currentUploads) => currentUploads.map((upload) => upload.clientId === clientId ? { ...upload, ...patch } : upload))
+  }
+}
+
+export function createAttachmentUploadItems(files: File[]): AttachmentUpload[] {
+  return files.map((file, index) => ({ clientId: `${file.name}:${file.size}:${file.type}:${index}`, name: file.name, status: 'idle', progress: 0 }))
+}
+
+export function shouldCreateFreshAttachmentIntent(upload: AttachmentUpload) {
+  return upload.status === 'failed'
+}
+
+export function buildAttachmentIntentRequestBody(ticketId: string, file: File, replaceAttachmentId?: string) {
+  return {
+    ticketId,
+    ...(replaceAttachmentId ? { replaceAttachmentId } : {}),
+    files: [{ filename: file.name, contentType: file.type, byteSize: file.size }],
+  }
+}
+
+async function createAttachmentIntent(ticketId: string, file: File, replaceAttachmentId?: string): Promise<IntentAttachment> {
+  const response = await fetch('/api/support/attachments/intent', {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify(buildAttachmentIntentRequestBody(ticketId, file, replaceAttachmentId)),
+  })
+  const body: unknown = await response.json()
+  if (!response.ok) throw new Error(readError(body, 'No se pudo autorizar el adjunto'))
+  const attachments = parseIntentAttachments(body)
+  if (attachments.length !== 1) throw new Error('Respuesta de adjunto invalida')
+  return attachments[0]
+}
+
+function uploadToR2(uploadUrl: string, file: File, onProgress: (progress: number) => void) {
+  return new Promise<void>((resolve, reject) => {
+    const request = new XMLHttpRequest()
+    request.open('PUT', uploadUrl)
+    request.setRequestHeader('content-type', file.type)
+    request.upload.onprogress = (event) => {
+      if (!event.lengthComputable) return
+      onProgress(Math.round((event.loaded / event.total) * 100))
+    }
+    request.onload = () => request.status >= 200 && request.status < 300 ? resolve() : reject(new Error('No se pudo subir el adjunto privado'))
+    request.onerror = () => reject(new Error('No se pudo subir el adjunto privado'))
+    request.send(file)
+  })
+}
+
+async function finalizeAttachment(attachmentId: string) {
+  const response = await fetch('/api/support/attachments/finalize', {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify({ attachmentId }),
+  })
+  const body: unknown = await response.json()
+  if (!response.ok) throw new Error(readError(body, 'No se pudo finalizar el adjunto'))
+}
+
+function parseIntentAttachments(body: unknown): IntentAttachment[] {
+  if (!isRecord(body) || !Array.isArray(body.attachments)) return []
+  return body.attachments.filter(isIntentAttachment)
+}
+
+function isIntentAttachment(value: unknown): value is IntentAttachment {
+  return isRecord(value) && typeof value.id === 'string' && typeof value.uploadUrl === 'string'
+}
+
+function readError(body: unknown, fallback: string) {
+  return isRecord(body) && typeof body.error === 'string' ? body.error : fallback
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null
+}
+
+function formatUploadStatus(upload: AttachmentUpload) {
+  if (upload.status === 'idle') return 'esperando envio'
+  if (upload.status === 'uploading') return `subiendo ${upload.progress}%`
+  if (upload.status === 'finalizing') return 'finalizando'
+  if (upload.status === 'uploaded') return 'finalizado'
+  return `fallo${upload.error ? ` (${upload.error})` : ''}`
+}

--- a/app/(auth)/ayuda/reportar/support-ticket-diagnostics-fields.tsx
+++ b/app/(auth)/ayuda/reportar/support-ticket-diagnostics-fields.tsx
@@ -1,0 +1,63 @@
+'use client'
+
+import { useEffect, useState } from 'react'
+
+type SupportTicketDiagnosticsFieldsProps = {
+  appBuildVersion: string
+}
+
+type SafeDiagnostics = {
+  currentRoute: string
+  browserName: string
+  osName: string
+  viewport: string
+}
+
+const initialDiagnostics: SafeDiagnostics = {
+  currentRoute: '',
+  browserName: '',
+  osName: '',
+  viewport: '',
+}
+
+export function SupportTicketDiagnosticsFields({ appBuildVersion }: SupportTicketDiagnosticsFieldsProps) {
+  const [diagnostics, setDiagnostics] = useState(initialDiagnostics)
+
+  useEffect(() => {
+    setDiagnostics({
+      currentRoute: window.location.pathname,
+      browserName: getBrowserFamily(window.navigator.userAgent),
+      osName: getOsFamily(window.navigator.userAgent),
+      viewport: `${window.innerWidth}x${window.innerHeight}`,
+    })
+  }, [])
+
+  return (
+    <>
+      <input type="hidden" name="currentRoute" value={diagnostics.currentRoute} />
+      <input type="hidden" name="browserName" value={diagnostics.browserName} />
+      <input type="hidden" name="osName" value={diagnostics.osName} />
+      <input type="hidden" name="viewport" value={diagnostics.viewport} />
+      <input type="hidden" name="appBuildVersion" value={appBuildVersion} />
+      <input type="hidden" name="sentryEventId" value="" />
+      <input type="hidden" name="diagnosticsConsent" value="true" />
+    </>
+  )
+}
+
+function getBrowserFamily(userAgent: string) {
+  if (/Edg\//.test(userAgent)) return 'Edge'
+  if (/Chrome\//.test(userAgent)) return 'Chrome'
+  if (/Safari\//.test(userAgent) && !/Chrome\//.test(userAgent)) return 'Safari'
+  if (/Firefox\//.test(userAgent)) return 'Firefox'
+  return 'Unknown'
+}
+
+function getOsFamily(userAgent: string) {
+  if (/Windows NT/.test(userAgent)) return 'Windows'
+  if (/Mac OS X/.test(userAgent)) return 'macOS'
+  if (/Android/.test(userAgent)) return 'Android'
+  if (/iPhone|iPad|iPod/.test(userAgent)) return 'iOS'
+  if (/Linux/.test(userAgent)) return 'Linux'
+  return 'Unknown'
+}

--- a/app/(auth)/ayuda/tickets/[id]/page.tsx
+++ b/app/(auth)/ayuda/tickets/[id]/page.tsx
@@ -42,120 +42,126 @@ export default async function TicketDetailPage({ params }: { params: Promise<{ i
   const assignee = createParticipant(ticket.assignee, 'Sin asignar')
 
   return (
-    <DashboardLayout>
-      <ContenedorDashboard titulo={`Ticket #${ticket.ticketNumber}`} botonRegreso={{ href: '/ayuda/tickets', texto: 'Volver a tickets' }}>
-        <TarjetaSistema className="overflow-hidden border-border/70 p-0">
-          <div className="border-b border-border bg-muted/20 p-4 sm:p-5">
-            <div className="flex flex-col gap-3 lg:flex-row lg:items-start lg:justify-between">
-              <div className="min-w-0 space-y-1.5">
-                <div className="flex flex-wrap items-center gap-2 text-[11px] font-medium uppercase tracking-[0.18em] text-muted-foreground">
-                  <span>Ticket #{ticket.ticketNumber}</span>
-                  <span aria-hidden="true">/</span>
-                  <span>{formatCategory(ticket.category)}</span>
+    <DashboardLayout className="lg:overflow-hidden">
+      <ContenedorDashboard className="lg:h-full lg:min-h-0" titulo={`Ticket #${ticket.ticketNumber}`} botonRegreso={{ href: '/ayuda/tickets', texto: 'Volver a tickets' }}>
+        <div className="space-y-6 lg:grid lg:h-[calc(100dvh-8rem)] lg:min-h-0 lg:grid-rows-[auto_minmax(0,1fr)] lg:gap-4 lg:space-y-0">
+          <TarjetaSistema className="overflow-hidden border-border/70 p-0">
+            <div className="border-b border-border bg-muted/20 p-4 sm:p-5">
+              <div className="flex flex-col gap-3 lg:flex-row lg:items-start lg:justify-between">
+                <div className="min-w-0 space-y-1.5">
+                  <div className="flex flex-wrap items-center gap-2 text-[11px] font-medium uppercase tracking-[0.18em] text-muted-foreground">
+                    <span>Ticket #{ticket.ticketNumber}</span>
+                    <span aria-hidden="true">/</span>
+                    <span>{formatCategory(ticket.category)}</span>
+                  </div>
+                  <TituloSistema nivel={2} className="text-balance leading-tight">{ticket.title}</TituloSistema>
+                  <TextoSistema tamaño="sm" className="max-w-3xl">{ticket.description}</TextoSistema>
                 </div>
-                <TituloSistema nivel={2} className="text-balance leading-tight">{ticket.title}</TituloSistema>
-                <TextoSistema tamaño="sm" className="max-w-3xl">{ticket.description}</TextoSistema>
-              </div>
-              <div className="flex flex-wrap items-center gap-2 lg:justify-end">
-                <BadgeSistema variante="info">{formatSupportStatus(ticket.status)}</BadgeSistema>
-                <span className="rounded-full border border-border bg-card px-3 py-1 text-xs font-medium text-muted-foreground">Prioridad {formatSeverity(ticket.severity)}</span>
+                <div className="flex flex-wrap items-center gap-2 lg:justify-end">
+                  <BadgeSistema variante="info">{formatSupportStatus(ticket.status)}</BadgeSistema>
+                  <span className="rounded-full border border-border bg-card px-3 py-1 text-xs font-medium text-muted-foreground">Prioridad {formatSeverity(ticket.severity)}</span>
+                </div>
               </div>
             </div>
-          </div>
 
-          <div className="grid gap-3 p-3 sm:grid-cols-3 sm:p-4">
-            <TicketStat label="Creado" value={formatMessageTimestamp(ticket.createdAt)} />
-            <TicketStat label="Actualizado" value={formatMessageTimestamp(ticket.updatedAt)} />
-            <TicketStat label="Responsable" value={assignee.fullName} />
-          </div>
-        </TarjetaSistema>
+            <div className="grid gap-3 p-3 sm:grid-cols-3 sm:p-4">
+              <TicketStat label="Creado" value={formatMessageTimestamp(ticket.createdAt)} />
+              <TicketStat label="Actualizado" value={formatMessageTimestamp(ticket.updatedAt)} />
+              <TicketStat label="Responsable" value={assignee.fullName} />
+            </div>
+          </TarjetaSistema>
 
-        <div className="grid items-start gap-5 xl:grid-cols-[280px_minmax(0,1fr)_320px]">
-          <aside className="order-2 space-y-4 xl:order-1">
-            <TarjetaSistema className="space-y-3">
-              <SectionHeader eyebrow="Contexto" title="Solicitante" />
-              <ParticipantSummary participant={reporter} role="Solicitante" />
-              <div className="grid gap-2 border-t border-border pt-3 text-sm">
-                <MetadataRow label="Categoría" value={formatCategory(ticket.category)} />
-                <MetadataRow label="Prioridad" value={formatSeverity(ticket.severity)} />
-                <MetadataRow label="Estado" value={formatSupportStatus(ticket.status)} />
-                <MetadataRow label="Responsable" value={assignee.fullName} />
-              </div>
-            </TarjetaSistema>
-          </aside>
-
-          <section className="order-1 space-y-4 xl:order-2">
-            <TarjetaSistema className="space-y-4">
-              <div className="flex flex-col gap-2 sm:flex-row sm:items-end sm:justify-between">
-                <SectionHeader eyebrow="Actividad" title="Conversación" />
-                <TextoSistema variante="muted" tamaño="sm">{ticket.messages.length} {ticket.messages.length === 1 ? 'respuesta pública' : 'respuestas públicas'}</TextoSistema>
-              </div>
-
-              {ticket.messages.length === 0 ? (
-                <div className="rounded-2xl border border-dashed border-border bg-muted/20 p-5 text-center">
-                  <TextoSistema variante="sutil">Aún no hay respuestas públicas.</TextoSistema>
+          <div className="grid items-start gap-5 lg:min-h-0 lg:grid-cols-[260px_minmax(0,1fr)_300px] lg:items-stretch xl:grid-cols-[280px_minmax(0,1fr)_320px]">
+            <aside className="order-2 space-y-4 lg:order-1 lg:flex lg:min-h-0 lg:flex-col lg:space-y-0 lg:gap-4 lg:overflow-hidden">
+              <TarjetaSistema className="space-y-3 lg:flex-none">
+                <SectionHeader eyebrow="Contexto" title="Solicitante" />
+                <ParticipantSummary participant={reporter} role="Solicitante" />
+                <div className="grid gap-2 border-t border-border pt-3 text-sm">
+                  <MetadataRow label="Categoría" value={formatCategory(ticket.category)} />
+                  <MetadataRow label="Prioridad" value={formatSeverity(ticket.severity)} />
+                  <MetadataRow label="Estado" value={formatSupportStatus(ticket.status)} />
+                  <MetadataRow label="Responsable" value={assignee.fullName} />
                 </div>
-              ) : (
-                <div className="space-y-3">
-                  {ticket.messages.map((message) => {
-                    const isReporter = isReporterMessage(message.authorUsuarioId, ticket.reporterUsuarioId)
-                    const roleLabel = isReporter ? 'Solicitante' : 'Equipo de soporte'
-                    const participant = createParticipant(message.author, roleLabel)
-
-                    return <MessageBubble key={message.id} message={message} participant={participant} roleLabel={roleLabel} isReporter={isReporter} />
-                  })}
-                </div>
-              )}
-
-              <div className="border-t border-border pt-4">
-                <SupportTicketReplyComposer action={canStaffReply ? staffReplyAction : replyAction} isStaffReply={canStaffReply} />
-              </div>
-            </TarjetaSistema>
-          </section>
-
-          <aside className="order-3 space-y-5">
-            {canManage && (
-              <TarjetaSistema className="space-y-4">
-                <SectionHeader eyebrow="Gestión" title="Estado del ticket" />
-                <SupportTicketStatusForm action={statusAction} currentStatus={ticket.status} options={STATUS_OPTIONS} />
               </TarjetaSistema>
-            )}
 
-            <TarjetaSistema className="space-y-4">
-              <div className="flex items-start justify-between gap-3">
-                <SectionHeader eyebrow="Evidencia" title="Adjuntos" />
-                <span className="rounded-full bg-muted px-2.5 py-1 text-xs font-medium text-muted-foreground">{ticket.attachments.length}</span>
-              </div>
-              {ticket.attachments.length === 0 ? (
-                <TextoSistema variante="sutil">No hay adjuntos finalizados.</TextoSistema>
-              ) : ticket.attachments.map((attachment) => (
-                <div key={attachment.id} className="rounded-2xl border border-border bg-muted/20 p-3">
-                  <div className="min-w-0">
-                    <p className="truncate text-sm font-semibold text-foreground">{attachment.filename}</p>
-                    <TextoSistema variante="muted" tamaño="sm">{formatAttachmentKind(attachment.kind)} · {formatBytes(attachment.byteSize)}</TextoSistema>
-                    <TextoSistema variante="muted" tamaño="sm">{attachment.contentType} · {formatAttachmentStatus(attachment.status)}</TextoSistema>
+              {ticket.evidence.diagnosticsConsent && (
+                <TarjetaSistema className="space-y-4 lg:flex lg:min-h-0 lg:flex-1 lg:flex-col lg:overflow-hidden">
+                  <SectionHeader eyebrow="Diagnóstico" title="Datos seguros" />
+                  <div className="grid gap-3 text-sm lg:min-h-0 lg:flex-1 lg:overflow-y-auto lg:pr-1">
+                    <MetadataRow label="Ruta" value={ticket.evidence.currentRoute ?? 'Ruta no disponible'} />
+                    <MetadataRow label="Navegador" value={ticket.evidence.browserName ?? 'Navegador no disponible'} />
+                    <MetadataRow label="Sistema" value={ticket.evidence.osName ?? 'Sistema operativo no disponible'} />
+                    <MetadataRow label="Viewport" value={ticket.evidence.viewport ?? 'Viewport no disponible'} />
                   </div>
-                  {attachment.status === 'uploaded' && (
-                    <a href={`/api/support/attachments/${attachment.id}/download`} aria-label={`Descargar ${attachment.filename}`} className="mt-3 inline-flex min-h-10 items-center rounded-xl border border-border px-3 text-sm font-medium text-[var(--brand-primary)] transition-colors hover:bg-card">
-                      Descargar archivo
-                    </a>
+                </TarjetaSistema>
+              )}
+            </aside>
+
+            <section className="order-1 lg:order-2 lg:min-h-0">
+              <TarjetaSistema className="space-y-4 lg:flex lg:h-full lg:min-h-0 lg:flex-col lg:overflow-hidden">
+                <div className="flex flex-col gap-2 sm:flex-row sm:items-end sm:justify-between lg:flex-none">
+                  <SectionHeader eyebrow="Actividad" title="Conversación" />
+                  <TextoSistema variante="muted" tamaño="sm">{ticket.messages.length} {ticket.messages.length === 1 ? 'respuesta pública' : 'respuestas públicas'}</TextoSistema>
+                </div>
+
+                <div className="lg:min-h-0 lg:flex-1 lg:overflow-y-auto lg:pr-1">
+                  {ticket.messages.length === 0 ? (
+                    <div className="rounded-2xl border border-dashed border-border bg-muted/20 p-5 text-center lg:min-h-full lg:content-center">
+                      <TextoSistema variante="sutil">Aún no hay respuestas públicas.</TextoSistema>
+                    </div>
+                  ) : (
+                    <div className="space-y-3">
+                      {ticket.messages.map((message) => {
+                        const isReporter = isReporterMessage(message.authorUsuarioId, ticket.reporterUsuarioId)
+                        const roleLabel = isReporter ? 'Solicitante' : 'Equipo de soporte'
+                        const participant = createParticipant(message.author, roleLabel)
+
+                        return <MessageBubble key={message.id} message={message} participant={participant} roleLabel={roleLabel} isReporter={isReporter} />
+                      })}
+                    </div>
                   )}
                 </div>
-              ))}
-            </TarjetaSistema>
 
-            {ticket.evidence.diagnosticsConsent && (
-              <TarjetaSistema className="space-y-4">
-                <SectionHeader eyebrow="Diagnóstico" title="Datos seguros" />
-                <div className="grid gap-3 text-sm">
-                  <MetadataRow label="Ruta" value={ticket.evidence.currentRoute ?? 'Ruta no disponible'} />
-                  <MetadataRow label="Navegador" value={ticket.evidence.browserName ?? 'Navegador no disponible'} />
-                  <MetadataRow label="Sistema" value={ticket.evidence.osName ?? 'Sistema operativo no disponible'} />
-                  <MetadataRow label="Viewport" value={ticket.evidence.viewport ?? 'Viewport no disponible'} />
+                <div className="border-t border-border pt-4 lg:flex-none">
+                  <SupportTicketReplyComposer action={canStaffReply ? staffReplyAction : replyAction} isStaffReply={canStaffReply} />
                 </div>
               </TarjetaSistema>
-            )}
-          </aside>
+            </section>
+
+            <aside className="order-3 space-y-5 lg:flex lg:min-h-0 lg:flex-col lg:space-y-0 lg:gap-4 lg:overflow-hidden">
+              {canManage && (
+                <TarjetaSistema className="space-y-4 lg:flex-none">
+                  <SectionHeader eyebrow="Gestión" title="Estado del ticket" />
+                  <SupportTicketStatusForm action={statusAction} currentStatus={ticket.status} options={STATUS_OPTIONS} />
+                </TarjetaSistema>
+              )}
+
+              <TarjetaSistema className="space-y-4 lg:flex lg:min-h-0 lg:flex-1 lg:flex-col lg:overflow-hidden">
+                <div className="flex items-start justify-between gap-3 lg:flex-none">
+                  <SectionHeader eyebrow="Evidencia" title="Adjuntos" />
+                  <span className="rounded-full bg-muted px-2.5 py-1 text-xs font-medium text-muted-foreground">{ticket.attachments.length}</span>
+                </div>
+                <div className="space-y-4 lg:min-h-0 lg:flex-1 lg:overflow-y-auto lg:pr-1">
+                  {ticket.attachments.length === 0 ? (
+                    <TextoSistema variante="sutil">No hay adjuntos finalizados.</TextoSistema>
+                  ) : ticket.attachments.map((attachment) => (
+                    <div key={attachment.id} className="rounded-2xl border border-border bg-muted/20 p-3">
+                      <div className="min-w-0">
+                        <p className="truncate text-sm font-semibold text-foreground">{attachment.filename}</p>
+                        <TextoSistema variante="muted" tamaño="sm">{formatAttachmentKind(attachment.kind)} · {formatBytes(attachment.byteSize)}</TextoSistema>
+                        <TextoSistema variante="muted" tamaño="sm">{attachment.contentType} · {formatAttachmentStatus(attachment.status)}</TextoSistema>
+                      </div>
+                      {attachment.status === 'uploaded' && (
+                        <a href={`/api/support/attachments/${attachment.id}/download`} aria-label={`Descargar ${attachment.filename}`} className="mt-3 inline-flex min-h-10 items-center rounded-xl border border-border px-3 text-sm font-medium text-[var(--brand-primary)] transition-colors hover:bg-card">
+                          Descargar archivo
+                        </a>
+                      )}
+                    </div>
+                  ))}
+                </div>
+              </TarjetaSistema>
+            </aside>
+          </div>
         </div>
       </ContenedorDashboard>
     </DashboardLayout>

--- a/app/(auth)/ayuda/tickets/[id]/page.tsx
+++ b/app/(auth)/ayuda/tickets/[id]/page.tsx
@@ -1,8 +1,10 @@
 import { notFound } from 'next/navigation'
 
-import { assignSupportTicket, createStaffSupportTicketReply, createSupportTicketMessage, getSupportTicketDetail, updateSupportTicketStatus } from '@/lib/actions/support.actions'
+import { createStaffSupportTicketReply, createSupportTicketMessage, getSupportTicketDetail, updateSupportTicketStatus } from '@/lib/actions/support.actions'
 import { formatSupportStatus } from '@/lib/support/support-labels'
-import { BadgeSistema, BotonSistema, ContenedorDashboard, InputSistema, SelectSistema, TarjetaSistema, TextareaSistema, TextoSistema, TituloSistema } from '@/components/ui/sistema-diseno'
+import { DashboardLayout } from '@/components/layout/dashboard-layout'
+import { BadgeSistema, ContenedorDashboard, TarjetaSistema, TextoSistema, TituloSistema } from '@/components/ui/sistema-diseno'
+import { SupportTicketReplyComposer, SupportTicketStatusForm } from './support-ticket-detail-actions'
 
 const STATUS_OPTIONS = [
   { valor: 'received', etiqueta: 'Recibido' },
@@ -20,30 +22,25 @@ export default async function TicketDetailPage({ params }: { params: Promise<{ i
 
   async function replyAction(formData: FormData) {
     'use server'
-    await createSupportTicketMessage(ticket.id, formData)
+    return createSupportTicketMessage(ticket.id, formData)
   }
 
   async function staffReplyAction(formData: FormData) {
     'use server'
-    await createStaffSupportTicketReply(ticket.id, formData)
+    return createStaffSupportTicketReply(ticket.id, formData)
   }
 
   async function statusAction(formData: FormData) {
     'use server'
-    await updateSupportTicketStatus(ticket.id, String(formData.get('status') ?? ''))
-  }
-
-  async function assignmentAction(formData: FormData) {
-    'use server'
-    const assigneeUsuarioId = String(formData.get('assigneeUsuarioId') ?? '').trim() || null
-    await assignSupportTicket(ticket.id, assigneeUsuarioId)
+    return updateSupportTicketStatus(ticket.id, String(formData.get('status') ?? ''))
   }
 
   const canManage = ticket.supportCapabilities.includes('support.manage')
   const canStaffReply = canManage || ticket.supportCapabilities.includes('support.reply')
 
   return (
-    <ContenedorDashboard titulo={`Ticket #${ticket.ticketNumber}`} botonRegreso={{ href: '/ayuda/tickets', texto: 'Volver a tickets' }}>
+    <DashboardLayout>
+      <ContenedorDashboard titulo={`Ticket #${ticket.ticketNumber}`} botonRegreso={{ href: '/ayuda/tickets', texto: 'Volver a tickets' }}>
       <TarjetaSistema className="space-y-4">
         <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
           <div className="space-y-2">
@@ -72,41 +69,31 @@ export default async function TicketDetailPage({ params }: { params: Promise<{ i
 
       <TarjetaSistema className="space-y-4">
         <TituloSistema nivel={2}>Conversacion</TituloSistema>
-        {ticket.messages.length === 0 ? <TextoSistema variante="sutil">Aun no hay respuestas.</TextoSistema> : ticket.messages.map((message) => (
-          <div key={message.id} className="rounded-xl border border-border bg-card/50 p-3">
-            <TextoSistema>{message.body}</TextoSistema>
+        {ticket.messages.length === 0 ? <TextoSistema variante="sutil">Aun no hay respuestas.</TextoSistema> : (
+          <div className="space-y-4 border-l border-border pl-4">
+            {ticket.messages.map((message) => (
+              <article key={message.id} className="relative rounded-2xl border border-border bg-card/70 p-4 shadow-sm">
+                <span className="absolute -left-[23px] top-5 h-3 w-3 rounded-full border-2 border-card bg-[var(--brand-primary)]" aria-hidden="true" />
+                <div className="mb-2 flex flex-col gap-1 sm:flex-row sm:items-center sm:justify-between">
+                  <p className="text-sm font-semibold text-foreground">Actualizacion</p>
+                  <time className="text-xs text-muted-foreground" dateTime={message.createdAt}>{formatMessageTimestamp(message.createdAt)}</time>
+                </div>
+                <TextoSistema>{message.body}</TextoSistema>
+              </article>
+            ))}
           </div>
-        ))}
-        <form action={replyAction} className="space-y-3">
-          <TextareaSistema name="body" label="Respuesta" filas={4} required />
-          <BotonSistema type="submit">Enviar respuesta</BotonSistema>
-        </form>
+        )}
+        <SupportTicketReplyComposer action={canStaffReply ? staffReplyAction : replyAction} isStaffReply={canStaffReply} />
       </TarjetaSistema>
 
-      {(canStaffReply || canManage) && (
+      {canManage && (
         <TarjetaSistema className="space-y-4">
-          <TituloSistema nivel={2}>Operacion del equipo</TituloSistema>
-          {canStaffReply && (
-            <form action={staffReplyAction} className="space-y-3">
-              <TextareaSistema name="body" label="Respuesta del equipo" filas={4} required />
-              <BotonSistema type="submit">Enviar respuesta del equipo</BotonSistema>
-            </form>
-          )}
-          {canManage && (
-            <div className="grid gap-4 md:grid-cols-2">
-              <form action={statusAction} className="space-y-3">
-                <SelectSistema label="Nuevo estado" name="status" defaultValue={ticket.status} opciones={STATUS_OPTIONS} />
-                <BotonSistema type="submit">Actualizar estado</BotonSistema>
-              </form>
-              <form action={assignmentAction} className="space-y-3">
-                <InputSistema label="Responsable" name="assigneeUsuarioId" defaultValue={ticket.assigneeUsuarioId ?? ''} placeholder="UUID del usuario responsable" />
-                <BotonSistema type="submit">Actualizar responsable</BotonSistema>
-              </form>
-            </div>
-          )}
+          <TituloSistema nivel={2}>Estado del ticket</TituloSistema>
+          <SupportTicketStatusForm action={statusAction} currentStatus={ticket.status} options={STATUS_OPTIONS} />
         </TarjetaSistema>
       )}
-    </ContenedorDashboard>
+      </ContenedorDashboard>
+    </DashboardLayout>
   )
 }
 
@@ -117,4 +104,8 @@ function formatAttachmentKind(kind: string) {
 function formatBytes(byteSize: number) {
   if (byteSize >= 1024 * 1024) return `${Math.round(byteSize / 1024 / 1024)} MB`
   return `${Math.max(1, Math.round(byteSize / 1024))} KB`
+}
+
+function formatMessageTimestamp(value: string) {
+  return new Intl.DateTimeFormat('es-MX', { dateStyle: 'medium', timeStyle: 'short' }).format(new Date(value))
 }

--- a/app/(auth)/ayuda/tickets/[id]/page.tsx
+++ b/app/(auth)/ayuda/tickets/[id]/page.tsx
@@ -28,7 +28,7 @@ export default async function TicketDetailPage({ params }: { params: Promise<{ i
 
   async function staffReplyAction(formData: FormData) {
     'use server'
-    return createStaffSupportTicketReply(ticket.id, formData)
+    return createStaffSupportTicketReply(ticket.id, formData, { autoAssignIfUnassigned: canManage && ticket.assigneeUsuarioId === null })
   }
 
   async function statusAction(formData: FormData) {
@@ -45,16 +45,16 @@ export default async function TicketDetailPage({ params }: { params: Promise<{ i
     <DashboardLayout>
       <ContenedorDashboard titulo={`Ticket #${ticket.ticketNumber}`} botonRegreso={{ href: '/ayuda/tickets', texto: 'Volver a tickets' }}>
         <TarjetaSistema className="overflow-hidden border-border/70 p-0">
-          <div className="border-b border-border bg-muted/20 p-5 sm:p-6">
-            <div className="flex flex-col gap-4 lg:flex-row lg:items-start lg:justify-between">
-              <div className="min-w-0 space-y-2">
-                <div className="flex flex-wrap items-center gap-2 text-xs font-medium uppercase tracking-[0.2em] text-muted-foreground">
+          <div className="border-b border-border bg-muted/20 p-4 sm:p-5">
+            <div className="flex flex-col gap-3 lg:flex-row lg:items-start lg:justify-between">
+              <div className="min-w-0 space-y-1.5">
+                <div className="flex flex-wrap items-center gap-2 text-[11px] font-medium uppercase tracking-[0.18em] text-muted-foreground">
                   <span>Ticket #{ticket.ticketNumber}</span>
                   <span aria-hidden="true">/</span>
                   <span>{formatCategory(ticket.category)}</span>
                 </div>
-                <TituloSistema nivel={2} className="text-balance">{ticket.title}</TituloSistema>
-                <TextoSistema className="max-w-3xl">{ticket.description}</TextoSistema>
+                <TituloSistema nivel={2} className="text-balance leading-tight">{ticket.title}</TituloSistema>
+                <TextoSistema tamaño="sm" className="max-w-3xl">{ticket.description}</TextoSistema>
               </div>
               <div className="flex flex-wrap items-center gap-2 lg:justify-end">
                 <BadgeSistema variante="info">{formatSupportStatus(ticket.status)}</BadgeSistema>
@@ -63,7 +63,7 @@ export default async function TicketDetailPage({ params }: { params: Promise<{ i
             </div>
           </div>
 
-          <div className="grid gap-4 p-4 lg:grid-cols-[minmax(0,1fr)_minmax(0,1fr)_minmax(0,1fr)] lg:p-5">
+          <div className="grid gap-3 p-3 sm:grid-cols-3 sm:p-4">
             <TicketStat label="Creado" value={formatMessageTimestamp(ticket.createdAt)} />
             <TicketStat label="Actualizado" value={formatMessageTimestamp(ticket.updatedAt)} />
             <TicketStat label="Responsable" value={assignee.fullName} />
@@ -71,26 +71,21 @@ export default async function TicketDetailPage({ params }: { params: Promise<{ i
         </TarjetaSistema>
 
         <div className="grid items-start gap-5 xl:grid-cols-[280px_minmax(0,1fr)_320px]">
-          <aside className="order-2 space-y-5 xl:order-1">
-            <TarjetaSistema className="space-y-4">
+          <aside className="order-2 space-y-4 xl:order-1">
+            <TarjetaSistema className="space-y-3">
               <SectionHeader eyebrow="Contexto" title="Solicitante" />
               <ParticipantSummary participant={reporter} role="Solicitante" />
-              <div className="grid gap-3 border-t border-border pt-4 text-sm">
+              <div className="grid gap-2 border-t border-border pt-3 text-sm">
                 <MetadataRow label="Categoría" value={formatCategory(ticket.category)} />
                 <MetadataRow label="Prioridad" value={formatSeverity(ticket.severity)} />
                 <MetadataRow label="Estado" value={formatSupportStatus(ticket.status)} />
+                <MetadataRow label="Responsable" value={assignee.fullName} />
               </div>
-            </TarjetaSistema>
-
-            <TarjetaSistema className="space-y-4">
-              <SectionHeader eyebrow="Asignación" title="Equipo de soporte" />
-              <ParticipantSummary participant={assignee} role={ticket.assigneeUsuarioId ? 'Responsable' : 'Pendiente'} muted={!ticket.assigneeUsuarioId} />
-              <TextoSistema variante="muted" tamaño="sm">Los controles de ciclo de vida se mantienen separados de la respuesta para evitar cambios accidentales.</TextoSistema>
             </TarjetaSistema>
           </aside>
 
-          <section className="order-1 space-y-5 xl:order-2">
-            <TarjetaSistema className="space-y-5">
+          <section className="order-1 space-y-4 xl:order-2">
+            <TarjetaSistema className="space-y-4">
               <div className="flex flex-col gap-2 sm:flex-row sm:items-end sm:justify-between">
                 <SectionHeader eyebrow="Actividad" title="Conversación" />
                 <TextoSistema variante="muted" tamaño="sm">{ticket.messages.length} {ticket.messages.length === 1 ? 'respuesta pública' : 'respuestas públicas'}</TextoSistema>
@@ -101,33 +96,18 @@ export default async function TicketDetailPage({ params }: { params: Promise<{ i
                   <TextoSistema variante="sutil">Aún no hay respuestas públicas.</TextoSistema>
                 </div>
               ) : (
-                <div className="space-y-4">
+                <div className="space-y-3">
                   {ticket.messages.map((message) => {
-                    const roleLabel = getMessageRoleLabel(message.authorUsuarioId, ticket.reporterUsuarioId)
+                    const isReporter = isReporterMessage(message.authorUsuarioId, ticket.reporterUsuarioId)
+                    const roleLabel = isReporter ? 'Solicitante' : 'Equipo de soporte'
                     const participant = createParticipant(message.author, roleLabel)
 
-                    return (
-                      <article key={message.id} className="rounded-3xl border border-border bg-card/75 p-4 shadow-sm sm:p-5">
-                        <div className="flex gap-3 sm:gap-4">
-                          <UserAvatar photoUrl={participant.photoUrl} nombre={participant.nombre} apellido={participant.apellido} size="md" className="ring-2 ring-background" />
-                          <div className="min-w-0 flex-1 space-y-3">
-                            <div className="flex flex-col gap-1 sm:flex-row sm:items-center sm:justify-between">
-                              <div className="min-w-0">
-                                <p className="truncate text-sm font-semibold text-foreground">{participant.fullName}</p>
-                                <p className="text-xs font-medium text-muted-foreground">{roleLabel}</p>
-                              </div>
-                              <time className="text-xs text-muted-foreground" dateTime={message.createdAt}>{formatMessageTimestamp(message.createdAt)}</time>
-                            </div>
-                            <TextoSistema className="whitespace-pre-wrap leading-relaxed">{message.body}</TextoSistema>
-                          </div>
-                        </div>
-                      </article>
-                    )
+                    return <MessageBubble key={message.id} message={message} participant={participant} roleLabel={roleLabel} isReporter={isReporter} />
                   })}
                 </div>
               )}
 
-              <div className="border-t border-border pt-5">
+              <div className="border-t border-border pt-4">
                 <SupportTicketReplyComposer action={canStaffReply ? staffReplyAction : replyAction} isStaffReply={canStaffReply} />
               </div>
             </TarjetaSistema>
@@ -184,8 +164,8 @@ export default async function TicketDetailPage({ params }: { params: Promise<{ i
 
 function SectionHeader({ eyebrow, title }: { eyebrow: string; title: string }) {
   return (
-    <div className="space-y-1">
-      <p className="text-xs font-semibold uppercase tracking-[0.2em] text-muted-foreground">{eyebrow}</p>
+    <div className="space-y-0.5">
+      <p className="text-[11px] font-semibold uppercase tracking-[0.18em] text-muted-foreground">{eyebrow}</p>
       <TituloSistema nivel={3}>{title}</TituloSistema>
     </div>
   )
@@ -193,8 +173,8 @@ function SectionHeader({ eyebrow, title }: { eyebrow: string; title: string }) {
 
 function TicketStat({ label, value }: { label: string; value: string }) {
   return (
-    <div className="rounded-2xl border border-border bg-card/70 p-3">
-      <p className="text-xs font-medium uppercase tracking-wide text-muted-foreground">{label}</p>
+    <div className="rounded-xl border border-border bg-card/70 px-3 py-2">
+      <p className="text-[11px] font-medium uppercase tracking-wide text-muted-foreground">{label}</p>
       <p className="mt-1 text-sm font-semibold text-foreground">{value}</p>
     </div>
   )
@@ -202,8 +182,8 @@ function TicketStat({ label, value }: { label: string; value: string }) {
 
 function ParticipantSummary({ participant, role, muted = false }: { participant: Participant; role: string; muted?: boolean }) {
   return (
-    <div className="flex items-center gap-3 rounded-2xl border border-border bg-muted/20 p-3">
-      <UserAvatar photoUrl={participant.photoUrl} nombre={participant.nombre} apellido={participant.apellido} size="md" />
+    <div className="flex items-center gap-3 rounded-xl border border-border bg-muted/20 p-2.5">
+      <UserAvatar photoUrl={participant.photoUrl} nombre={participant.nombre} apellido={participant.apellido} size="sm" />
       <div className="min-w-0">
         <p className={`truncate text-sm font-semibold ${muted ? 'text-muted-foreground' : 'text-foreground'}`}>{participant.fullName}</p>
         <p className="text-xs font-medium text-muted-foreground">{role}</p>
@@ -228,6 +208,30 @@ type Participant = {
   photoUrl: string | null
 }
 
+type TicketMessage = {
+  id: string
+  body: string
+  authorUsuarioId?: string
+  createdAt: string
+}
+
+function MessageBubble({ message, participant, roleLabel, isReporter }: { message: TicketMessage; participant: Participant; roleLabel: string; isReporter: boolean }) {
+  return (
+    <article className={`flex gap-2.5 ${isReporter ? 'justify-start' : 'justify-end'}`}>
+      {isReporter && <UserAvatar photoUrl={participant.photoUrl} nombre={participant.nombre} apellido={participant.apellido} size="sm" className="mt-1 ring-2 ring-background" />}
+      <div className={`max-w-[min(92%,42rem)] rounded-2xl border px-3 py-2.5 shadow-sm ${isReporter ? 'rounded-tl-md border-border bg-card/85' : 'rounded-tr-md border-border border-l-4 border-l-[var(--brand-primary)] bg-muted/40'}`}>
+        <div className="mb-1 flex flex-wrap items-center gap-x-2 gap-y-0.5">
+          <p className="text-sm font-semibold text-foreground">{participant.fullName}</p>
+          <span className="text-xs font-medium text-muted-foreground">{roleLabel}</span>
+          <time className="text-xs text-muted-foreground" dateTime={message.createdAt}>{formatMessageTimestamp(message.createdAt)}</time>
+        </div>
+        <TextoSistema tamaño="sm" className="whitespace-pre-wrap leading-relaxed">{message.body}</TextoSistema>
+      </div>
+      {!isReporter && <UserAvatar photoUrl={participant.photoUrl} nombre={participant.nombre} apellido={participant.apellido} size="sm" className="mt-1 ring-2 ring-background" />}
+    </article>
+  )
+}
+
 function createParticipant(profile: { nombre: string | null; apellido: string | null; photoUrl: string | null } | null | undefined, fallbackName: string): Participant {
   const nombre = profile?.nombre?.trim() || fallbackName
   const apellido = profile?.apellido?.trim() || ''
@@ -236,9 +240,8 @@ function createParticipant(profile: { nombre: string | null; apellido: string | 
   return { nombre, apellido, fullName, photoUrl: profile?.photoUrl ?? null }
 }
 
-function getMessageRoleLabel(authorUsuarioId: string | undefined, reporterUsuarioId: string | undefined) {
-  if (!authorUsuarioId || !reporterUsuarioId) return 'Actualización'
-  return authorUsuarioId === reporterUsuarioId ? 'Solicitante' : 'Equipo de soporte'
+function isReporterMessage(authorUsuarioId: string | undefined, reporterUsuarioId: string | undefined) {
+  return Boolean(authorUsuarioId && reporterUsuarioId && authorUsuarioId === reporterUsuarioId)
 }
 
 function formatCategory(category: string) {

--- a/app/(auth)/ayuda/tickets/[id]/page.tsx
+++ b/app/(auth)/ayuda/tickets/[id]/page.tsx
@@ -4,11 +4,12 @@ import { createStaffSupportTicketReply, createSupportTicketMessage, getSupportTi
 import { formatSupportStatus } from '@/lib/support/support-labels'
 import { DashboardLayout } from '@/components/layout/dashboard-layout'
 import { BadgeSistema, ContenedorDashboard, TarjetaSistema, TextoSistema, TituloSistema } from '@/components/ui/sistema-diseno'
+import { UserAvatar } from '@/components/ui/UserAvatar'
 import { SupportTicketReplyComposer, SupportTicketStatusForm } from './support-ticket-detail-actions'
 
 const STATUS_OPTIONS = [
   { valor: 'received', etiqueta: 'Recibido' },
-  { valor: 'in_review', etiqueta: 'En revision' },
+  { valor: 'in_review', etiqueta: 'En revisión' },
   { valor: 'in_progress', etiqueta: 'En progreso' },
   { valor: 'resolved', etiqueta: 'Resuelto' },
   { valor: 'closed', etiqueta: 'Cerrado' },
@@ -37,64 +38,222 @@ export default async function TicketDetailPage({ params }: { params: Promise<{ i
 
   const canManage = ticket.supportCapabilities.includes('support.manage')
   const canStaffReply = canManage || ticket.supportCapabilities.includes('support.reply')
+  const reporter = createParticipant(ticket.reporter, 'Solicitante')
+  const assignee = createParticipant(ticket.assignee, 'Sin asignar')
 
   return (
     <DashboardLayout>
       <ContenedorDashboard titulo={`Ticket #${ticket.ticketNumber}`} botonRegreso={{ href: '/ayuda/tickets', texto: 'Volver a tickets' }}>
-      <TarjetaSistema className="space-y-4">
-        <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
-          <div className="space-y-2">
-            <TituloSistema nivel={2}>{ticket.title}</TituloSistema>
-            <TextoSistema>{ticket.description}</TextoSistema>
-          </div>
-          <BadgeSistema variante="info">{formatSupportStatus(ticket.status)}</BadgeSistema>
-        </div>
-        {ticket.evidence.diagnosticsConsent && (
-          <TextoSistema variante="muted" tamaño="sm">Diagnosticos seguros: {ticket.evidence.currentRoute ?? 'ruta no disponible'} · {ticket.evidence.browserName ?? 'navegador no disponible'} · {ticket.evidence.osName ?? 'sistema operativo no disponible'} · {ticket.evidence.viewport ?? 'viewport no disponible'}</TextoSistema>
-        )}
-      </TarjetaSistema>
-
-      <TarjetaSistema className="space-y-4">
-        <TituloSistema nivel={2}>Adjuntos</TituloSistema>
-        {ticket.attachments.length === 0 ? <TextoSistema variante="sutil">No hay adjuntos finalizados.</TextoSistema> : ticket.attachments.map((attachment) => (
-          <div key={attachment.id} className="flex flex-col gap-2 rounded-xl border border-border bg-card/50 p-3 sm:flex-row sm:items-center sm:justify-between">
-            <div>
-              <TextoSistema>{attachment.filename}</TextoSistema>
-              <TextoSistema variante="muted" tamaño="sm">{formatAttachmentKind(attachment.kind)} · {formatBytes(attachment.byteSize)} · {attachment.status === 'uploaded' ? 'Finalizado' : 'Pendiente'}</TextoSistema>
-            </div>
-            {attachment.status === 'uploaded' && <a href={`/api/support/attachments/${attachment.id}/download`} className="text-sm font-medium text-[var(--brand-primary)]">Descargar {attachment.filename}</a>}
-          </div>
-        ))}
-      </TarjetaSistema>
-
-      <TarjetaSistema className="space-y-4">
-        <TituloSistema nivel={2}>Conversacion</TituloSistema>
-        {ticket.messages.length === 0 ? <TextoSistema variante="sutil">Aun no hay respuestas.</TextoSistema> : (
-          <div className="space-y-4 border-l border-border pl-4">
-            {ticket.messages.map((message) => (
-              <article key={message.id} className="relative rounded-2xl border border-border bg-card/70 p-4 shadow-sm">
-                <span className="absolute -left-[23px] top-5 h-3 w-3 rounded-full border-2 border-card bg-[var(--brand-primary)]" aria-hidden="true" />
-                <div className="mb-2 flex flex-col gap-1 sm:flex-row sm:items-center sm:justify-between">
-                  <p className="text-sm font-semibold text-foreground">Actualizacion</p>
-                  <time className="text-xs text-muted-foreground" dateTime={message.createdAt}>{formatMessageTimestamp(message.createdAt)}</time>
+        <TarjetaSistema className="overflow-hidden border-border/70 p-0">
+          <div className="border-b border-border bg-muted/20 p-5 sm:p-6">
+            <div className="flex flex-col gap-4 lg:flex-row lg:items-start lg:justify-between">
+              <div className="min-w-0 space-y-2">
+                <div className="flex flex-wrap items-center gap-2 text-xs font-medium uppercase tracking-[0.2em] text-muted-foreground">
+                  <span>Ticket #{ticket.ticketNumber}</span>
+                  <span aria-hidden="true">/</span>
+                  <span>{formatCategory(ticket.category)}</span>
                 </div>
-                <TextoSistema>{message.body}</TextoSistema>
-              </article>
-            ))}
+                <TituloSistema nivel={2} className="text-balance">{ticket.title}</TituloSistema>
+                <TextoSistema className="max-w-3xl">{ticket.description}</TextoSistema>
+              </div>
+              <div className="flex flex-wrap items-center gap-2 lg:justify-end">
+                <BadgeSistema variante="info">{formatSupportStatus(ticket.status)}</BadgeSistema>
+                <span className="rounded-full border border-border bg-card px-3 py-1 text-xs font-medium text-muted-foreground">Prioridad {formatSeverity(ticket.severity)}</span>
+              </div>
+            </div>
           </div>
-        )}
-        <SupportTicketReplyComposer action={canStaffReply ? staffReplyAction : replyAction} isStaffReply={canStaffReply} />
-      </TarjetaSistema>
 
-      {canManage && (
-        <TarjetaSistema className="space-y-4">
-          <TituloSistema nivel={2}>Estado del ticket</TituloSistema>
-          <SupportTicketStatusForm action={statusAction} currentStatus={ticket.status} options={STATUS_OPTIONS} />
+          <div className="grid gap-4 p-4 lg:grid-cols-[minmax(0,1fr)_minmax(0,1fr)_minmax(0,1fr)] lg:p-5">
+            <TicketStat label="Creado" value={formatMessageTimestamp(ticket.createdAt)} />
+            <TicketStat label="Actualizado" value={formatMessageTimestamp(ticket.updatedAt)} />
+            <TicketStat label="Responsable" value={assignee.fullName} />
+          </div>
         </TarjetaSistema>
-      )}
+
+        <div className="grid items-start gap-5 xl:grid-cols-[280px_minmax(0,1fr)_320px]">
+          <aside className="order-2 space-y-5 xl:order-1">
+            <TarjetaSistema className="space-y-4">
+              <SectionHeader eyebrow="Contexto" title="Solicitante" />
+              <ParticipantSummary participant={reporter} role="Solicitante" />
+              <div className="grid gap-3 border-t border-border pt-4 text-sm">
+                <MetadataRow label="Categoría" value={formatCategory(ticket.category)} />
+                <MetadataRow label="Prioridad" value={formatSeverity(ticket.severity)} />
+                <MetadataRow label="Estado" value={formatSupportStatus(ticket.status)} />
+              </div>
+            </TarjetaSistema>
+
+            <TarjetaSistema className="space-y-4">
+              <SectionHeader eyebrow="Asignación" title="Equipo de soporte" />
+              <ParticipantSummary participant={assignee} role={ticket.assigneeUsuarioId ? 'Responsable' : 'Pendiente'} muted={!ticket.assigneeUsuarioId} />
+              <TextoSistema variante="muted" tamaño="sm">Los controles de ciclo de vida se mantienen separados de la respuesta para evitar cambios accidentales.</TextoSistema>
+            </TarjetaSistema>
+          </aside>
+
+          <section className="order-1 space-y-5 xl:order-2">
+            <TarjetaSistema className="space-y-5">
+              <div className="flex flex-col gap-2 sm:flex-row sm:items-end sm:justify-between">
+                <SectionHeader eyebrow="Actividad" title="Conversación" />
+                <TextoSistema variante="muted" tamaño="sm">{ticket.messages.length} {ticket.messages.length === 1 ? 'respuesta pública' : 'respuestas públicas'}</TextoSistema>
+              </div>
+
+              {ticket.messages.length === 0 ? (
+                <div className="rounded-2xl border border-dashed border-border bg-muted/20 p-5 text-center">
+                  <TextoSistema variante="sutil">Aún no hay respuestas públicas.</TextoSistema>
+                </div>
+              ) : (
+                <div className="space-y-4">
+                  {ticket.messages.map((message) => {
+                    const roleLabel = getMessageRoleLabel(message.authorUsuarioId, ticket.reporterUsuarioId)
+                    const participant = createParticipant(message.author, roleLabel)
+
+                    return (
+                      <article key={message.id} className="rounded-3xl border border-border bg-card/75 p-4 shadow-sm sm:p-5">
+                        <div className="flex gap-3 sm:gap-4">
+                          <UserAvatar photoUrl={participant.photoUrl} nombre={participant.nombre} apellido={participant.apellido} size="md" className="ring-2 ring-background" />
+                          <div className="min-w-0 flex-1 space-y-3">
+                            <div className="flex flex-col gap-1 sm:flex-row sm:items-center sm:justify-between">
+                              <div className="min-w-0">
+                                <p className="truncate text-sm font-semibold text-foreground">{participant.fullName}</p>
+                                <p className="text-xs font-medium text-muted-foreground">{roleLabel}</p>
+                              </div>
+                              <time className="text-xs text-muted-foreground" dateTime={message.createdAt}>{formatMessageTimestamp(message.createdAt)}</time>
+                            </div>
+                            <TextoSistema className="whitespace-pre-wrap leading-relaxed">{message.body}</TextoSistema>
+                          </div>
+                        </div>
+                      </article>
+                    )
+                  })}
+                </div>
+              )}
+
+              <div className="border-t border-border pt-5">
+                <SupportTicketReplyComposer action={canStaffReply ? staffReplyAction : replyAction} isStaffReply={canStaffReply} />
+              </div>
+            </TarjetaSistema>
+          </section>
+
+          <aside className="order-3 space-y-5">
+            {canManage && (
+              <TarjetaSistema className="space-y-4">
+                <SectionHeader eyebrow="Gestión" title="Estado del ticket" />
+                <SupportTicketStatusForm action={statusAction} currentStatus={ticket.status} options={STATUS_OPTIONS} />
+              </TarjetaSistema>
+            )}
+
+            <TarjetaSistema className="space-y-4">
+              <div className="flex items-start justify-between gap-3">
+                <SectionHeader eyebrow="Evidencia" title="Adjuntos" />
+                <span className="rounded-full bg-muted px-2.5 py-1 text-xs font-medium text-muted-foreground">{ticket.attachments.length}</span>
+              </div>
+              {ticket.attachments.length === 0 ? (
+                <TextoSistema variante="sutil">No hay adjuntos finalizados.</TextoSistema>
+              ) : ticket.attachments.map((attachment) => (
+                <div key={attachment.id} className="rounded-2xl border border-border bg-muted/20 p-3">
+                  <div className="min-w-0">
+                    <p className="truncate text-sm font-semibold text-foreground">{attachment.filename}</p>
+                    <TextoSistema variante="muted" tamaño="sm">{formatAttachmentKind(attachment.kind)} · {formatBytes(attachment.byteSize)}</TextoSistema>
+                    <TextoSistema variante="muted" tamaño="sm">{attachment.contentType} · {formatAttachmentStatus(attachment.status)}</TextoSistema>
+                  </div>
+                  {attachment.status === 'uploaded' && (
+                    <a href={`/api/support/attachments/${attachment.id}/download`} aria-label={`Descargar ${attachment.filename}`} className="mt-3 inline-flex min-h-10 items-center rounded-xl border border-border px-3 text-sm font-medium text-[var(--brand-primary)] transition-colors hover:bg-card">
+                      Descargar archivo
+                    </a>
+                  )}
+                </div>
+              ))}
+            </TarjetaSistema>
+
+            {ticket.evidence.diagnosticsConsent && (
+              <TarjetaSistema className="space-y-4">
+                <SectionHeader eyebrow="Diagnóstico" title="Datos seguros" />
+                <div className="grid gap-3 text-sm">
+                  <MetadataRow label="Ruta" value={ticket.evidence.currentRoute ?? 'Ruta no disponible'} />
+                  <MetadataRow label="Navegador" value={ticket.evidence.browserName ?? 'Navegador no disponible'} />
+                  <MetadataRow label="Sistema" value={ticket.evidence.osName ?? 'Sistema operativo no disponible'} />
+                  <MetadataRow label="Viewport" value={ticket.evidence.viewport ?? 'Viewport no disponible'} />
+                </div>
+              </TarjetaSistema>
+            )}
+          </aside>
+        </div>
       </ContenedorDashboard>
     </DashboardLayout>
   )
+}
+
+function SectionHeader({ eyebrow, title }: { eyebrow: string; title: string }) {
+  return (
+    <div className="space-y-1">
+      <p className="text-xs font-semibold uppercase tracking-[0.2em] text-muted-foreground">{eyebrow}</p>
+      <TituloSistema nivel={3}>{title}</TituloSistema>
+    </div>
+  )
+}
+
+function TicketStat({ label, value }: { label: string; value: string }) {
+  return (
+    <div className="rounded-2xl border border-border bg-card/70 p-3">
+      <p className="text-xs font-medium uppercase tracking-wide text-muted-foreground">{label}</p>
+      <p className="mt-1 text-sm font-semibold text-foreground">{value}</p>
+    </div>
+  )
+}
+
+function ParticipantSummary({ participant, role, muted = false }: { participant: Participant; role: string; muted?: boolean }) {
+  return (
+    <div className="flex items-center gap-3 rounded-2xl border border-border bg-muted/20 p-3">
+      <UserAvatar photoUrl={participant.photoUrl} nombre={participant.nombre} apellido={participant.apellido} size="md" />
+      <div className="min-w-0">
+        <p className={`truncate text-sm font-semibold ${muted ? 'text-muted-foreground' : 'text-foreground'}`}>{participant.fullName}</p>
+        <p className="text-xs font-medium text-muted-foreground">{role}</p>
+      </div>
+    </div>
+  )
+}
+
+function MetadataRow({ label, value }: { label: string; value: string }) {
+  return (
+    <div className="flex items-start justify-between gap-3">
+      <span className="text-muted-foreground">{label}</span>
+      <span className="max-w-[60%] break-words text-right font-medium text-foreground">{value}</span>
+    </div>
+  )
+}
+
+type Participant = {
+  nombre: string
+  apellido: string
+  fullName: string
+  photoUrl: string | null
+}
+
+function createParticipant(profile: { nombre: string | null; apellido: string | null; photoUrl: string | null } | null | undefined, fallbackName: string): Participant {
+  const nombre = profile?.nombre?.trim() || fallbackName
+  const apellido = profile?.apellido?.trim() || ''
+  const fullName = `${nombre} ${apellido}`.trim()
+
+  return { nombre, apellido, fullName, photoUrl: profile?.photoUrl ?? null }
+}
+
+function getMessageRoleLabel(authorUsuarioId: string | undefined, reporterUsuarioId: string | undefined) {
+  if (!authorUsuarioId || !reporterUsuarioId) return 'Actualización'
+  return authorUsuarioId === reporterUsuarioId ? 'Solicitante' : 'Equipo de soporte'
+}
+
+function formatCategory(category: string) {
+  const labels: Record<string, string> = { bug: 'Error', access: 'Acceso', billing: 'Facturación', other: 'Otro' }
+  return labels[category] ?? (category || 'Sin categoría')
+}
+
+function formatSeverity(severity: string) {
+  const labels: Record<string, string> = { low: 'baja', normal: 'normal', high: 'alta', urgent: 'urgente' }
+  return labels[severity] ?? severity
+}
+
+function formatAttachmentStatus(status: string) {
+  const labels: Record<string, string> = { uploaded: 'Finalizado', pending_upload: 'Pendiente', rejected: 'Rechazado', deleted: 'Eliminado' }
+  return labels[status] ?? status
 }
 
 function formatAttachmentKind(kind: string) {

--- a/app/(auth)/ayuda/tickets/[id]/page.tsx
+++ b/app/(auth)/ayuda/tickets/[id]/page.tsx
@@ -1,8 +1,16 @@
 import { notFound } from 'next/navigation'
 
-import { createSupportTicketMessage, getSupportTicketDetail } from '@/lib/actions/support.actions'
+import { assignSupportTicket, createStaffSupportTicketReply, createSupportTicketMessage, getSupportTicketDetail, updateSupportTicketStatus } from '@/lib/actions/support.actions'
 import { formatSupportStatus } from '@/lib/support/support-labels'
-import { BadgeSistema, BotonSistema, ContenedorDashboard, TarjetaSistema, TextareaSistema, TextoSistema, TituloSistema } from '@/components/ui/sistema-diseno'
+import { BadgeSistema, BotonSistema, ContenedorDashboard, InputSistema, SelectSistema, TarjetaSistema, TextareaSistema, TextoSistema, TituloSistema } from '@/components/ui/sistema-diseno'
+
+const STATUS_OPTIONS = [
+  { valor: 'received', etiqueta: 'Recibido' },
+  { valor: 'in_review', etiqueta: 'En revision' },
+  { valor: 'in_progress', etiqueta: 'En progreso' },
+  { valor: 'resolved', etiqueta: 'Resuelto' },
+  { valor: 'closed', etiqueta: 'Cerrado' },
+]
 
 export default async function TicketDetailPage({ params }: { params: Promise<{ id: string }> }) {
   const { id } = await params
@@ -14,6 +22,25 @@ export default async function TicketDetailPage({ params }: { params: Promise<{ i
     'use server'
     await createSupportTicketMessage(ticket.id, formData)
   }
+
+  async function staffReplyAction(formData: FormData) {
+    'use server'
+    await createStaffSupportTicketReply(ticket.id, formData)
+  }
+
+  async function statusAction(formData: FormData) {
+    'use server'
+    await updateSupportTicketStatus(ticket.id, String(formData.get('status') ?? ''))
+  }
+
+  async function assignmentAction(formData: FormData) {
+    'use server'
+    const assigneeUsuarioId = String(formData.get('assigneeUsuarioId') ?? '').trim() || null
+    await assignSupportTicket(ticket.id, assigneeUsuarioId)
+  }
+
+  const canManage = ticket.supportCapabilities.includes('support.manage')
+  const canStaffReply = canManage || ticket.supportCapabilities.includes('support.reply')
 
   return (
     <ContenedorDashboard titulo={`Ticket #${ticket.ticketNumber}`} botonRegreso={{ href: '/ayuda/tickets', texto: 'Volver a tickets' }}>
@@ -31,6 +58,19 @@ export default async function TicketDetailPage({ params }: { params: Promise<{ i
       </TarjetaSistema>
 
       <TarjetaSistema className="space-y-4">
+        <TituloSistema nivel={2}>Adjuntos</TituloSistema>
+        {ticket.attachments.length === 0 ? <TextoSistema variante="sutil">No hay adjuntos finalizados.</TextoSistema> : ticket.attachments.map((attachment) => (
+          <div key={attachment.id} className="flex flex-col gap-2 rounded-xl border border-border bg-card/50 p-3 sm:flex-row sm:items-center sm:justify-between">
+            <div>
+              <TextoSistema>{attachment.filename}</TextoSistema>
+              <TextoSistema variante="muted" tamaño="sm">{formatAttachmentKind(attachment.kind)} · {formatBytes(attachment.byteSize)} · {attachment.status === 'uploaded' ? 'Finalizado' : 'Pendiente'}</TextoSistema>
+            </div>
+            {attachment.status === 'uploaded' && <a href={`/api/support/attachments/${attachment.id}/download`} className="text-sm font-medium text-[var(--brand-primary)]">Descargar {attachment.filename}</a>}
+          </div>
+        ))}
+      </TarjetaSistema>
+
+      <TarjetaSistema className="space-y-4">
         <TituloSistema nivel={2}>Conversacion</TituloSistema>
         {ticket.messages.length === 0 ? <TextoSistema variante="sutil">Aun no hay respuestas.</TextoSistema> : ticket.messages.map((message) => (
           <div key={message.id} className="rounded-xl border border-border bg-card/50 p-3">
@@ -42,6 +82,39 @@ export default async function TicketDetailPage({ params }: { params: Promise<{ i
           <BotonSistema type="submit">Enviar respuesta</BotonSistema>
         </form>
       </TarjetaSistema>
+
+      {(canStaffReply || canManage) && (
+        <TarjetaSistema className="space-y-4">
+          <TituloSistema nivel={2}>Operacion del equipo</TituloSistema>
+          {canStaffReply && (
+            <form action={staffReplyAction} className="space-y-3">
+              <TextareaSistema name="body" label="Respuesta del equipo" filas={4} required />
+              <BotonSistema type="submit">Enviar respuesta del equipo</BotonSistema>
+            </form>
+          )}
+          {canManage && (
+            <div className="grid gap-4 md:grid-cols-2">
+              <form action={statusAction} className="space-y-3">
+                <SelectSistema label="Nuevo estado" name="status" defaultValue={ticket.status} opciones={STATUS_OPTIONS} />
+                <BotonSistema type="submit">Actualizar estado</BotonSistema>
+              </form>
+              <form action={assignmentAction} className="space-y-3">
+                <InputSistema label="Responsable" name="assigneeUsuarioId" defaultValue={ticket.assigneeUsuarioId ?? ''} placeholder="UUID del usuario responsable" />
+                <BotonSistema type="submit">Actualizar responsable</BotonSistema>
+              </form>
+            </div>
+          )}
+        </TarjetaSistema>
+      )}
     </ContenedorDashboard>
   )
+}
+
+function formatAttachmentKind(kind: string) {
+  return kind === 'video' ? 'Video' : 'Captura'
+}
+
+function formatBytes(byteSize: number) {
+  if (byteSize >= 1024 * 1024) return `${Math.round(byteSize / 1024 / 1024)} MB`
+  return `${Math.max(1, Math.round(byteSize / 1024))} KB`
 }

--- a/app/(auth)/ayuda/tickets/[id]/support-ticket-detail-actions.tsx
+++ b/app/(auth)/ayuda/tickets/[id]/support-ticket-detail-actions.tsx
@@ -1,0 +1,65 @@
+'use client'
+
+import { useActionState, useEffect, useRef } from 'react'
+
+import { BotonSistema, SelectSistema, TextareaSistema, TextoSistema } from '@/components/ui/sistema-diseno'
+import { useNotificaciones } from '@/hooks/use-notificaciones'
+
+type SupportFormState = { success: boolean; error?: string } | null
+type SupportFormAction = (formData: FormData) => Promise<Exclude<SupportFormState, null>>
+
+export function SupportTicketReplyComposer({ action, isStaffReply }: { action: SupportFormAction; isStaffReply: boolean }) {
+  const toast = useNotificaciones()
+  const formRef = useRef<HTMLFormElement>(null)
+  const [state, formAction, isPending] = useActionState(async (_previousState: SupportFormState, formData: FormData) => action(formData), null)
+
+  useEffect(() => {
+    if (isPending) toast.info(isStaffReply ? 'Enviando respuesta del equipo...' : 'Enviando respuesta...')
+  }, [isPending, isStaffReply, toast])
+
+  useEffect(() => {
+    if (!state) return
+    if (state.success) {
+      toast.success(isStaffReply ? 'Respuesta del equipo enviada' : 'Respuesta enviada')
+      formRef.current?.reset()
+      return
+    }
+    toast.error(state.error ?? 'No se pudo enviar la respuesta')
+  }, [state, isStaffReply, toast])
+
+  return (
+    <form ref={formRef} action={formAction} className="space-y-3 rounded-2xl border border-border bg-muted/30 p-4">
+      <div className="space-y-1">
+        <p className="text-sm font-semibold text-foreground">{isStaffReply ? 'Respuesta del equipo de soporte' : 'Responder al ticket'}</p>
+        <TextoSistema variante="sutil" tamaño="sm">{isStaffReply ? 'Esta respuesta sera visible para el reportante.' : 'Agrega informacion o responde a soporte.'}</TextoSistema>
+      </div>
+      <TextareaSistema name="body" label={isStaffReply ? 'Respuesta del equipo' : 'Respuesta'} filas={4} required />
+      <BotonSistema type="submit" disabled={isPending}>{isPending ? 'Enviando...' : isStaffReply ? 'Enviar respuesta del equipo' : 'Enviar respuesta'}</BotonSistema>
+    </form>
+  )
+}
+
+export function SupportTicketStatusForm({ action, currentStatus, options }: { action: SupportFormAction; currentStatus: string; options: { valor: string; etiqueta: string }[] }) {
+  const toast = useNotificaciones()
+  const [state, formAction, isPending] = useActionState(async (_previousState: SupportFormState, formData: FormData) => action(formData), null)
+
+  useEffect(() => {
+    if (isPending) toast.info('Actualizando estado del ticket...')
+  }, [isPending, toast])
+
+  useEffect(() => {
+    if (!state) return
+    if (state.success) {
+      toast.success('Estado del ticket actualizado')
+      return
+    }
+    toast.error(state.error ?? 'No se pudo actualizar el estado')
+  }, [state, toast])
+
+  return (
+    <form action={formAction} className="space-y-3 rounded-2xl border border-border bg-muted/30 p-4">
+      <SelectSistema label="Nuevo estado" name="status" defaultValue={currentStatus} opciones={options} />
+      <BotonSistema type="submit" disabled={isPending}>{isPending ? 'Actualizando...' : 'Actualizar estado'}</BotonSistema>
+    </form>
+  )
+}

--- a/app/(auth)/ayuda/tickets/[id]/support-ticket-detail-actions.tsx
+++ b/app/(auth)/ayuda/tickets/[id]/support-ticket-detail-actions.tsx
@@ -30,11 +30,11 @@ export function SupportTicketReplyComposer({ action, isStaffReply }: { action: S
   return (
     <form ref={formRef} action={formAction} className="space-y-3 rounded-2xl border border-border bg-muted/30 p-4">
       <div className="space-y-1">
-        <p className="text-sm font-semibold text-foreground">{isStaffReply ? 'Respuesta del equipo de soporte' : 'Responder al ticket'}</p>
-        <TextoSistema variante="sutil" tamaño="sm">{isStaffReply ? 'Esta respuesta sera visible para el reportante.' : 'Agrega informacion o responde a soporte.'}</TextoSistema>
+        <p className="text-sm font-semibold text-foreground">{isStaffReply ? 'Responder como soporte' : 'Responder al equipo de soporte'}</p>
+        <TextoSistema variante="sutil" tamaño="sm">{isStaffReply ? 'Tu respuesta será visible para el solicitante.' : 'Agrega información o responde al equipo que revisa tu caso.'}</TextoSistema>
       </div>
-      <TextareaSistema name="body" label={isStaffReply ? 'Respuesta del equipo' : 'Respuesta'} filas={4} required />
-      <BotonSistema type="submit" disabled={isPending}>{isPending ? 'Enviando...' : isStaffReply ? 'Enviar respuesta del equipo' : 'Enviar respuesta'}</BotonSistema>
+      <TextareaSistema name="body" label={isStaffReply ? 'Respuesta de soporte' : 'Respuesta al equipo de soporte'} filas={4} required />
+      <BotonSistema type="submit" disabled={isPending}>{isPending ? 'Enviando...' : isStaffReply ? 'Enviar respuesta al solicitante' : 'Enviar respuesta'}</BotonSistema>
     </form>
   )
 }

--- a/app/(auth)/ayuda/tickets/page.tsx
+++ b/app/(auth)/ayuda/tickets/page.tsx
@@ -2,6 +2,7 @@ import Link from 'next/link'
 
 import { listSupportTickets } from '@/lib/actions/support.actions'
 import { formatSupportCategory, formatSupportSeverity, formatSupportStatus } from '@/lib/support/support-labels'
+import { DashboardLayout } from '@/components/layout/dashboard-layout'
 import { BadgeSistema, BotonSistema, ContenedorDashboard, TarjetaSistema, TextoSistema } from '@/components/ui/sistema-diseno'
 
 export default async function TicketsPage() {
@@ -9,22 +10,24 @@ export default async function TicketsPage() {
   const tickets = result.success ? result.tickets : []
 
   return (
-    <ContenedorDashboard titulo="Mis tickets de soporte" accionPrincipal={<Link href="/ayuda/reportar"><BotonSistema tamaño="sm">Nuevo ticket</BotonSistema></Link>}>
-      <div className="space-y-3">
-        {tickets.length === 0 ? (
-          <TarjetaSistema><TextoSistema variante="sutil">Todavia no has enviado tickets de soporte.</TextoSistema></TarjetaSistema>
-        ) : tickets.map((ticket) => (
-          <Link key={ticket.id} href={`/ayuda/tickets/${ticket.id}`} className="block focus-ring rounded-2xl">
-            <TarjetaSistema className="flex items-center justify-between gap-4">
-              <div>
-                <p className="font-semibold text-foreground">#{ticket.ticketNumber} {ticket.title}</p>
-                <TextoSistema variante="sutil" tamaño="sm">{formatSupportCategory(ticket.category)} · {formatSupportSeverity(ticket.severity)}</TextoSistema>
-              </div>
-              <BadgeSistema variante="info">{formatSupportStatus(ticket.status)}</BadgeSistema>
-            </TarjetaSistema>
-          </Link>
-        ))}
-      </div>
-    </ContenedorDashboard>
+    <DashboardLayout>
+      <ContenedorDashboard titulo="Mis tickets de soporte" accionPrincipal={<Link href="/ayuda/reportar"><BotonSistema tamaño="sm">Nuevo ticket</BotonSistema></Link>}>
+        <div className="space-y-3">
+          {tickets.length === 0 ? (
+            <TarjetaSistema><TextoSistema variante="sutil">Todavia no has enviado tickets de soporte.</TextoSistema></TarjetaSistema>
+          ) : tickets.map((ticket) => (
+            <Link key={ticket.id} href={`/ayuda/tickets/${ticket.id}`} className="block focus-ring rounded-2xl">
+              <TarjetaSistema className="flex items-center justify-between gap-4">
+                <div>
+                  <p className="font-semibold text-foreground">#{ticket.ticketNumber} {ticket.title}</p>
+                  <TextoSistema variante="sutil" tamaño="sm">{formatSupportCategory(ticket.category)} · {formatSupportSeverity(ticket.severity)}</TextoSistema>
+                </div>
+                <BadgeSistema variante="info">{formatSupportStatus(ticket.status)}</BadgeSistema>
+              </TarjetaSistema>
+            </Link>
+          ))}
+        </div>
+      </ContenedorDashboard>
+    </DashboardLayout>
   )
 }

--- a/app/(auth)/ayuda/tickets/page.tsx
+++ b/app/(auth)/ayuda/tickets/page.tsx
@@ -1,5 +1,5 @@
 import Link from 'next/link'
-import { TicketIcon } from 'lucide-react'
+import { Eye, TicketIcon } from 'lucide-react'
 
 import { listSupportTickets } from '@/lib/actions/support.actions'
 import { formatSupportCategory, formatSupportSeverity, formatSupportStatus } from '@/lib/support/support-labels'
@@ -43,6 +43,17 @@ export default async function TicketsPage() {
       className: 'hidden text-sm text-muted-foreground lg:table-cell',
       headerClassName: 'hidden lg:table-cell',
     },
+    {
+      key: 'actions',
+      header: 'Acciones',
+      cell: (ticket) => (
+        <Link href={`/ayuda/tickets/${ticket.id}`} className="inline-flex items-center gap-1 text-xs font-medium text-orange-600 hover:text-orange-700 focus-ring">
+          <Eye className="h-4 w-4" aria-hidden="true" />
+          Ver detalle
+        </Link>
+      ),
+      className: 'whitespace-nowrap text-sm',
+    },
   ]
 
   return (
@@ -56,9 +67,7 @@ export default async function TicketsPage() {
           getRowHref={(ticket) => `/ayuda/tickets/${ticket.id}`}
           getRowLabel={(ticket) => `#${ticket.ticketNumber} ${ticket.title}`}
           emptyState={<TextoSistema variante="sutil">Todavia no has enviado tickets de soporte.</TextoSistema>}
-          className="hidden overflow-hidden md:block"
-          tableClassName="w-full divide-y divide-border"
-          bodyClassName="divide-y divide-border"
+          className="hidden md:block"
         />
         <TicketsMobileList tickets={tickets} />
       </ContenedorDashboard>
@@ -119,6 +128,10 @@ function TicketsMobileList({ tickets }: { tickets: TicketRow[] }) {
                 </div>
                 <div className="text-xs text-muted-foreground/70">{formatTicketDate(ticket.createdAt)}</div>
               </div>
+              <Link href={`/ayuda/tickets/${ticket.id}`} className="mt-3 inline-flex items-center gap-1 text-xs font-medium text-orange-600 hover:text-orange-700 focus-ring">
+                <Eye className="h-4 w-4" aria-hidden="true" />
+                Ver detalle
+              </Link>
             </div>
           </div>
         </TarjetaSistema>

--- a/app/(auth)/ayuda/tickets/page.tsx
+++ b/app/(auth)/ayuda/tickets/page.tsx
@@ -3,31 +3,61 @@ import Link from 'next/link'
 import { listSupportTickets } from '@/lib/actions/support.actions'
 import { formatSupportCategory, formatSupportSeverity, formatSupportStatus } from '@/lib/support/support-labels'
 import { DashboardLayout } from '@/components/layout/dashboard-layout'
-import { BadgeSistema, BotonSistema, ContenedorDashboard, TarjetaSistema, TextoSistema } from '@/components/ui/sistema-diseno'
+import { DataTable, type DataTableColumn } from '@/components/ui/data-table'
+import { BadgeSistema, BotonSistema, ContenedorDashboard, TextoSistema } from '@/components/ui/sistema-diseno'
 
 export default async function TicketsPage() {
   const result = await listSupportTickets()
   const tickets = result.success ? result.tickets : []
+  type Ticket = (typeof tickets)[number]
+
+  const columns: DataTableColumn<Ticket>[] = [
+    {
+      key: 'ticket',
+      header: 'Ticket',
+      cell: (ticket) => `#${ticket.ticketNumber} ${ticket.title}`,
+      className: 'min-w-[260px]',
+    },
+    {
+      key: 'category',
+      header: 'Categoria',
+      cell: (ticket) => formatSupportCategory(ticket.category),
+    },
+    {
+      key: 'severity',
+      header: 'Severidad',
+      cell: (ticket) => formatSupportSeverity(ticket.severity),
+    },
+    {
+      key: 'status',
+      header: 'Estado',
+      cell: (ticket) => <BadgeSistema variante="info">{formatSupportStatus(ticket.status)}</BadgeSistema>,
+    },
+    {
+      key: 'createdAt',
+      header: 'Fecha',
+      cell: (ticket) => formatTicketDate(ticket.createdAt),
+      className: 'text-muted-foreground',
+    },
+  ]
 
   return (
     <DashboardLayout>
       <ContenedorDashboard titulo="Mis tickets de soporte" accionPrincipal={<Link href="/ayuda/reportar"><BotonSistema tamaño="sm">Nuevo ticket</BotonSistema></Link>}>
-        <div className="space-y-3">
-          {tickets.length === 0 ? (
-            <TarjetaSistema><TextoSistema variante="sutil">Todavia no has enviado tickets de soporte.</TextoSistema></TarjetaSistema>
-          ) : tickets.map((ticket) => (
-            <Link key={ticket.id} href={`/ayuda/tickets/${ticket.id}`} className="block focus-ring rounded-2xl">
-              <TarjetaSistema className="flex items-center justify-between gap-4">
-                <div>
-                  <p className="font-semibold text-foreground">#{ticket.ticketNumber} {ticket.title}</p>
-                  <TextoSistema variante="sutil" tamaño="sm">{formatSupportCategory(ticket.category)} · {formatSupportSeverity(ticket.severity)}</TextoSistema>
-                </div>
-                <BadgeSistema variante="info">{formatSupportStatus(ticket.status)}</BadgeSistema>
-              </TarjetaSistema>
-            </Link>
-          ))}
-        </div>
+        <DataTable
+          rows={tickets}
+          columns={columns}
+          getRowKey={(ticket) => ticket.id}
+          caption="Historial de tickets de soporte enviados por ti."
+          getRowHref={(ticket) => `/ayuda/tickets/${ticket.id}`}
+          getRowLabel={(ticket) => `#${ticket.ticketNumber} ${ticket.title}`}
+          emptyState={<TextoSistema variante="sutil">Todavia no has enviado tickets de soporte.</TextoSistema>}
+        />
       </ContenedorDashboard>
     </DashboardLayout>
   )
+}
+
+function formatTicketDate(value: string) {
+  return new Intl.DateTimeFormat('es-MX', { dateStyle: 'medium' }).format(new Date(value))
 }

--- a/app/(auth)/ayuda/tickets/page.tsx
+++ b/app/(auth)/ayuda/tickets/page.tsx
@@ -1,32 +1,35 @@
 import Link from 'next/link'
+import { TicketIcon } from 'lucide-react'
 
 import { listSupportTickets } from '@/lib/actions/support.actions'
 import { formatSupportCategory, formatSupportSeverity, formatSupportStatus } from '@/lib/support/support-labels'
 import { DashboardLayout } from '@/components/layout/dashboard-layout'
 import { DataTable, type DataTableColumn } from '@/components/ui/data-table'
-import { BadgeSistema, BotonSistema, ContenedorDashboard, TextoSistema } from '@/components/ui/sistema-diseno'
+import { BadgeSistema, BotonSistema, ContenedorDashboard, TarjetaSistema, TextoSistema } from '@/components/ui/sistema-diseno'
 
 export default async function TicketsPage() {
   const result = await listSupportTickets()
   const tickets = result.success ? result.tickets : []
-  type Ticket = (typeof tickets)[number]
+  type TicketSummary = (typeof tickets)[number]
 
-  const columns: DataTableColumn<Ticket>[] = [
+  const columns: DataTableColumn<TicketSummary>[] = [
     {
       key: 'ticket',
       header: 'Ticket',
-      cell: (ticket) => `#${ticket.ticketNumber} ${ticket.title}`,
-      className: 'min-w-[260px]',
+      cell: (ticket) => <TicketIdentity ticket={ticket} />,
+      className: 'min-w-[300px] whitespace-nowrap',
     },
     {
       key: 'category',
       header: 'Categoria',
       cell: (ticket) => formatSupportCategory(ticket.category),
+      className: 'text-sm text-muted-foreground',
     },
     {
       key: 'severity',
       header: 'Severidad',
       cell: (ticket) => formatSupportSeverity(ticket.severity),
+      className: 'text-sm text-muted-foreground',
     },
     {
       key: 'status',
@@ -37,7 +40,8 @@ export default async function TicketsPage() {
       key: 'createdAt',
       header: 'Fecha',
       cell: (ticket) => formatTicketDate(ticket.createdAt),
-      className: 'text-muted-foreground',
+      className: 'hidden text-sm text-muted-foreground lg:table-cell',
+      headerClassName: 'hidden lg:table-cell',
     },
   ]
 
@@ -52,12 +56,83 @@ export default async function TicketsPage() {
           getRowHref={(ticket) => `/ayuda/tickets/${ticket.id}`}
           getRowLabel={(ticket) => `#${ticket.ticketNumber} ${ticket.title}`}
           emptyState={<TextoSistema variante="sutil">Todavia no has enviado tickets de soporte.</TextoSistema>}
+          className="hidden overflow-hidden md:block"
+          tableClassName="w-full divide-y divide-border"
+          bodyClassName="divide-y divide-border"
         />
+        <TicketsMobileList tickets={tickets} />
       </ContenedorDashboard>
     </DashboardLayout>
+  )
+}
+
+function TicketIdentity({ ticket }: { ticket: TicketRow }) {
+  return (
+    <div className="flex items-center gap-3">
+      <div className="flex h-10 w-16 flex-shrink-0 items-center justify-center rounded-lg bg-gradient-to-r from-orange-400 to-orange-500">
+        <TicketIcon className="h-4 w-4 text-white" aria-hidden="true" />
+      </div>
+      <div className="min-w-0">
+        <div className="flex items-center gap-2 font-medium text-foreground">
+          <span>#{ticket.ticketNumber}</span>
+          <span className="truncate">{ticket.title}</span>
+        </div>
+        <div className="mt-0.5 text-xs text-muted-foreground">Creado {formatTicketDate(ticket.createdAt)}</div>
+      </div>
+    </div>
+  )
+}
+
+function TicketsMobileList({ tickets }: { tickets: TicketRow[] }) {
+  if (tickets.length === 0) {
+    return (
+      <TarjetaSistema className="p-8 text-center md:hidden">
+        <TicketIcon className="mx-auto mb-3 h-12 w-12 text-muted-foreground/40" aria-hidden="true" />
+        <TextoSistema variante="sutil">Todavia no has enviado tickets de soporte.</TextoSistema>
+      </TarjetaSistema>
+    )
+  }
+
+  return (
+    <div className="space-y-4 md:hidden">
+      {tickets.map((ticket) => (
+        <TarjetaSistema key={ticket.id} className="p-4">
+          <div className="flex items-start gap-3">
+            <div className="mt-0.5 flex h-8 w-12 flex-shrink-0 items-center justify-center rounded-lg bg-gradient-to-r from-orange-400 to-orange-500">
+              <TicketIcon className="h-4 w-4 text-white" aria-hidden="true" />
+            </div>
+            <div className="min-w-0 flex-1">
+              <div className="mb-2 flex items-start justify-between gap-2">
+                <Link href={`/ayuda/tickets/${ticket.id}`} className="min-w-0 flex-1 truncate rounded-md font-semibold text-foreground hover:text-[var(--brand-primary)] focus-ring" aria-label={`#${ticket.ticketNumber} ${ticket.title}`}>
+                  #{ticket.ticketNumber} {ticket.title}
+                </Link>
+                <BadgeSistema variante="info" tamaño="sm" className="flex-shrink-0">
+                  {formatSupportStatus(ticket.status)}
+                </BadgeSistema>
+              </div>
+              <div className="space-y-1 text-sm text-muted-foreground">
+                <div>
+                  <span className="font-medium">Categoria:</span> {formatSupportCategory(ticket.category)}
+                </div>
+                <div>
+                  <span className="font-medium">Severidad:</span> {formatSupportSeverity(ticket.severity)}
+                </div>
+                <div className="text-xs text-muted-foreground/70">{formatTicketDate(ticket.createdAt)}</div>
+              </div>
+            </div>
+          </div>
+        </TarjetaSistema>
+      ))}
+    </div>
   )
 }
 
 function formatTicketDate(value: string) {
   return new Intl.DateTimeFormat('es-MX', { dateStyle: 'medium' }).format(new Date(value))
 }
+
+type TicketRow = Awaited<ReturnType<typeof listSupportTickets>> extends { tickets: infer Tickets }
+  ? Tickets extends Array<infer Ticket>
+    ? Ticket
+    : never
+  : never

--- a/app/(auth)/configuracion/soporte/page.tsx
+++ b/app/(auth)/configuracion/soporte/page.tsx
@@ -1,0 +1,70 @@
+import { grantSupportCapability, revokeSupportCapability } from '@/lib/actions/support-capabilities.actions'
+import { SUPPORT_CAPABILITIES, SUPPORT_CAPABILITY_LABELS } from '@/lib/support/capabilities'
+import { getUserWithRoles } from '@/lib/getUserWithRoles'
+import { createSupabaseServerClient } from '@/lib/supabase/server'
+import { BotonSistema, ContenedorDashboard, InputSistema, SelectSistema, TarjetaSistema, TextoSistema, TituloSistema } from '@/components/ui/sistema-diseno'
+import { redirect } from 'next/navigation'
+
+const SUPPORT_CONFIGURATION_ROLES = ['admin', 'pastor', 'director-general']
+
+const CAPABILITY_OPTIONS = SUPPORT_CAPABILITIES.map((capability) => ({
+  valor: capability,
+  etiqueta: SUPPORT_CAPABILITY_LABELS[capability],
+}))
+
+export default async function SupportCapabilitiesPage() {
+  const supabase = await createSupabaseServerClient()
+  const userData = await getUserWithRoles(supabase)
+
+  if (!userData?.user) redirect('/login')
+
+  const hasHigherRole = userData.roles.some((role: string) => SUPPORT_CONFIGURATION_ROLES.includes(role))
+  const hasSupportManage = await hasSupportManageCapability(supabase, userData.user.id)
+  if (!hasHigherRole || !hasSupportManage) redirect('/dashboard')
+
+  async function grantAction(formData: FormData) {
+    'use server'
+    await grantSupportCapability(String(formData.get('usuarioId') ?? ''), String(formData.get('capability') ?? ''))
+  }
+
+  async function revokeAction(formData: FormData) {
+    'use server'
+    await revokeSupportCapability(String(formData.get('usuarioId') ?? ''), String(formData.get('capability') ?? ''))
+  }
+
+  return (
+    <ContenedorDashboard titulo="Configuracion de soporte" descripcion="Administra capacidades de soporte con cambios auditados y limitados al conjunto permitido.">
+      <TarjetaSistema className="space-y-4">
+        <TituloSistema nivel={2}>Capacidades permitidas</TituloSistema>
+        <TextoSistema variante="sutil">Solo se pueden administrar support.view, support.reply y support.manage para usuarios staff o admin.</TextoSistema>
+        <div className="grid gap-4 md:grid-cols-2">
+          <form action={grantAction} className="space-y-3">
+            <InputSistema label="Usuario destino" name="usuarioId" required placeholder="UUID del usuario" />
+            <SelectSistema label="Capacidad" name="capability" opciones={CAPABILITY_OPTIONS} defaultValue="support.view" />
+            <BotonSistema type="submit">Otorgar capacidad</BotonSistema>
+          </form>
+          <form action={revokeAction} className="space-y-3">
+            <InputSistema label="Usuario destino" name="usuarioId" required placeholder="UUID del usuario" />
+            <SelectSistema label="Capacidad" name="capability" opciones={CAPABILITY_OPTIONS} defaultValue="support.view" />
+            <BotonSistema type="submit" variante="outline">Revocar capacidad</BotonSistema>
+          </form>
+        </div>
+      </TarjetaSistema>
+    </ContenedorDashboard>
+  )
+}
+
+async function hasSupportManageCapability(supabase: Awaited<ReturnType<typeof createSupabaseServerClient>>, authId: string) {
+  const { data: usuario } = await supabase.from('usuarios').select('id').eq('auth_id', authId).maybeSingle()
+  if (!usuario?.id) return false
+
+  const { data, error } = await supabase
+    .from('support_user_capabilities')
+    .select('capability')
+    .eq('usuario_id', usuario.id)
+    .eq('capability', 'support.manage')
+    .is('revoked_at', null)
+    .maybeSingle()
+
+  return !error && Boolean(data)
+}

--- a/app/(auth)/configuracion/soporte/page.tsx
+++ b/app/(auth)/configuracion/soporte/page.tsx
@@ -2,6 +2,7 @@ import { grantSupportCapability, revokeSupportCapability } from '@/lib/actions/s
 import { SUPPORT_CAPABILITIES, SUPPORT_CAPABILITY_LABELS } from '@/lib/support/capabilities'
 import { getUserWithRoles } from '@/lib/getUserWithRoles'
 import { createSupabaseServerClient } from '@/lib/supabase/server'
+import { DashboardLayout } from '@/components/layout/dashboard-layout'
 import { BotonSistema, ContenedorDashboard, InputSistema, SelectSistema, TarjetaSistema, TextoSistema, TituloSistema } from '@/components/ui/sistema-diseno'
 import { redirect } from 'next/navigation'
 
@@ -20,7 +21,18 @@ export default async function SupportCapabilitiesPage() {
 
   const hasHigherRole = userData.roles.some((role: string) => SUPPORT_CONFIGURATION_ROLES.includes(role))
   const hasSupportManage = await hasSupportManageCapability(supabase, userData.user.id)
-  if (!hasHigherRole || !hasSupportManage) redirect('/dashboard')
+  if (!hasHigherRole || !hasSupportManage) {
+    return (
+      <DashboardLayout>
+        <ContenedorDashboard titulo="Configuracion de soporte" botonRegreso={{ href: '/dashboard', texto: 'Dashboard' }}>
+          <TarjetaSistema className="space-y-3">
+            <TituloSistema nivel={2}>Acceso requerido</TituloSistema>
+            <TextoSistema variante="sutil">Esta configuracion requiere un rol de administracion alto y la capacidad support.manage. Si necesitas administrar soporte, solicita acceso a un administrador autorizado.</TextoSistema>
+          </TarjetaSistema>
+        </ContenedorDashboard>
+      </DashboardLayout>
+    )
+  }
 
   async function grantAction(formData: FormData) {
     'use server'
@@ -33,24 +45,26 @@ export default async function SupportCapabilitiesPage() {
   }
 
   return (
-    <ContenedorDashboard titulo="Configuracion de soporte" descripcion="Administra capacidades de soporte con cambios auditados y limitados al conjunto permitido.">
-      <TarjetaSistema className="space-y-4">
-        <TituloSistema nivel={2}>Capacidades permitidas</TituloSistema>
-        <TextoSistema variante="sutil">Solo se pueden administrar support.view, support.reply y support.manage para usuarios staff o admin.</TextoSistema>
-        <div className="grid gap-4 md:grid-cols-2">
-          <form action={grantAction} className="space-y-3">
-            <InputSistema label="Usuario destino" name="usuarioId" required placeholder="UUID del usuario" />
-            <SelectSistema label="Capacidad" name="capability" opciones={CAPABILITY_OPTIONS} defaultValue="support.view" />
-            <BotonSistema type="submit">Otorgar capacidad</BotonSistema>
-          </form>
-          <form action={revokeAction} className="space-y-3">
-            <InputSistema label="Usuario destino" name="usuarioId" required placeholder="UUID del usuario" />
-            <SelectSistema label="Capacidad" name="capability" opciones={CAPABILITY_OPTIONS} defaultValue="support.view" />
-            <BotonSistema type="submit" variante="outline">Revocar capacidad</BotonSistema>
-          </form>
-        </div>
-      </TarjetaSistema>
-    </ContenedorDashboard>
+    <DashboardLayout>
+      <ContenedorDashboard titulo="Configuracion de soporte" descripcion="Administra capacidades de soporte con cambios auditados y limitados al conjunto permitido.">
+        <TarjetaSistema className="space-y-4">
+          <TituloSistema nivel={2}>Capacidades permitidas</TituloSistema>
+          <TextoSistema variante="sutil">Solo se pueden administrar support.view, support.reply y support.manage para usuarios staff o admin.</TextoSistema>
+          <div className="grid gap-4 md:grid-cols-2">
+            <form action={grantAction} className="space-y-3">
+              <InputSistema label="Usuario destino" name="usuarioId" required placeholder="UUID del usuario" />
+              <SelectSistema label="Capacidad" name="capability" opciones={CAPABILITY_OPTIONS} defaultValue="support.view" />
+              <BotonSistema type="submit">Otorgar capacidad</BotonSistema>
+            </form>
+            <form action={revokeAction} className="space-y-3">
+              <InputSistema label="Usuario destino" name="usuarioId" required placeholder="UUID del usuario" />
+              <SelectSistema label="Capacidad" name="capability" opciones={CAPABILITY_OPTIONS} defaultValue="support.view" />
+              <BotonSistema type="submit" variante="outline">Revocar capacidad</BotonSistema>
+            </form>
+          </div>
+        </TarjetaSistema>
+      </ContenedorDashboard>
+    </DashboardLayout>
   )
 }
 

--- a/app/api/inngest/route.ts
+++ b/app/api/inngest/route.ts
@@ -1,0 +1,7 @@
+import { supportInngestRoute } from '@/lib/support/inngest-route'
+
+export const runtime = 'nodejs'
+
+export async function POST(request: Request): Promise<Response> {
+  return supportInngestRoute(request)
+}

--- a/app/api/support/external/inbound/route.ts
+++ b/app/api/support/external/inbound/route.ts
@@ -1,0 +1,7 @@
+import { supportExternalInboundRoute } from '@/lib/support/external-bridge'
+
+export const runtime = 'nodejs'
+
+export async function POST(request: Request): Promise<Response> {
+  return supportExternalInboundRoute(request)
+}

--- a/components/ui/data-table.tsx
+++ b/components/ui/data-table.tsx
@@ -2,18 +2,17 @@ import Link from 'next/link'
 import type { ReactNode } from 'react'
 
 import { cn } from '@/lib/utils'
-import {
-  Table,
-  TableBody,
-  TableCaption,
-  TableCell,
-  TableHead,
-  TableHeader,
-  TableRow,
-} from '@/components/ui/table'
+import { TarjetaSistema } from '@/components/ui/sistema-diseno'
 
 export interface DataTableColumn<Row> {
   key: string
+  header: ReactNode
+  cell: (row: Row) => ReactNode
+  className?: string
+  headerClassName?: string
+}
+
+interface DataTableSelectColumn<Row> {
   header: ReactNode
   cell: (row: Row) => ReactNode
   className?: string
@@ -24,6 +23,7 @@ interface DataTableProps<Row> {
   columns: DataTableColumn<Row>[]
   rows: Row[]
   getRowKey: (row: Row) => string
+  selectColumn?: DataTableSelectColumn<Row>
   caption?: ReactNode
   emptyState?: ReactNode
   getRowHref?: (row: Row) => string
@@ -39,6 +39,7 @@ export function DataTable<Row>({
   columns,
   rows,
   getRowKey,
+  selectColumn,
   caption,
   emptyState,
   getRowHref,
@@ -49,50 +50,64 @@ export function DataTable<Row>({
   bodyClassName,
   linkClassName,
 }: DataTableProps<Row>) {
+  const columnCount = columns.length + (selectColumn ? 1 : 0)
+
   return (
-    <div className={cn('overflow-x-auto rounded-2xl border border-border bg-card shadow-sm [&_[data-slot=table-container]]:overflow-visible', className)}>
-      <Table className={cn('min-w-[720px]', tableClassName)}>
-        {caption && <TableCaption>{caption}</TableCaption>}
-        <TableHeader>
-          <TableRow className="hover:bg-transparent">
-            {columns.map((column) => (
-              <TableHead key={column.key} className={cn('px-6 py-3 text-xs font-medium uppercase tracking-wider text-muted-foreground', column.headerClassName)}>
-                {column.header}
-              </TableHead>
-            ))}
-          </TableRow>
-        </TableHeader>
-        <TableBody className={bodyClassName}>
-          {rows.length === 0 ? (
-            <TableRow className="hover:bg-transparent">
-              <TableCell colSpan={columns.length} className="px-6 py-12 text-center text-muted-foreground">
-                {emptyState}
-              </TableCell>
-            </TableRow>
-          ) : rows.map((row) => {
-            const href = getRowHref?.(row)
-            const resolvedRowClassName = typeof rowClassName === 'function' ? rowClassName(row) : rowClassName
+    <TarjetaSistema className={cn('overflow-hidden p-0', className)}>
+      <div className="overflow-x-auto">
+        <table className={cn('min-w-full divide-y divide-border', tableClassName)}>
+          {caption && <caption className="sr-only">{caption}</caption>}
+          <thead>
+            <tr>
+              {selectColumn && (
+                <th className={cn('px-4 py-3 text-left', selectColumn.headerClassName)}>
+                  {selectColumn.header}
+                </th>
+              )}
+              {columns.map((column) => (
+                <th key={column.key} className={cn('px-6 py-3 text-left text-xs font-medium uppercase tracking-wider text-muted-foreground', column.headerClassName)}>
+                  {column.header}
+                </th>
+              ))}
+            </tr>
+          </thead>
+          <tbody className={cn('divide-y divide-border', bodyClassName)}>
+            {rows.length === 0 ? (
+              <tr>
+                <td colSpan={columnCount} className="px-6 py-12 text-center text-muted-foreground">
+                  {emptyState}
+                </td>
+              </tr>
+            ) : rows.map((row) => {
+              const href = getRowHref?.(row)
+              const resolvedRowClassName = typeof rowClassName === 'function' ? rowClassName(row) : rowClassName
 
-            return (
-              <TableRow key={getRowKey(row)} className={cn('hover:bg-accent/50', href && 'group', resolvedRowClassName)}>
-                {columns.map((column, columnIndex) => {
-                  const content = column.cell(row)
+              return (
+                <tr key={getRowKey(row)} className={cn('transition-colors hover:bg-accent/50', href && 'group', resolvedRowClassName)}>
+                  {selectColumn && (
+                    <td className={cn('px-4 py-4', selectColumn.className)}>
+                      {selectColumn.cell(row)}
+                    </td>
+                  )}
+                  {columns.map((column, columnIndex) => {
+                    const content = column.cell(row)
 
-                  return (
-                    <TableCell key={column.key} className={cn('px-6 py-4', column.className)}>
-                      {href && columnIndex === 0 ? (
-                        <Link href={href} aria-label={getRowLabel?.(row)} className={cn('focus-ring block rounded-md font-medium text-foreground transition-colors group-hover:text-orange-600', linkClassName)}>
-                          {content}
-                        </Link>
-                      ) : content}
-                    </TableCell>
-                  )
-                })}
-              </TableRow>
-            )
-          })}
-        </TableBody>
-      </Table>
-    </div>
+                    return (
+                      <td key={column.key} className={cn('px-6 py-4', column.className)}>
+                        {href && columnIndex === 0 ? (
+                          <Link href={href} aria-label={getRowLabel?.(row)} className={cn('focus-ring block rounded-md font-medium text-foreground transition-colors hover:text-orange-600 group-hover:text-orange-600', linkClassName)}>
+                            {content}
+                          </Link>
+                        ) : content}
+                      </td>
+                    )
+                  })}
+                </tr>
+              )
+            })}
+          </tbody>
+        </table>
+      </div>
+    </TarjetaSistema>
   )
 }

--- a/components/ui/data-table.tsx
+++ b/components/ui/data-table.tsx
@@ -1,0 +1,89 @@
+import Link from 'next/link'
+import type { ReactNode } from 'react'
+
+import { cn } from '@/lib/utils'
+import {
+  Table,
+  TableBody,
+  TableCaption,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from '@/components/ui/table'
+
+export interface DataTableColumn<Row> {
+  key: string
+  header: ReactNode
+  cell: (row: Row) => ReactNode
+  className?: string
+  headerClassName?: string
+}
+
+interface DataTableProps<Row> {
+  columns: DataTableColumn<Row>[]
+  rows: Row[]
+  getRowKey: (row: Row) => string
+  caption?: ReactNode
+  emptyState?: ReactNode
+  getRowHref?: (row: Row) => string
+  getRowLabel?: (row: Row) => string
+  className?: string
+}
+
+export function DataTable<Row>({
+  columns,
+  rows,
+  getRowKey,
+  caption,
+  emptyState,
+  getRowHref,
+  getRowLabel,
+  className,
+}: DataTableProps<Row>) {
+  return (
+    <div className={cn('overflow-x-auto rounded-2xl border border-border bg-card shadow-sm [&_[data-slot=table-container]]:overflow-visible', className)}>
+      <Table className="min-w-[720px]">
+        {caption && <TableCaption>{caption}</TableCaption>}
+        <TableHeader>
+          <TableRow className="hover:bg-transparent">
+            {columns.map((column) => (
+              <TableHead key={column.key} className={cn('px-4 text-xs font-semibold uppercase tracking-wide text-muted-foreground', column.headerClassName)}>
+                {column.header}
+              </TableHead>
+            ))}
+          </TableRow>
+        </TableHeader>
+        <TableBody>
+          {rows.length === 0 ? (
+            <TableRow className="hover:bg-transparent">
+              <TableCell colSpan={columns.length} className="px-4 py-8 text-center text-muted-foreground">
+                {emptyState}
+              </TableCell>
+            </TableRow>
+          ) : rows.map((row) => {
+            const href = getRowHref?.(row)
+
+            return (
+              <TableRow key={getRowKey(row)} className={href ? 'group' : undefined}>
+                {columns.map((column, columnIndex) => {
+                  const content = column.cell(row)
+
+                  return (
+                    <TableCell key={column.key} className={cn('px-4 py-3', column.className)}>
+                      {href && columnIndex === 0 ? (
+                        <Link href={href} aria-label={getRowLabel?.(row)} className="focus-ring rounded-md font-medium text-foreground group-hover:text-[var(--brand-primary)]">
+                          {content}
+                        </Link>
+                      ) : content}
+                    </TableCell>
+                  )
+                })}
+              </TableRow>
+            )
+          })}
+        </TableBody>
+      </Table>
+    </div>
+  )
+}

--- a/components/ui/data-table.tsx
+++ b/components/ui/data-table.tsx
@@ -29,6 +29,10 @@ interface DataTableProps<Row> {
   getRowHref?: (row: Row) => string
   getRowLabel?: (row: Row) => string
   className?: string
+  tableClassName?: string
+  rowClassName?: string | ((row: Row) => string | undefined)
+  bodyClassName?: string
+  linkClassName?: string
 }
 
 export function DataTable<Row>({
@@ -40,39 +44,44 @@ export function DataTable<Row>({
   getRowHref,
   getRowLabel,
   className,
+  tableClassName,
+  rowClassName,
+  bodyClassName,
+  linkClassName,
 }: DataTableProps<Row>) {
   return (
     <div className={cn('overflow-x-auto rounded-2xl border border-border bg-card shadow-sm [&_[data-slot=table-container]]:overflow-visible', className)}>
-      <Table className="min-w-[720px]">
+      <Table className={cn('min-w-[720px]', tableClassName)}>
         {caption && <TableCaption>{caption}</TableCaption>}
         <TableHeader>
           <TableRow className="hover:bg-transparent">
             {columns.map((column) => (
-              <TableHead key={column.key} className={cn('px-4 text-xs font-semibold uppercase tracking-wide text-muted-foreground', column.headerClassName)}>
+              <TableHead key={column.key} className={cn('px-6 py-3 text-xs font-medium uppercase tracking-wider text-muted-foreground', column.headerClassName)}>
                 {column.header}
               </TableHead>
             ))}
           </TableRow>
         </TableHeader>
-        <TableBody>
+        <TableBody className={bodyClassName}>
           {rows.length === 0 ? (
             <TableRow className="hover:bg-transparent">
-              <TableCell colSpan={columns.length} className="px-4 py-8 text-center text-muted-foreground">
+              <TableCell colSpan={columns.length} className="px-6 py-12 text-center text-muted-foreground">
                 {emptyState}
               </TableCell>
             </TableRow>
           ) : rows.map((row) => {
             const href = getRowHref?.(row)
+            const resolvedRowClassName = typeof rowClassName === 'function' ? rowClassName(row) : rowClassName
 
             return (
-              <TableRow key={getRowKey(row)} className={href ? 'group' : undefined}>
+              <TableRow key={getRowKey(row)} className={cn('hover:bg-accent/50', href && 'group', resolvedRowClassName)}>
                 {columns.map((column, columnIndex) => {
                   const content = column.cell(row)
 
                   return (
-                    <TableCell key={column.key} className={cn('px-4 py-3', column.className)}>
+                    <TableCell key={column.key} className={cn('px-6 py-4', column.className)}>
                       {href && columnIndex === 0 ? (
-                        <Link href={href} aria-label={getRowLabel?.(row)} className="focus-ring rounded-md font-medium text-foreground group-hover:text-[var(--brand-primary)]">
+                        <Link href={href} aria-label={getRowLabel?.(row)} className={cn('focus-ring block rounded-md font-medium text-foreground transition-colors group-hover:text-orange-600', linkClassName)}>
                           {content}
                         </Link>
                       ) : content}

--- a/components/ui/header-movil.tsx
+++ b/components/ui/header-movil.tsx
@@ -26,6 +26,7 @@ interface SubItem {
   href: string
   icon?: React.ComponentType<{ className?: string }>
   roles?: string[]
+  capabilities?: string[]
 }
 
 // ── Menu items with optional children (mirror of sidebar) ──
@@ -36,7 +37,10 @@ interface MobileMenuItem {
   href: string
   children?: SubItem[]
   roles?: string[]
+  capabilities?: string[]
 }
+
+const SUPPORT_CONFIGURATION_ROLES = ['admin', 'pastor', 'director-general']
 
 const mainMenuItems: MobileMenuItem[] = [
   { id: 'dashboard', label: 'Dashboard', icon: Home, href: '/dashboard' },
@@ -66,8 +70,10 @@ const mainMenuItems: MobileMenuItem[] = [
     children: [
       { id: 'config-general', label: 'General', href: '/configuracion', icon: Settings, roles: ['admin', 'pastor'] },
       { id: 'config-dg', label: 'Directores Generales', href: '/configuracion/directores-generales', icon: Users, roles: ['admin', 'pastor', 'director-general'] },
+      { id: 'config-soporte', label: 'Soporte', href: '/configuracion/soporte', icon: HelpCircle, roles: SUPPORT_CONFIGURATION_ROLES, capabilities: ['support.manage'] },
     ],
   },
+  { id: 'soporte-admin', label: 'Soporte', icon: HelpCircle, href: '/ayuda/admin', capabilities: ['support.view', 'support.reply', 'support.manage'] },
 ]
 
 const footerMenuItems: MobileMenuItem[] = [
@@ -104,7 +110,7 @@ export function HeaderMovil({ titulo }: HeaderMovilProps) {
   const [userMenuOpen, setUserMenuOpen] = useState(false)
   const [openSubmenus, setOpenSubmenus] = useState<Set<string>>(new Set())
   const pathname = usePathname()
-  const { usuario, roles, loading } = useCurrentUser()
+  const { usuario, roles, supportCapabilities = [], loading } = useCurrentUser()
   const branding = useBranding()
   const toast = useNotificaciones()
   const { theme, setTheme } = useTheme()
@@ -182,6 +188,13 @@ export function HeaderMovil({ titulo }: HeaderMovilProps) {
   }, [])
 
   const closeDrawer = useCallback(() => setDrawerOpen(false), [])
+
+  const canAccess = (item: Pick<MobileMenuItem, 'roles' | 'capabilities'>): boolean => {
+    const hasRequiredRole = !item.roles || item.roles.some((role) => roles.includes(role))
+    const hasRequiredCapability = !item.capabilities || item.capabilities.some((capability) => supportCapabilities.includes(capability))
+
+    return hasRequiredRole && hasRequiredCapability
+  }
 
   const isActive = (href: string): boolean => {
     return pathname === href ||
@@ -439,11 +452,11 @@ export function HeaderMovil({ titulo }: HeaderMovilProps) {
         <nav className="flex-1 overflow-y-auto px-3 py-1">
           <ul className="space-y-0.5">
             {mainMenuItems
-              .filter(item => !item.roles || item.roles.some(r => roles.includes(r)))
+              .filter(canAccess)
               .map(item => {
               const Icon = item.icon
               const visibleChildren = item.children?.filter(
-                child => !child.roles || child.roles.some(r => roles.includes(r))
+                canAccess
               ) ?? []
               const hasChildren = visibleChildren.length > 0
               const active = isActive(item.href)

--- a/components/ui/sidebar-moderna.tsx
+++ b/components/ui/sidebar-moderna.tsx
@@ -43,6 +43,8 @@ interface SubItem {
   icon?: React.ComponentType<{ className?: string }>
   /** Roles que pueden ver este sub-item. Si no se define, es visible para todos. */
   roles?: string[]
+  /** Support capabilities que pueden ver este sub-item. Si no se define, es visible para todos. */
+  capabilities?: string[]
 }
 
 interface MenuItem {
@@ -56,7 +58,11 @@ interface MenuItem {
   className?: string
   /** Roles que pueden ver este item. Si no se define, es visible para todos. */
   roles?: string[]
+  /** Support capabilities que pueden ver este item. Si no se define, es visible para todos. */
+  capabilities?: string[]
 }
+
+const SUPPORT_CONFIGURATION_ROLES = ['admin', 'pastor', 'director-general']
 
 const menuItems: MenuItem[] = [
   {
@@ -97,7 +103,15 @@ const menuItems: MenuItem[] = [
     children: [
       { id: 'config-general', label: 'General', href: '/configuracion', icon: Settings, roles: ['admin', 'pastor'] },
       { id: 'config-dg', label: 'Directores Generales', href: '/configuracion/directores-generales', icon: Users, roles: ['admin', 'pastor', 'director-general'] },
+      { id: 'config-soporte', label: 'Soporte', href: '/configuracion/soporte', icon: HelpCircle, roles: SUPPORT_CONFIGURATION_ROLES, capabilities: ['support.manage'] },
     ],
+  },
+  {
+    id: 'soporte-admin',
+    label: 'Soporte',
+    icon: HelpCircle,
+    href: '/ayuda/admin',
+    capabilities: ['support.view', 'support.reply', 'support.manage'],
   },
 ]
 
@@ -122,7 +136,7 @@ export function SidebarModerna({ className }: SidebarModernaProps) {
   const [tooltip, setTooltip] = useState<{ label: string; top: number } | null>(null)
   const router = useRouter()
   const pathname = usePathname()
-  const { usuario, roles, loading } = useCurrentUser()
+  const { usuario, roles, supportCapabilities = [], loading } = useCurrentUser()
   const branding = useBranding()
 
 
@@ -244,6 +258,13 @@ export function SidebarModerna({ className }: SidebarModernaProps) {
     return isActive(item.href)
   }
 
+  const canAccess = (item: Pick<MenuItem, 'roles' | 'capabilities'>): boolean => {
+    const hasRequiredRole = !item.roles || item.roles.some((role) => roles.includes(role))
+    const hasRequiredCapability = !item.capabilities || item.capabilities.some((capability) => supportCapabilities.includes(capability))
+
+    return hasRequiredRole && hasRequiredCapability
+  }
+
   // ─── Shared link styles ───
   const linkClasses = (active: boolean) => cn(
     "flex items-center gap-3 px-3 py-2 rounded-xl group relative min-h-[44px]",
@@ -331,12 +352,12 @@ export function SidebarModerna({ className }: SidebarModernaProps) {
         <nav className="flex-1 px-3 py-2 overflow-y-auto">
           <ul className="space-y-0.5">
             {menuItems
-              .filter((item) => !item.roles || item.roles.some(r => roles.includes(r)))
+              .filter(canAccess)
               .map((item) => {
                 const Icon = item.icon
-                // Filter children by role — if none are visible, treat as simple link
+                // Filter children by access — if none are visible, treat as simple link
                 const visibleChildren = item.children?.filter(
-                  (child) => !child.roles || child.roles.some(r => roles.includes(r))
+                  canAccess
                 ) ?? []
                 const hasChildren = visibleChildren.length > 0
                 const parentActive = isParentActive(item)

--- a/docs/support-operations.md
+++ b/docs/support-operations.md
@@ -21,6 +21,23 @@ This runbook covers the operational path for the support ticket system. It is in
 | Sentry | Support stores Sentry references only; raw payloads, replay media, cookies, headers, and diagnostics are scrubbed. |
 | GitHub | No MVP sync. Future GitHub issues are downstream engineering artifacts only. |
 
+## Production Readiness Gates
+
+Support must remain in a safe degraded state until every gate below has explicit review evidence. Safe degraded means users can be protected by hidden navigation, disabled side effects, or unavailable provider workflows without deleting tickets, messages, audit events, or private attachment metadata.
+
+| Gate | Required evidence | Failure behavior |
+|------|-------------------|------------------|
+| DB gate | Support migrations are reviewed as additive and non-destructive; generated Supabase types match the reviewed schema. | Do not claim production readiness; keep support data preserved and ship only additive corrections. |
+| provider gate | Non-production R2, Inngest, Resend, and Sentry checks prove private storage, ID-only events, safe emails, and scrubbed evidence. | Disable provider side effects and keep app flows authenticated/degraded. |
+| environment gate | Server-only secrets exist in the target runtime and no secret appears in `NEXT_PUBLIC_*`, docs, logs, or tickets. | Block rollout until secrets are configured or rotate any exposed value. |
+| RLS/privacy gate | `pnpm test:rls` or the approved staging RLS equivalent passes; privacy tests prove diagnostics, attachments, signed URLs, object keys, cookies, storage, and raw payloads are excluded. | Hide staff surfaces and do not expose cross-user support data. |
+| smoke gate | Reporter create, attachment upload/finalize/download, staff queue/detail, notification, inbound bridge, and rollback smoke checks pass in non-production. | Keep the feature degraded and document the failed check before retry. |
+| rollback gate | Rollback starts by hiding entry points and disabling side effects, not by deleting production data. | Do not proceed until the rollback owner and first action are known. |
+
+## External Escalation Approval
+
+Outbound bridge payloads are staff-approved sanitized external escalation only. The bridge sanitizer removes known support secrets, signed URL markers, token-like query values, and object-key patterns, but it must not be treated as a general PII scrubber. Staff must rewrite summaries and reproduction steps before escalation so user-identifying details, private church/member context, free-form sensitive text, attachments, raw diagnostics, and internal notes are not sent downstream.
+
 ## Environment Checklist
 
 Set secrets only in the runtime provider or deployment environment. Never commit them to the repository, docs, OpenSpec artifacts, screenshots, or support tickets.
@@ -49,7 +66,7 @@ Operational limits from code and spec:
 
 | Setting | Required | Notes |
 |---------|----------|-------|
-| Event names | Yes | `support/ticket.created`, `support/ticket.message.created`, `support/ticket.status.changed`, `support/attachment.finalized`. |
+| Event names | Yes | `support/ticket.created`, `support/ticket.message.created`, `support/ticket.status.changed`, `support/attachment.finalized`, `support/external.update.received`. |
 | Payload shape | Yes | IDs only: `eventId`, `ticketId`, optional `actorUserId`, and relevant message or attachment IDs. |
 | Idempotency | Yes | Email keys use `email:{eventId}:{recipient}`. Preserve this shape in any worker integration. |
 | Provider credentials | Future wiring | The current support module defines event contracts and email dispatch helpers; provider-specific live Inngest client wiring must be reviewed before enabling. |
@@ -76,6 +93,39 @@ Before enabling support evidence in production, reviewers must confirm:
 - Replay text is masked and media is blocked by default.
 - Support evidence stores allowlisted diagnostics and Sentry event IDs only.
 - Sentry requests, headers, bodies, user fields, URLs, and support contexts are scrubbed before send.
+
+## PR5.3 Staging Smoke Tooling
+
+Run PR5.3 provider smokes only against staging or a local app connected to staging-safe provider resources. The smoke script loads `.env.staging.local` by default, refuses to run unless `RLS_ENV=staging`, rejects obvious production hosts, and redacts secrets, ticket IDs, idempotency keys, recipients, and R2 object details in logs.
+
+Command:
+
+```bash
+pnpm support:smoke:staging
+```
+
+Focused checks are available when a provider input is not ready:
+
+```bash
+node scripts/support-smoke-staging.mjs --only=inngest,r2
+node scripts/support-smoke-staging.mjs --only=external
+node scripts/support-smoke-staging.mjs --only=resend
+```
+
+Required environment keys, without values:
+
+| Check | Required keys | Evidence produced |
+|-------|---------------|-------------------|
+| Global guard | `RLS_ENV=staging` | Script refuses non-staging execution before provider calls. |
+| Protected Vercel preview routes | `VERCEL_AUTOMATION_BYPASS_SECRET` when `SUPPORT_SMOKE_BASE_URL` is behind Vercel Deployment Protection | The route smoke requests include `x-vercel-protection-bypass` so Vercel allows the request to reach app auth. Do not use this key for direct provider checks. |
+| Inngest route | `SUPPORT_SMOKE_BASE_URL`, `SUPPORT_INNGEST_WEBHOOK_SECRET` | `/api/inngest` rejects missing/invalid auth and accepts a signed ID-only support event with HTTP 202. |
+| External bridge | `SUPPORT_SMOKE_BASE_URL`, `SUPPORT_EXTERNAL_BRIDGE_TOKEN`, `SUPPORT_EXTERNAL_BRIDGE_AUTHOR_USUARIO_ID`, `SUPPORT_SMOKE_TICKET_ID` | `/api/support/external/inbound` rejects invalid auth, accepts one sanitized staging update, and treats the duplicate idempotency key as duplicate. |
+| R2 direct provider | `R2_ACCOUNT_ID`, `R2_ACCESS_KEY_ID`, `R2_SECRET_ACCESS_KEY` | Private support bucket accepts one smoke PUT, returns matching bytes on GET, and deletes the smoke object in cleanup. |
+| Resend | `RESEND_API_KEY`, `SUPPORT_SMOKE_EMAIL_TO`, optional `RESEND_FROM_NAME`, `RESEND_FROM_EMAIL` | Resend accepts a staging-safe notification email with no evidence, attachments, diagnostics, secrets, object keys, or user PII. |
+
+`SUPPORT_SMOKE_BASE_URL` must be a staging/preview/local origin for the running Next.js app. Do not use the production `connect.yosoyglobal.org` origin. `SUPPORT_SMOKE_TICKET_ID` must be a safe staging support ticket UUID because the external bridge persists a clearly labeled smoke update. `SUPPORT_SMOKE_EMAIL_TO` must be a reviewer-controlled staging recipient; do not send smoke email to users.
+
+The R2 smoke intentionally exercises direct provider put/get/delete, not the authenticated attachment app routes. The app-level attachment intent/finalize/download route smoke still requires an authenticated staging user/session with access to the staging ticket; do that manually unless a reviewer provides a safe session mechanism for automation.
 
 ## Rollback Guidance
 

--- a/hooks/use-notificaciones.ts
+++ b/hooks/use-notificaciones.ts
@@ -1,19 +1,20 @@
 "use client"
 
+import { useCallback, useMemo } from 'react'
 import { toast } from 'sonner'
 
 export const useNotificaciones = () => {
-  const exito = (mensaje: string) => {
+  const exito = useCallback((mensaje: string) => {
     toast.success('Éxito', { description: mensaje })
-  }
+  }, [])
 
-  const error = (mensaje: string) => {
+  const error = useCallback((mensaje: string) => {
     toast.error('Error', { description: mensaje })
-  }
+  }, [])
 
-  const info = (mensaje: string) => {
+  const info = useCallback((mensaje: string) => {
     toast.info('Información', { description: mensaje })
-  }
+  }, [])
 
-  return { success: exito, error, info }
+  return useMemo(() => ({ success: exito, error, info }), [exito, error, info])
 }

--- a/hooks/useCurrentUser.ts
+++ b/hooks/useCurrentUser.ts
@@ -9,13 +9,18 @@ type Usuario = Database['public']['Tables']['usuarios']['Row']
 interface CurrentUserData {
   usuario: Usuario | null
   roles: string[]
+  supportCapabilities: string[]
   loading: boolean
   error: string | null
 }
 
+const SUPPORT_CAPABILITIES = ['support.view', 'support.reply', 'support.manage'] as const
+type SupportCapability = (typeof SUPPORT_CAPABILITIES)[number]
+
 export function useCurrentUser(): CurrentUserData {
   const [usuario, setUsuario] = useState<Usuario | null>(null)
   const [roles, setRoles] = useState<string[]>([])
+  const [supportCapabilities, setSupportCapabilities] = useState<string[]>([])
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState<string | null>(null)
 
@@ -37,6 +42,7 @@ export function useCurrentUser(): CurrentUserData {
         if (!user) {
           setUsuario(null)
           setRoles([])
+          setSupportCapabilities([])
           return
         }
 
@@ -59,17 +65,34 @@ export function useCurrentUser(): CurrentUserData {
         if (!rolesError && rolesData) {
           // rolesData puede ser array de strings o de objetos
           userRoles = Array.isArray(rolesData)
-            ? (rolesData as any[]).map(r => typeof r === "string" ? r : r?.nombre_interno).filter(Boolean)
+            ? rolesData.map((role: unknown) => typeof role === "string" ? role : getRoleName(role)).filter((role): role is string => Boolean(role))
             : []
+        }
+
+        let userSupportCapabilities: string[] = []
+        if (userData?.id) {
+          const { data: capabilitiesData, error: capabilitiesError } = await supabase
+            .from('support_user_capabilities')
+            .select('capability')
+            .eq('usuario_id', userData.id)
+            .is('revoked_at', null)
+
+          if (!capabilitiesError && capabilitiesData) {
+            userSupportCapabilities = capabilitiesData
+              .map((row: { capability: string }) => row.capability)
+              .filter((capability): capability is SupportCapability => SUPPORT_CAPABILITIES.includes(capability as SupportCapability))
+          }
         }
 
         setUsuario(userData)
         setRoles(userRoles)
+        setSupportCapabilities(userSupportCapabilities)
       } catch (err) {
         console.error('Error en useCurrentUser:', err)
         setError(err instanceof Error ? err.message : 'Error desconocido')
         setUsuario(null)
         setRoles([])
+        setSupportCapabilities([])
       } finally {
         setLoading(false)
       }
@@ -83,6 +106,7 @@ export function useCurrentUser(): CurrentUserData {
       if (event === 'SIGNED_OUT') {
         setUsuario(null)
         setRoles([])
+        setSupportCapabilities([])
         setLoading(false)
       } else if (event === 'SIGNED_IN' && session) {
         fetchCurrentUser()
@@ -94,5 +118,11 @@ export function useCurrentUser(): CurrentUserData {
     }
   }, [])
 
-  return { usuario, roles, loading, error }
+  return { usuario, roles, supportCapabilities, loading, error }
+}
+
+function getRoleName(role: unknown) {
+  if (typeof role !== 'object' || role === null || !('nombre_interno' in role)) return undefined
+  const roleName = role.nombre_interno
+  return typeof roleName === 'string' ? roleName : undefined
 }

--- a/lib/actions/support-capabilities.actions.ts
+++ b/lib/actions/support-capabilities.actions.ts
@@ -1,0 +1,79 @@
+"use server"
+
+import { revalidatePath } from 'next/cache'
+
+import { isSupportCapability, type SupportCapability } from '@/lib/support/capabilities'
+import { createSupabaseServerClient } from '@/lib/supabase/server'
+
+type SupportCapabilityActionResult = { success: true } | { success: false; error: string }
+
+const SUPPORT_CAPABILITY_ERROR = 'No se pudo actualizar la capacidad de soporte'
+const SUPPORT_CONFIGURATION_ROLES = ['admin', 'pastor', 'director-general']
+
+export async function grantSupportCapability(targetUsuarioId: string, capability: string): Promise<SupportCapabilityActionResult> {
+  return updateSupportCapability('grant_support_capability', targetUsuarioId, capability)
+}
+
+export async function revokeSupportCapability(targetUsuarioId: string, capability: string): Promise<SupportCapabilityActionResult> {
+  return updateSupportCapability('revoke_support_capability', targetUsuarioId, capability)
+}
+
+async function updateSupportCapability(rpcName: 'grant_support_capability' | 'revoke_support_capability', targetUsuarioId: string, capability: string): Promise<SupportCapabilityActionResult> {
+  if (!isSupportCapability(capability)) return { success: false, error: 'Capacidad de soporte invalida' }
+
+  const supabase = await createSupabaseServerClient()
+  const actor = await getActorUsuarioId(supabase)
+  if (!actor.success) return actor
+
+  const authorization = await requireSupportCapabilityAdminContext(supabase, actor.usuarioId, actor.authId)
+  if (!authorization.success) return authorization
+
+  const { error } = await supabase.rpc(rpcName as never, {
+    p_target_usuario_id: targetUsuarioId,
+    p_capability: capability as SupportCapability,
+  } as never)
+
+  if (error) return { success: false, error: SUPPORT_CAPABILITY_ERROR }
+  revalidatePath('/configuracion/soporte')
+  revalidatePath('/ayuda/admin')
+  return { success: true }
+}
+
+async function getActorUsuarioId(supabase: Awaited<ReturnType<typeof createSupabaseServerClient>>) {
+  const { data: { user } } = await supabase.auth.getUser()
+  if (!user) return { success: false as const, error: 'No autenticado' }
+
+  const { data, error } = await supabase.from('usuarios').select('id').eq('auth_id', user.id).maybeSingle()
+  if (error || !data?.id) return { success: false as const, error: 'Perfil de usuario no encontrado' }
+  return { success: true as const, usuarioId: data.id, authId: user.id }
+}
+
+async function requireSupportCapabilityAdminContext(supabase: Awaited<ReturnType<typeof createSupabaseServerClient>>, usuarioId: string, authId: string) {
+  const { data, error } = await supabase
+    .from('support_user_capabilities')
+    .select('capability')
+    .eq('usuario_id', usuarioId)
+    .eq('capability', 'support.manage')
+    .is('revoked_at', null)
+    .maybeSingle()
+
+  if (error || !data) return { success: false as const, error: 'No autorizado' }
+
+  const { data: roles, error: rolesError } = await supabase.rpc('obtener_roles_usuario' as never, { p_auth_id: authId } as never)
+  const roleRows: unknown = roles
+  if (rolesError || !Array.isArray(roleRows) || !roleRows.some((role) => hasSupportConfigurationRole(role))) {
+    return { success: false as const, error: 'No autorizado' }
+  }
+
+  return { success: true as const }
+}
+
+function hasSupportConfigurationRole(role: unknown) {
+  const roleName = typeof role === 'string'
+    ? role
+    : typeof role === 'object' && role !== null && 'nombre_interno' in role && typeof role.nombre_interno === 'string'
+      ? role.nombre_interno
+      : null
+
+  return roleName !== null && SUPPORT_CONFIGURATION_ROLES.includes(roleName)
+}

--- a/lib/actions/support.actions.ts
+++ b/lib/actions/support.actions.ts
@@ -4,15 +4,16 @@ import { revalidatePath } from 'next/cache'
 import { z } from 'zod'
 
 import { diagnosticsConsentSchema, sanitizeSupportEvidence } from '@/lib/support/support-evidence'
+import { createSupportTicketCreatedEvent, dispatchSupportInngestEvent } from '@/lib/support/inngest'
 import { createSupabaseServerClient } from '@/lib/supabase/server'
 
 const SUPPORT_TICKET_STATUSES = ['received', 'in_review', 'in_progress', 'resolved', 'closed'] as const
+const SUPPORT_TICKET_CAPABILITIES = ['support.view', 'support.reply', 'support.manage'] as const
 
 const supportTicketSchema = z.object({
-  title: z.string().trim().min(5).max(160),
+  subject: z.string().trim().min(5).max(160),
   description: z.string().trim().min(10).max(8000),
   category: z.string().trim().min(2).max(80),
-  severity: z.enum(['low', 'normal', 'high', 'urgent']).default('normal'),
   currentRoute: z.string().trim().max(500).optional(),
   browserName: z.string().trim().max(120).optional(),
   osName: z.string().trim().max(120).optional(),
@@ -42,7 +43,9 @@ const SUPPORT_STAFF_QUEUE_ERROR = 'No se pudo cargar la cola de soporte'
 const SUPPORT_STAFF_REPLY_ERROR = 'No se pudo enviar la respuesta de soporte del equipo'
 const SUPPORT_STAFF_ASSIGNMENT_ERROR = 'No se pudo asignar el ticket de soporte'
 const SUPPORT_STAFF_STATUS_ERROR = 'No se pudo actualizar el estado del ticket de soporte'
+const DEFAULT_REPORTER_SEVERITY = 'normal'
 type SupportCapability = 'support.view' | 'support.reply' | 'support.manage'
+type SupportActionResult<T extends Record<string, unknown> = Record<string, never>> = ({ success: true } & T) | { success: false; error: string }
 
 type SupportTicketRow = {
   id: string
@@ -52,6 +55,7 @@ type SupportTicketRow = {
   status: string
   category: string
   severity: string
+  assignee_usuario_id: string | null
   current_route: string | null
   browser_name: string | null
   os_name: string | null
@@ -64,13 +68,16 @@ type SupportTicketRow = {
 }
 
 type SupportMessageRow = { id: string; body: string; created_at: string }
+type SupportAttachmentRow = { id: string; original_filename: string; kind: string; content_type: string; byte_size: number; status: string }
 
 type StaffSupportTicketRow = Pick<SupportTicketRow, 'id' | 'ticket_number' | 'title' | 'status' | 'category' | 'severity' | 'created_at' | 'updated_at'> & {
   assignee_usuario_id: string | null
   campus_id: string | null
 }
 
-export async function createSupportTicket(formData: FormData) {
+type SupportCapabilityRow = { capability: string }
+
+export async function createSupportTicket(formData: FormData): Promise<SupportActionResult<{ ticketId: string; ticketNumber: number }>> {
   const parsed = supportTicketSchema.safeParse(Object.fromEntries(formData))
   if (!parsed.success) return { success: false, error: parsed.error.errors[0]?.message ?? 'Ticket de soporte invalido' }
 
@@ -81,16 +88,32 @@ export async function createSupportTicket(formData: FormData) {
   const { data, error } = await supabase.from('support_tickets').insert({
     reporter_usuario_id: actor.usuarioId,
     status: 'received',
-    title: parsed.data.title,
+    title: parsed.data.subject,
     description: parsed.data.description,
     category: parsed.data.category,
-    severity: parsed.data.severity,
+    severity: DEFAULT_REPORTER_SEVERITY,
     ...sanitizeSupportEvidence(parsed.data),
   }).select('id,ticket_number').single()
 
   if (error || !data) return { success: false, error: SUPPORT_TICKET_CREATE_ERROR }
+
+  const audit = await appendSupportTicketEvent(supabase, {
+    ticketId: data.id,
+    actorUsuarioId: actor.usuarioId,
+    action: 'support.ticket.created',
+    targetType: 'support_ticket',
+    targetId: data.id,
+    metadata: { source: 'reporter' },
+  })
+  if (!audit.success) return { success: false, error: SUPPORT_TICKET_CREATE_ERROR }
+
+  await dispatchSupportInngestEvent(createSupportTicketCreatedEvent({ eventId: audit.eventId, ticketId: data.id, actorUserId: actor.usuarioId }))
   revalidatePath('/ayuda/tickets')
   return { success: true, ticketId: data.id, ticketNumber: data.ticket_number }
+}
+
+export async function createSupportTicketFromForm(_previousState: SupportActionResult<{ ticketId: string; ticketNumber: number }> | null, formData: FormData): Promise<SupportActionResult<{ ticketId: string; ticketNumber: number }>> {
+  return createSupportTicket(formData)
 }
 
 export async function listSupportTickets() {
@@ -115,8 +138,8 @@ export async function listStaffSupportTickets(filters: unknown) {
   const actor = await getActorUsuarioId(supabase)
   if (!actor.success) return { ...actor, tickets: [] }
 
-  const capability = await requireSupportCapability(supabase, actor.usuarioId, 'support.view')
-  if (!capability.success) return { ...capability, tickets: [] }
+  const supportCapabilities = await listActorSupportCapabilities(supabase, actor.usuarioId)
+  if (!hasSupportCapability(supportCapabilities, 'support.view')) return { success: false, error: 'No autorizado', tickets: [] }
 
   const { search, status, category, campusId, assigneeId } = parsed.data
   let query = supabase
@@ -132,7 +155,7 @@ export async function listStaffSupportTickets(filters: unknown) {
   const { data, error } = await query.order('created_at', { ascending: false }).limit(50)
 
   if (error) return { success: false, error: SUPPORT_STAFF_QUEUE_ERROR, tickets: [] }
-  return { success: true, tickets: (data ?? []).map(toStaffTicketSummary) }
+  return { success: true, supportCapabilities, tickets: (data ?? []).map(toStaffTicketSummary) }
 }
 
 export async function createStaffSupportTicketReply(ticketId: string, formData: FormData) {
@@ -191,12 +214,12 @@ export async function updateSupportTicketStatus(ticketId: string, status: string
 
 export async function getSupportTicketDetail(ticketId: string) {
   const supabase = await createSupabaseServerClient()
-  const { data: { user } } = await supabase.auth.getUser()
-  if (!user) return { success: false, error: 'No autenticado' }
+  const actor = await getActorUsuarioId(supabase)
+  if (!actor.success) return actor
 
   const { data: ticket, error } = await supabase
     .from('support_tickets')
-    .select('id,ticket_number,title,description,status,category,severity,current_route,browser_name,os_name,viewport,app_build_version,sentry_event_id,diagnostics_consent,created_at,updated_at')
+    .select('id,ticket_number,title,description,status,category,severity,assignee_usuario_id,current_route,browser_name,os_name,viewport,app_build_version,sentry_event_id,diagnostics_consent,created_at,updated_at')
     .eq('id', ticketId)
     .maybeSingle()
 
@@ -211,7 +234,16 @@ export async function getSupportTicketDetail(ticketId: string) {
     .order('created_at', { ascending: true })
 
   if (messagesError) return { success: false, error: SUPPORT_TICKET_DETAIL_ERROR }
-  return { success: true, ticket: toTicketDetail(ticket as SupportTicketRow, messages ?? []) }
+
+  const { data: attachments, error: attachmentsError } = await supabase
+    .from('support_ticket_attachments')
+    .select('id,original_filename,kind,content_type,byte_size,status')
+    .eq('ticket_id', ticketId)
+    .order('created_at', { ascending: true })
+
+  if (attachmentsError) return { success: false, error: SUPPORT_TICKET_DETAIL_ERROR }
+  const supportCapabilities = await listActorSupportCapabilities(supabase, actor.usuarioId)
+  return { success: true, ticket: toTicketDetail(ticket as SupportTicketRow, messages ?? [], attachments ?? [], supportCapabilities) }
 }
 
 export async function createSupportTicketMessage(ticketId: string, formData: FormData) {
@@ -222,16 +254,79 @@ export async function createSupportTicketMessage(ticketId: string, formData: For
   const actor = await getActorUsuarioId(supabase)
   if (!actor.success) return actor
 
-  const { error } = await supabase.from('support_ticket_messages').insert({
+  const messageInsertResult = supabase.from('support_ticket_messages').insert({
     ticket_id: ticketId,
     author_usuario_id: actor.usuarioId,
     body: parsed.data.body,
     is_internal: false,
   })
+  const message = await resolveInsertWithOptionalSingle(messageInsertResult)
 
-  if (error) return { success: false, error: SUPPORT_TICKET_MESSAGE_ERROR }
+  if (message.error) return { success: false, error: SUPPORT_TICKET_MESSAGE_ERROR }
+
+  const audit = await appendSupportTicketEvent(supabase, {
+    ticketId,
+    actorUsuarioId: actor.usuarioId,
+    action: 'support.reporter_message.created',
+    targetType: 'support_ticket_message',
+    targetId: message.id ?? null,
+    metadata: { source: 'reporter' },
+  })
+  if (!audit.success) return { success: false, error: SUPPORT_TICKET_MESSAGE_ERROR }
+
   revalidatePath(`/ayuda/tickets/${ticketId}`)
   return { success: true }
+}
+
+async function appendSupportTicketEvent(
+  supabase: Awaited<ReturnType<typeof createSupabaseServerClient>>,
+  input: {
+    ticketId: string
+    actorUsuarioId: string
+    action: string
+    targetType: string
+    targetId: string | null
+    metadata: Record<string, string>
+  }
+) {
+  const insertResult = supabase.from('support_ticket_events').insert({
+    ticket_id: input.ticketId,
+    actor_usuario_id: input.actorUsuarioId,
+    action: input.action,
+    target_type: input.targetType,
+    target_id: input.targetId,
+    metadata: input.metadata,
+  })
+  const event = await resolveInsertWithOptionalSingle(insertResult)
+
+  if (event.error) return { success: false as const }
+  return { success: true as const, eventId: event.id ?? `${input.action}:${input.ticketId}` }
+}
+
+async function resolveInsertWithOptionalSingle(insertResult: unknown): Promise<{ id: string | null; error: unknown }> {
+  if (hasSelect(insertResult)) {
+    const selected = insertResult.select('id')
+    if (hasSingle(selected)) {
+      const { data, error } = await selected.single()
+      return { id: readInsertedId(data), error }
+    }
+  }
+
+  const result = await insertResult as { error?: unknown }
+  return { id: null, error: result?.error ?? null }
+}
+
+function hasSelect(value: unknown): value is { select: (columns: string) => unknown } {
+  return typeof value === 'object' && value !== null && 'select' in value && typeof value.select === 'function'
+}
+
+function hasSingle(value: unknown): value is { single: () => Promise<{ data: unknown; error: unknown }> } {
+  return typeof value === 'object' && value !== null && 'single' in value && typeof value.single === 'function'
+}
+
+function readInsertedId(value: unknown) {
+  if (typeof value !== 'object' || value === null || !('id' in value) || typeof value.id !== 'string') return null
+  return value.id
 }
 
 async function getActorUsuarioId(supabase: Awaited<ReturnType<typeof createSupabaseServerClient>>) {
@@ -243,28 +338,45 @@ async function getActorUsuarioId(supabase: Awaited<ReturnType<typeof createSupab
 }
 
 async function requireSupportCapability(supabase: Awaited<ReturnType<typeof createSupabaseServerClient>>, usuarioId: string, capability: SupportCapability) {
+  const supportCapabilities = await listActorSupportCapabilities(supabase, usuarioId)
+  if (!hasSupportCapability(supportCapabilities, capability)) return { success: false as const, error: 'No autorizado' }
+  return { success: true as const }
+}
+
+async function listActorSupportCapabilities(supabase: Awaited<ReturnType<typeof createSupabaseServerClient>>, usuarioId: string): Promise<SupportCapability[]> {
   const { data, error } = await supabase
     .from('support_user_capabilities')
     .select('capability')
     .eq('usuario_id', usuarioId)
-    .eq('capability', capability)
     .is('revoked_at', null)
-    .maybeSingle()
 
-  if (error || !data) return { success: false as const, error: 'No autorizado' }
-  return { success: true as const }
+  if (error) return []
+  return (data ?? [])
+    .map((row: SupportCapabilityRow) => row.capability)
+    .filter((capability): capability is SupportCapability => SUPPORT_TICKET_CAPABILITIES.includes(capability as SupportCapability))
 }
 
-function toTicketSummary(ticket: Omit<SupportTicketRow, 'description' | 'current_route' | 'browser_name' | 'os_name' | 'viewport' | 'app_build_version' | 'sentry_event_id' | 'diagnostics_consent'>) {
+function hasSupportCapability(supportCapabilities: SupportCapability[], requiredCapability: SupportCapability) {
+  return supportCapabilities.some((capability) => {
+    if (capability === requiredCapability) return true
+    if (capability === 'support.manage') return true
+    return capability === 'support.reply' && requiredCapability === 'support.view'
+  })
+}
+
+function toTicketSummary(ticket: Omit<SupportTicketRow, 'description' | 'assignee_usuario_id' | 'current_route' | 'browser_name' | 'os_name' | 'viewport' | 'app_build_version' | 'sentry_event_id' | 'diagnostics_consent'>) {
   return { id: ticket.id, ticketNumber: ticket.ticket_number, title: ticket.title, status: ticket.status, category: ticket.category, severity: ticket.severity, createdAt: ticket.created_at, updatedAt: ticket.updated_at }
 }
 
-function toTicketDetail(ticket: SupportTicketRow, messages: SupportMessageRow[]) {
+function toTicketDetail(ticket: SupportTicketRow, messages: SupportMessageRow[], attachments: SupportAttachmentRow[], supportCapabilities: SupportCapability[]) {
   return {
     ...toTicketSummary(ticket),
     description: ticket.description,
+    assigneeUsuarioId: ticket.assignee_usuario_id,
     evidence: { currentRoute: ticket.current_route, browserName: ticket.browser_name, osName: ticket.os_name, viewport: ticket.viewport, appBuildVersion: ticket.app_build_version, sentryEventId: ticket.sentry_event_id, diagnosticsConsent: ticket.diagnostics_consent },
     messages: messages.map((message) => ({ id: message.id, body: message.body, createdAt: message.created_at })),
+    attachments: attachments.map((attachment) => ({ id: attachment.id, filename: attachment.original_filename, kind: attachment.kind, contentType: attachment.content_type, byteSize: attachment.byte_size, status: attachment.status })),
+    supportCapabilities,
   }
 }
 

--- a/lib/actions/support.actions.ts
+++ b/lib/actions/support.actions.ts
@@ -55,6 +55,7 @@ type SupportTicketRow = {
   status: string
   category: string
   severity: string
+  reporter_usuario_id: string
   assignee_usuario_id: string | null
   current_route: string | null
   browser_name: string | null
@@ -65,9 +66,12 @@ type SupportTicketRow = {
   diagnostics_consent: boolean
   created_at: string
   updated_at: string
+  reporter?: UsuarioProfileRow | null
+  assignee?: UsuarioProfileRow | null
 }
 
-type SupportMessageRow = { id: string; body: string; created_at: string }
+type UsuarioProfileRow = { id: string; nombre: string | null; apellido: string | null; foto_perfil_url: string | null }
+type SupportMessageRow = { id: string; body: string; author_usuario_id: string; created_at: string; author?: UsuarioProfileRow | null }
 type SupportAttachmentRow = { id: string; original_filename: string; kind: string; content_type: string; byte_size: number; status: string }
 
 type StaffSupportTicketRow = Pick<SupportTicketRow, 'id' | 'ticket_number' | 'title' | 'status' | 'category' | 'severity' | 'created_at' | 'updated_at'> & {
@@ -219,7 +223,7 @@ export async function getSupportTicketDetail(ticketId: string) {
 
   const { data: ticket, error } = await supabase
     .from('support_tickets')
-    .select('id,ticket_number,title,description,status,category,severity,assignee_usuario_id,current_route,browser_name,os_name,viewport,app_build_version,sentry_event_id,diagnostics_consent,created_at,updated_at')
+    .select('id,ticket_number,title,description,status,category,severity,reporter_usuario_id,assignee_usuario_id,current_route,browser_name,os_name,viewport,app_build_version,sentry_event_id,diagnostics_consent,created_at,updated_at,reporter:usuarios!support_tickets_reporter_usuario_id_fkey(id,nombre,apellido,foto_perfil_url),assignee:usuarios!support_tickets_assignee_usuario_id_fkey(id,nombre,apellido,foto_perfil_url)')
     .eq('id', ticketId)
     .maybeSingle()
 
@@ -228,7 +232,7 @@ export async function getSupportTicketDetail(ticketId: string) {
 
   const { data: messages, error: messagesError } = await supabase
     .from('support_ticket_messages')
-    .select('id,body,created_at')
+    .select('id,body,author_usuario_id,created_at,author:usuarios!support_ticket_messages_author_usuario_id_fkey(id,nombre,apellido,foto_perfil_url)')
     .eq('ticket_id', ticketId)
     .eq('is_internal', false)
     .order('created_at', { ascending: true })
@@ -239,6 +243,7 @@ export async function getSupportTicketDetail(ticketId: string) {
     .from('support_ticket_attachments')
     .select('id,original_filename,kind,content_type,byte_size,status')
     .eq('ticket_id', ticketId)
+    .eq('status', 'uploaded')
     .order('created_at', { ascending: true })
 
   if (attachmentsError) return { success: false, error: SUPPORT_TICKET_DETAIL_ERROR }
@@ -364,7 +369,7 @@ function hasSupportCapability(supportCapabilities: SupportCapability[], required
   })
 }
 
-function toTicketSummary(ticket: Omit<SupportTicketRow, 'description' | 'assignee_usuario_id' | 'current_route' | 'browser_name' | 'os_name' | 'viewport' | 'app_build_version' | 'sentry_event_id' | 'diagnostics_consent'>) {
+function toTicketSummary(ticket: Omit<SupportTicketRow, 'description' | 'reporter_usuario_id' | 'assignee_usuario_id' | 'current_route' | 'browser_name' | 'os_name' | 'viewport' | 'app_build_version' | 'sentry_event_id' | 'diagnostics_consent' | 'reporter' | 'assignee'>) {
   return { id: ticket.id, ticketNumber: ticket.ticket_number, title: ticket.title, status: ticket.status, category: ticket.category, severity: ticket.severity, createdAt: ticket.created_at, updatedAt: ticket.updated_at }
 }
 
@@ -372,12 +377,20 @@ function toTicketDetail(ticket: SupportTicketRow, messages: SupportMessageRow[],
   return {
     ...toTicketSummary(ticket),
     description: ticket.description,
+    reporterUsuarioId: ticket.reporter_usuario_id,
     assigneeUsuarioId: ticket.assignee_usuario_id,
+    reporter: toSafeUsuarioProfile(ticket.reporter),
+    assignee: toSafeUsuarioProfile(ticket.assignee),
     evidence: { currentRoute: ticket.current_route, browserName: ticket.browser_name, osName: ticket.os_name, viewport: ticket.viewport, appBuildVersion: ticket.app_build_version, sentryEventId: ticket.sentry_event_id, diagnosticsConsent: ticket.diagnostics_consent },
-    messages: messages.map((message) => ({ id: message.id, body: message.body, createdAt: message.created_at })),
+    messages: messages.map((message) => ({ id: message.id, body: message.body, authorUsuarioId: message.author_usuario_id, author: toSafeUsuarioProfile(message.author), createdAt: message.created_at })),
     attachments: attachments.map((attachment) => ({ id: attachment.id, filename: attachment.original_filename, kind: attachment.kind, contentType: attachment.content_type, byteSize: attachment.byte_size, status: attachment.status })),
     supportCapabilities,
   }
+}
+
+function toSafeUsuarioProfile(profile: UsuarioProfileRow | null | undefined) {
+  if (!profile) return null
+  return { id: profile.id, nombre: profile.nombre, apellido: profile.apellido, photoUrl: profile.foto_perfil_url }
 }
 
 function toStaffTicketSummary(ticket: StaffSupportTicketRow) {

--- a/lib/actions/support.actions.ts
+++ b/lib/actions/support.actions.ts
@@ -162,7 +162,7 @@ export async function listStaffSupportTickets(filters: unknown) {
   return { success: true, supportCapabilities, tickets: (data ?? []).map(toStaffTicketSummary) }
 }
 
-export async function createStaffSupportTicketReply(ticketId: string, formData: FormData) {
+export async function createStaffSupportTicketReply(ticketId: string, formData: FormData, options: { autoAssignIfUnassigned?: boolean } = {}) {
   const parsed = messageSchema.safeParse(Object.fromEntries(formData))
   if (!parsed.success) return { success: false, error: parsed.error.errors[0]?.message ?? 'Respuesta invalida' }
 
@@ -174,6 +174,13 @@ export async function createStaffSupportTicketReply(ticketId: string, formData: 
 
   const { error } = await supabase.rpc('create_staff_support_ticket_reply' as never, { p_ticket_id: ticketId, p_body: parsed.data.body } as never)
   if (error) return { success: false, error: SUPPORT_STAFF_REPLY_ERROR }
+
+  if (options.autoAssignIfUnassigned) {
+    const manageCapability = await requireSupportCapability(supabase, actor.usuarioId, 'support.manage')
+    if (manageCapability.success) {
+      await supabase.rpc('auto_assign_support_ticket_if_unassigned' as never, { p_ticket_id: ticketId } as never)
+    }
+  }
 
   revalidatePath(`/ayuda/tickets/${ticketId}`)
   revalidatePath('/ayuda/admin')

--- a/lib/supabase/database.types.ts
+++ b/lib/supabase/database.types.ts
@@ -2490,7 +2490,7 @@ export type Database = {
           metadata: Json
           target_id: string | null
           target_type: string
-          ticket_id: string
+          ticket_id: string | null
         }
         Insert: {
           action: string
@@ -2501,7 +2501,7 @@ export type Database = {
           metadata?: Json
           target_id?: string | null
           target_type: string
-          ticket_id: string
+          ticket_id?: string | null
         }
         Update: {
           action?: string
@@ -2512,7 +2512,7 @@ export type Database = {
           metadata?: Json
           target_id?: string | null
           target_type?: string
-          ticket_id?: string
+          ticket_id?: string | null
         }
         Relationships: [
           {
@@ -3860,6 +3860,19 @@ export type Database = {
           sl_row: Database["public"]["Tables"]["segmento_lideres"]["Row"]
         }
         Returns: boolean
+      }
+      record_support_external_inbound_update: {
+        Args: {
+          p_author_usuario_id: string
+          p_idempotency_key: string
+          p_message_body: string
+          p_ticket_id: string
+        }
+        Returns: {
+          duplicate: boolean
+          event_id: string
+          message_id: string | null
+        }[]
       }
       actualizar_rol_miembro: {
         Args: {

--- a/lib/support/external-bridge.ts
+++ b/lib/support/external-bridge.ts
@@ -1,0 +1,161 @@
+import { z } from 'zod'
+import { timingSafeEqual } from 'crypto'
+
+import { createSupabaseAdminClient } from '@/lib/supabase/admin'
+
+const inboundUpdateSchema = z.object({
+  ticketId: z.string().uuid(),
+  idempotencyKey: z.string().trim().min(3).max(120),
+  message: z.string().trim().min(1).max(8000),
+})
+
+type ExternalEscalationInput = {
+  ticketId: string
+  ticketNumber: number
+  title: string
+  summary: string
+  recipient: string
+} & Record<string, unknown>
+
+type InsertAuditEventInput = {
+  ticketId: string
+  actorUsuarioId: string
+  action: string
+  targetType: string
+  idempotencyKey: string
+  body: string
+  isInternal: boolean
+}
+
+type PersistInboundUpdateResult = { duplicate: boolean; eventId: string; messageId?: string }
+
+type ProcessExternalBridgeInboundUpdateParams = {
+  authorizationHeader: string | null
+  expectedToken: string
+  authorUsuarioId: string
+  body: unknown
+  persistInboundUpdate: (input: InsertAuditEventInput) => Promise<PersistInboundUpdateResult>
+}
+
+export function createExternalEscalationPayload(input: ExternalEscalationInput) {
+  return {
+    ticketId: input.ticketId,
+    ticketNumber: input.ticketNumber,
+    title: sanitizeExternalBridgeMessage(input.title),
+    summary: sanitizeExternalBridgeMessage(input.summary),
+    recipient: sanitizeExternalBridgeMessage(input.recipient),
+    internalTicketUrl: `/ayuda/tickets/${encodeURIComponent(input.ticketId)}`,
+  }
+}
+
+export function verifyExternalBridgeAuthorization(authorizationHeader: string | null, expectedToken: string) {
+  if (!authorizationHeader || !expectedToken) return false
+  const expected = Buffer.from(`Bearer ${expectedToken}`)
+  const received = Buffer.from(authorizationHeader)
+  if (received.length !== expected.length) return false
+  return timingSafeEqual(received, expected)
+}
+
+export function sanitizeExternalBridgeMessage(message: string) {
+  return message
+    .replace(/https?:\/\/\S*(?:signature|token|X-Amz-Signature|r2)\S*/gi, '[redacted-url]')
+    .replace(/\b(?:token|signedUrl|signature|password|cookie)=\S+/gi, '[redacted]')
+    .replace(/support\/[\w-]+\/[\w-]+\/\S+/gi, '[redacted-object-key]')
+    .trim()
+}
+
+export async function processExternalBridgeInboundUpdate(params: ProcessExternalBridgeInboundUpdateParams) {
+  if (!verifyExternalBridgeAuthorization(params.authorizationHeader, params.expectedToken)) {
+    return { success: false as const, status: 401, error: 'Unauthorized external support update' }
+  }
+
+  const parsed = inboundUpdateSchema.safeParse(params.body)
+  if (!parsed.success) {
+    return { success: false as const, status: 400, error: 'Invalid external support update' }
+  }
+
+  const inboundUpdate = await params.persistInboundUpdate({
+    ticketId: parsed.data.ticketId,
+    actorUsuarioId: params.authorUsuarioId,
+    action: 'external.update.received',
+    targetType: 'support_external_update',
+    idempotencyKey: parsed.data.idempotencyKey,
+    body: sanitizeExternalBridgeMessage(parsed.data.message),
+    isInternal: false,
+  })
+
+  if (inboundUpdate.duplicate) {
+    return { success: true as const, duplicate: true, eventId: inboundUpdate.eventId }
+  }
+
+  return { success: true as const, duplicate: false, messageId: inboundUpdate.messageId, eventId: inboundUpdate.eventId }
+}
+
+export async function supportExternalInboundRoute(request: Request): Promise<Response> {
+  const expectedToken = process.env.SUPPORT_EXTERNAL_BRIDGE_TOKEN
+  const authorUsuarioId = process.env.SUPPORT_EXTERNAL_BRIDGE_AUTHOR_USUARIO_ID
+
+  if (!expectedToken || !authorUsuarioId) {
+    return jsonResponse({ error: 'External support bridge is not configured' }, 503)
+  }
+
+  if (!verifyExternalBridgeAuthorization(request.headers.get('authorization'), expectedToken)) {
+    return jsonResponse({ error: 'Unauthorized external support update' }, 401)
+  }
+
+  const body = await readJson(request)
+  if (!body.success) {
+    return jsonResponse({ error: 'Malformed external support update' }, 400)
+  }
+
+  const supabase = createSupabaseAdminClient()
+  const result = await processExternalBridgeInboundUpdate({
+    authorizationHeader: request.headers.get('authorization'),
+    expectedToken,
+    authorUsuarioId,
+    body: body.data,
+    persistInboundUpdate: (input) => recordSupportExternalInboundUpdate(supabase, input),
+  })
+
+  if (!result.success) {
+    return jsonResponse({ error: result.error }, result.status)
+  }
+
+  return jsonResponse(result)
+}
+
+async function readJson(request: Request) {
+  try {
+    return { success: true as const, data: await request.json() }
+  } catch {
+    return { success: false as const }
+  }
+}
+
+async function recordSupportExternalInboundUpdate(
+  supabase: ReturnType<typeof createSupabaseAdminClient>,
+  input: InsertAuditEventInput
+): Promise<PersistInboundUpdateResult> {
+  const { data, error } = await supabase
+    .rpc('record_support_external_inbound_update', {
+      p_ticket_id: input.ticketId,
+      p_author_usuario_id: input.actorUsuarioId,
+      p_message_body: input.body,
+      p_idempotency_key: input.idempotencyKey,
+    })
+
+  if (error || !data) throw new Error('External support update persistence failed')
+
+  const row = Array.isArray(data) ? data[0] : data
+  if (!row?.event_id) throw new Error('External support update persistence failed')
+
+  return {
+    duplicate: Boolean(row.duplicate),
+    eventId: row.event_id,
+    ...(row.message_id ? { messageId: row.message_id } : {}),
+  }
+}
+
+function jsonResponse(body: unknown, status = 200): Response {
+  return Response.json(body, { status })
+}

--- a/lib/support/inngest-route.ts
+++ b/lib/support/inngest-route.ts
@@ -1,0 +1,122 @@
+import { timingSafeEqual } from 'crypto'
+
+import { createSupabaseAdminClient } from '@/lib/supabase/admin'
+import {
+  SUPPORT_INNGEST_EVENTS,
+  createSupportAttachmentFinalizedEvent,
+  createSupportExternalUpdateReceivedEvent,
+  createSupportTicketCreatedEvent,
+  createSupportTicketMessageCreatedEvent,
+  createSupportTicketStatusChangedEvent,
+  deliverSupportNotificationEvent,
+} from '@/lib/support/inngest'
+
+type SupportInngestRouteEvent = {
+  name: string
+  id?: string
+  data?: {
+    eventId?: string
+    ticketId?: string
+    messageId?: string
+    attachmentId?: string
+  }
+}
+
+const SUPPORT_EVENT_NAMES = new Set([
+  'support/ticket.created',
+  'support/ticket.message.created',
+  'support/ticket.status.changed',
+  'support/attachment.finalized',
+  'support/external.update.received',
+])
+
+export async function supportInngestRoute(request: Request): Promise<Response> {
+  const secret = process.env.SUPPORT_INNGEST_WEBHOOK_SECRET
+  if (!secret) {
+    return jsonResponse({ error: 'Support event provider secret is not configured' }, 503)
+  }
+
+  if (!verifyBearerToken(request.headers.get('authorization'), secret)) {
+    return jsonResponse({ error: 'Unauthorized support event provider request' }, 401)
+  }
+
+  const body = await readJson(request)
+  if (!body.success) {
+    return jsonResponse({ error: 'Malformed support event provider payload' }, 400)
+  }
+
+  const event = parseSupportInngestRouteEvent(body.data)
+  if (!event || !SUPPORT_EVENT_NAMES.has(event.name) || !event.data?.eventId || !event.data.ticketId) {
+    return jsonResponse({ error: 'Invalid support event provider payload' }, 400)
+  }
+
+  if (process.env.SUPABASE_URL && process.env.SUPABASE_SERVICE_ROLE_KEY) {
+    await deliverSupportNotificationEvent(toSupportNotificationEvent(event), createSupabaseAdminClient())
+  }
+
+  return jsonResponse({ accepted: true, eventId: event.data.eventId, name: event.name }, 202)
+}
+
+async function readJson(request: Request) {
+  try {
+    return { success: true as const, data: await request.json() }
+  } catch {
+    return { success: false as const }
+  }
+}
+
+function parseSupportInngestRouteEvent(value: unknown): SupportInngestRouteEvent | null {
+  if (!value || typeof value !== 'object') return null
+  if (!('name' in value) || typeof value.name !== 'string') return null
+
+  const data = 'data' in value && value.data && typeof value.data === 'object' ? value.data : null
+  return {
+    name: value.name,
+    ...('id' in value && typeof value.id === 'string' ? { id: value.id } : {}),
+    ...(data ? { data: pickIdOnlyData(data) } : {}),
+  }
+}
+
+function pickIdOnlyData(data: object) {
+  return {
+    ...('eventId' in data && typeof data.eventId === 'string' ? { eventId: data.eventId } : {}),
+    ...('ticketId' in data && typeof data.ticketId === 'string' ? { ticketId: data.ticketId } : {}),
+    ...('messageId' in data && typeof data.messageId === 'string' ? { messageId: data.messageId } : {}),
+    ...('attachmentId' in data && typeof data.attachmentId === 'string' ? { attachmentId: data.attachmentId } : {}),
+  }
+}
+
+function verifyBearerToken(authorizationHeader: string | null, expectedToken: string) {
+  if (!authorizationHeader || !expectedToken) return false
+
+  const expected = Buffer.from(`Bearer ${expectedToken}`)
+  const received = Buffer.from(authorizationHeader)
+  if (received.length !== expected.length) return false
+  return timingSafeEqual(received, expected)
+}
+
+function toSupportNotificationEvent(event: SupportInngestRouteEvent) {
+  const payload = { eventId: event.data?.eventId ?? '', ticketId: event.data?.ticketId ?? '' }
+
+  if (event.name === SUPPORT_INNGEST_EVENTS.ticketMessageCreated) {
+    return createSupportTicketMessageCreatedEvent({ ...payload, messageId: event.data?.messageId ?? '' })
+  }
+
+  if (event.name === SUPPORT_INNGEST_EVENTS.ticketStatusChanged) {
+    return createSupportTicketStatusChangedEvent(payload)
+  }
+
+  if (event.name === SUPPORT_INNGEST_EVENTS.attachmentFinalized) {
+    return createSupportAttachmentFinalizedEvent({ ...payload, attachmentId: event.data?.attachmentId ?? '' })
+  }
+
+  if (event.name === SUPPORT_INNGEST_EVENTS.externalUpdateReceived) {
+    return createSupportExternalUpdateReceivedEvent(payload)
+  }
+
+  return createSupportTicketCreatedEvent(payload)
+}
+
+function jsonResponse(body: unknown, status = 200): Response {
+  return Response.json(body, { status })
+}

--- a/lib/support/inngest.ts
+++ b/lib/support/inngest.ts
@@ -1,15 +1,11 @@
 import type { SupportEmailStatus } from '@/emails/support-ticket'
-import {
-  sendSupportTicketCreatedEmail,
-  sendSupportTicketMessageEmail,
-  sendSupportTicketStatusChangedEmail,
-} from '@/lib/email/support'
 
 export const SUPPORT_INNGEST_EVENTS = {
   ticketCreated: 'support/ticket.created',
   ticketMessageCreated: 'support/ticket.message.created',
   ticketStatusChanged: 'support/ticket.status.changed',
   attachmentFinalized: 'support/attachment.finalized',
+  externalUpdateReceived: 'support/external.update.received',
 } as const
 
 type SupportInngestEventName = typeof SUPPORT_INNGEST_EVENTS[keyof typeof SUPPORT_INNGEST_EVENTS]
@@ -32,12 +28,14 @@ type SupportTicketCreatedEvent = SupportInngestEvent<typeof SUPPORT_INNGEST_EVEN
 type SupportTicketMessageCreatedEvent = SupportInngestEvent<typeof SUPPORT_INNGEST_EVENTS.ticketMessageCreated, SupportMessageEventPayload>
 type SupportTicketStatusChangedEvent = SupportInngestEvent<typeof SUPPORT_INNGEST_EVENTS.ticketStatusChanged, SupportBaseEventPayload>
 type SupportAttachmentFinalizedEvent = SupportInngestEvent<typeof SUPPORT_INNGEST_EVENTS.attachmentFinalized, SupportAttachmentEventPayload>
+type SupportExternalUpdateReceivedEvent = SupportInngestEvent<typeof SUPPORT_INNGEST_EVENTS.externalUpdateReceived, SupportBaseEventPayload>
 
 export type SupportNotificationEvent =
   | SupportTicketCreatedEvent
   | SupportTicketMessageCreatedEvent
   | SupportTicketStatusChangedEvent
   | SupportAttachmentFinalizedEvent
+  | SupportExternalUpdateReceivedEvent
 
 export interface SupportInngestEvent<Name extends SupportInngestEventName, Payload extends SupportBaseEventPayload> {
   name: Name
@@ -52,6 +50,28 @@ interface SupportNotificationEmailData {
   ticketNumber: number
   title: string
   status: SupportEmailStatus
+}
+
+interface SupportTicketNotificationRow {
+  id: string
+  ticket_number: number
+  title: string
+  status: SupportEmailStatus
+}
+
+interface SupportCapabilityRecipientRow {
+  usuario?: {
+    id: string
+    nombre: string | null
+    apellido: string | null
+    email: string | null
+  } | null
+}
+
+interface SupportInngestDispatchOptions {
+  endpoint?: string
+  secret?: string
+  fetch?: typeof fetch
 }
 
 interface SkippedSupportNotificationEmailResult {
@@ -82,14 +102,56 @@ export function createSupportAttachmentFinalizedEvent(payload: SupportAttachment
   })
 }
 
+export function createSupportExternalUpdateReceivedEvent(payload: SupportBaseEventPayload): SupportExternalUpdateReceivedEvent {
+  return createSupportEvent(SUPPORT_INNGEST_EVENTS.externalUpdateReceived, toBasePayload(payload))
+}
+
 export function createSupportEmailIdempotencyKey(eventId: string, recipientEmail: string) {
   return `email:${eventId}:${recipientEmail.trim().toLowerCase()}`
+}
+
+export async function dispatchSupportInngestEvent(
+  event: SupportNotificationEvent,
+  options: SupportInngestDispatchOptions = {}
+) {
+  const endpoint = options.endpoint ?? process.env.SUPPORT_INNGEST_EVENT_URL
+  const secret = options.secret ?? process.env.SUPPORT_INNGEST_WEBHOOK_SECRET
+  const fetchFn = options.fetch ?? fetch
+
+  if (!endpoint || !secret) {
+    return { success: true as const, skipped: true as const, reason: 'Support event provider not configured' }
+  }
+
+  const response = await fetchFn(endpoint, {
+    method: 'POST',
+    headers: { authorization: `Bearer ${secret}`, 'content-type': 'application/json' },
+    body: JSON.stringify(event),
+  })
+
+  if (!response.ok) return { success: false as const, status: response.status }
+  return { success: true as const, status: response.status }
+}
+
+export async function deliverSupportNotificationEvent(
+  event: SupportNotificationEvent,
+  supabase: { from: (table: string) => unknown }
+) {
+  const ticket = await loadSupportTicketNotificationData(supabase, event.data.ticketId)
+  if (!ticket) return []
+
+  const recipients = await loadSupportStaffRecipients(supabase, ticket)
+  return sendSupportNotificationEmails(event, recipients)
 }
 
 export async function sendSupportNotificationEmail(
   event: SupportNotificationEvent,
   emailData: SupportNotificationEmailData
 ) {
+  const {
+    sendSupportTicketCreatedEmail,
+    sendSupportTicketMessageEmail,
+    sendSupportTicketStatusChangedEmail,
+  } = await import('@/lib/email/support')
   const idempotencyKey = createSupportEmailIdempotencyKey(event.data.eventId, emailData.recipientEmail)
   const params = { ...emailData, idempotencyKey }
 
@@ -131,6 +193,56 @@ export async function sendSupportNotificationEmails(
   }
 
   return results
+}
+
+async function loadSupportTicketNotificationData(
+  supabase: { from: (table: string) => unknown },
+  ticketId: string
+): Promise<SupportTicketNotificationRow | null> {
+  const query = supabase.from('support_tickets') as {
+    select: (columns: string) => { eq: (column: string, value: string) => { single: () => Promise<{ data: SupportTicketNotificationRow | null; error: unknown }> } }
+  }
+  const { data, error } = await query.select('id,ticket_number,title,status').eq('id', ticketId).single()
+  if (error || !data) return null
+  return data
+}
+
+async function loadSupportStaffRecipients(
+  supabase: { from: (table: string) => unknown },
+  ticket: SupportTicketNotificationRow
+): Promise<SupportNotificationEmailData[]> {
+  const query = supabase.from('support_user_capabilities') as {
+    select: (columns: string) => { is: (column: string, value: null) => Promise<{ data: SupportCapabilityRecipientRow[] | null; error: unknown }> }
+  }
+  const { data, error } = await query
+    .select('usuario:usuarios!support_user_capabilities_usuario_id_fkey(id,nombre,apellido,email)')
+    .is('revoked_at', null)
+
+  if (error || !data) return []
+
+  const seen = new Set<string>()
+  const recipients: SupportNotificationEmailData[] = []
+
+  for (const row of data) {
+    const usuario = row.usuario
+    const email = usuario?.email?.trim()
+    if (!usuario || !email) continue
+
+    const key = email.toLowerCase()
+    if (seen.has(key)) continue
+
+    seen.add(key)
+    recipients.push({
+      recipientEmail: email,
+      recipientName: [usuario.nombre, usuario.apellido].filter(Boolean).join(' ') || undefined,
+      ticketId: ticket.id,
+      ticketNumber: ticket.ticket_number,
+      title: ticket.title,
+      status: ticket.status,
+    })
+  }
+
+  return recipients
 }
 
 function createSupportEvent<Name extends SupportInngestEventName, Payload extends SupportBaseEventPayload>(

--- a/lib/support/r2-routes.ts
+++ b/lib/support/r2-routes.ts
@@ -14,26 +14,40 @@ import {
 } from './r2'
 
 type RouteResult = { status: number; body: Record<string, unknown> }
-type ExistingAttachment = { kind: string; byte_size: number; status: string }
+type ExistingAttachment = { id?: string; kind: string; byte_size: number; status: string }
 type Attachment = ExistingAttachment & { id: string; ticket_id: string; uploaded_by_usuario_id: string; bucket: string; object_key: string; content_type: string }
 type Context = { authUserId: string; actorUsuarioId: string; now: Date; env?: Record<string, string | undefined> }
 
-export async function createAttachmentIntentResponse(input: Context & { body: { ticketId: string; files: unknown[] }; existingAttachments: ExistingAttachment[]; insertAttachment: (row: Record<string, unknown>) => Promise<void> }): Promise<RouteResult> {
+export async function createAttachmentIntentResponse(input: Context & { body: { ticketId: string; files: unknown[]; replaceAttachmentId?: string }; existingAttachments: ExistingAttachment[]; insertAttachment: (row: Record<string, unknown>) => Promise<void>; markRejected?: (id: string, reason: string) => Promise<boolean> }): Promise<RouteResult> {
   try {
     const files = input.body.files.map((file) => validateSupportAttachmentIntent(file as never))
-    enforceSupportAttachmentBatch(files, input.existingAttachments)
+    const replacedAttachment = findRetryReplacement(input.existingAttachments, input.body.replaceAttachmentId)
+    const retainedAttachments = replacedAttachment
+      ? input.existingAttachments.filter((attachment) => attachment.id !== replacedAttachment.id)
+      : input.existingAttachments
+    enforceSupportAttachmentBatch(files, retainedAttachments)
+    if (replacedAttachment?.id) {
+      if (!input.markRejected) throw new Error('Retry replacement requires metadata rejection')
+      const replacementStillEligible = await input.markRejected(replacedAttachment.id, 'replaced_by_retry')
+      if (!replacementStillEligible) throw new Error('Attachment retry is no longer available')
+    }
     const config = getSupportR2Config(input.env)
     const attachments = []
     for (const file of files) {
       const attachmentId = createSupportAttachmentId()
       const objectKey = buildSupportAttachmentKey(input.body.ticketId, attachmentId, file.filename)
       await input.insertAttachment({ id: attachmentId, ticket_id: input.body.ticketId, uploaded_by_usuario_id: input.actorUsuarioId, kind: file.kind, status: 'pending_upload', bucket: SUPPORT_R2_BUCKET, object_key: objectKey, original_filename: file.filename, content_type: file.contentType, byte_size: file.byteSize })
-      attachments.push({ id: attachmentId, bucket: SUPPORT_R2_BUCKET, objectKey, method: 'PUT', uploadUrl: createSupportR2SignedUrl({ method: 'PUT', key: objectKey, expiresInSeconds: SUPPORT_UPLOAD_URL_TTL_SECONDS, contentType: file.contentType, config }), expiresInSeconds: SUPPORT_UPLOAD_URL_TTL_SECONDS })
+      attachments.push({ id: attachmentId, bucket: SUPPORT_R2_BUCKET, method: 'PUT', uploadUrl: createSupportR2SignedUrl({ method: 'PUT', key: objectKey, expiresInSeconds: SUPPORT_UPLOAD_URL_TTL_SECONDS, contentType: file.contentType, config }), expiresInSeconds: SUPPORT_UPLOAD_URL_TTL_SECONDS })
     }
     return { status: 200, body: { attachments } }
   } catch (error) {
     return { status: 400, body: { error: error instanceof Error ? error.message : 'Invalid attachment intent' } }
   }
+}
+
+function findRetryReplacement(existingAttachments: ExistingAttachment[], replaceAttachmentId: string | undefined) {
+  if (!replaceAttachmentId) return null
+  return existingAttachments.find((attachment) => attachment.id === replaceAttachmentId && attachment.status === 'pending_upload') ?? null
 }
 
 export async function finalizeAttachmentResponse(input: Context & { attachment: Attachment; headObject: (key: string) => Promise<{ contentType: string | null; byteSize: number }>; readObjectPrefix: (key: string) => Promise<Uint8Array>; markUploaded: (id: string) => Promise<void>; markRejected: (id: string, reason: string) => Promise<void>; deleteObject: (key: string) => Promise<void> }): Promise<RouteResult> {
@@ -61,10 +75,15 @@ export async function supportAttachmentIntentRoute(request: Request) {
   if (!context) return NextResponse.json({ error: 'Not authenticated' }, { status: 401 })
   const body = await request.json()
   const supabase = await createSupabaseServerClient()
-  const { data: existing } = await supabase.from('support_ticket_attachments').select('kind,byte_size,status').eq('ticket_id', body.ticketId)
+  const { data: existing } = await supabase.from('support_ticket_attachments').select('id,kind,byte_size,status').eq('ticket_id', body.ticketId)
+  const admin = createSupabaseAdminClient()
   const result = await createAttachmentIntentResponse({ ...context, body, existingAttachments: existing ?? [], insertAttachment: async (row) => {
     const { error } = await supabase.from('support_ticket_attachments').insert(row as never)
     if (error) throw new Error(error.message)
+  }, markRejected: async (id, reason) => {
+    const { data, error } = await admin.from('support_ticket_attachments').update({ status: 'rejected', rejection_reason: reason }).eq('id', id).eq('ticket_id', body.ticketId).eq('status', 'pending_upload').select('id').maybeSingle()
+    if (error) throw new Error(error.message)
+    return Boolean(data?.id)
   } })
   return NextResponse.json(result.body, { status: result.status })
 }
@@ -84,7 +103,19 @@ export async function supportAttachmentFinalizeRoute(request: Request) {
 export async function supportAttachmentDownloadRoute(_request: Request, attachmentId: string) {
   const { NextResponse } = await import('next/server')
   const result = await getAttachmentDownloadResult(attachmentId)
-  return NextResponse.json(result.body, { status: result.status })
+  if (result.status !== 200) return NextResponse.json(result.body, { status: result.status })
+  const downloadUrl = typeof result.body.downloadUrl === 'string' ? result.body.downloadUrl : null
+  if (!downloadUrl) return NextResponse.json({ error: 'Attachment not available' }, { status: 403 })
+  const response = await fetch(downloadUrl)
+  if (!response.ok) return NextResponse.json({ error: 'Attachment download failed' }, { status: 502 })
+  return new Response(response.body ?? await response.arrayBuffer(), {
+    status: 200,
+    headers: {
+      'content-type': response.headers.get('content-type') ?? 'application/octet-stream',
+      'content-disposition': 'attachment',
+      'cache-control': 'no-store',
+    },
+  })
 }
 
 export async function supportAttachmentDownloadHeadRoute(_request: Request, attachmentId: string) {

--- a/lib/support/sentry-privacy.ts
+++ b/lib/support/sentry-privacy.ts
@@ -18,7 +18,7 @@ const SENSITIVE_HEADER_NAMES = new Set([
 
 const SUPPORT_CONTEXT_ALLOWLIST = new Set(['sentryEventId'])
 
-const SENSITIVE_BREADCRUMB_DATA_KEY = /(?:diagnostics?|evidence|attachments?|r2|sentry|github|request|headers?|cookies?|env|query_string)/i
+const SENSITIVE_BREADCRUMB_DATA_KEY = /(?:diagnostics?|evidence|attachments?|r2|sentry|github|request|headers?|cookies?|env|query_string|signed|object[_-]?key)/i
 const ABSOLUTE_URL_PATTERN = /https?:\/\/[^\s)'"<>]+/gi
 const SUPPORT_PATH_PATTERN = /\/(?:ayuda|support)(?:\/[^\s)'"<>?#]*)?(?:\?[^\s)'"<>#]*)?(?:#[^\s)'"<>]*)?/gi
 

--- a/lib/support/support-evidence.ts
+++ b/lib/support/support-evidence.ts
@@ -14,7 +14,7 @@ const supportEvidenceSchema = z.object({
 
 export function sanitizeSupportEvidence(input: Record<string, unknown>) {
   const parsed = supportEvidenceSchema.parse(input)
-  const diagnosticsConsent = parsed.diagnosticsConsent ?? false
+  const diagnosticsConsent = parsed.diagnosticsConsent ?? true
 
   return {
     current_route: sanitizeRouteEvidence(parsed.currentRoute),

--- a/openspec/changes/archive/2026-06-11-support-ticket-production-readiness/apply-progress.md
+++ b/openspec/changes/archive/2026-06-11-support-ticket-production-readiness/apply-progress.md
@@ -1,0 +1,66 @@
+# Apply Progress: Support Ticket Production Readiness
+
+## Status
+
+- Change: `support-ticket-production-readiness`
+- Mode: Strict TDD
+- Artifact store: Hybrid
+- Current status: 17/17 original tasks complete; critical verify fixes applied; ready for re-verify.
+- Production mutation: None.
+
+## Previous Evidence Preserved
+
+Engram observation `#7330` recorded cumulative completion through PR5.3: all 17 OpenSpec tasks complete, staging migrations applied, staging RLS passed 12/12, and guarded non-production provider smoke checks passed for `inngest`, `external`, `r2`, and `resend`.
+
+The previous apply-progress did not include an auditable Strict TDD Cycle Evidence table. Per the verify report, RED-cycle and safety-net evidence for the original 17 tasks cannot be reconstructed from the current artifacts without fabricating history. Existing tests and command output prove GREEN state, but not test-before-code ordering for every original task.
+
+## Critical Fixes Applied
+
+- Added reporter ticket creation audit events and post-commit ID-only event dispatch.
+- Added reporter public message audit events.
+- Added guarded support event provider dispatch and support-staff notification delivery that fetches active support staff recipients and uses the existing Resend helpers with per-recipient idempotency.
+- Added an additive RLS/grant migration allowing authenticated reporters to append only their own reporter-created support audit events.
+- Repaired local dependency installation from the frozen lockfile so `pnpm lint` can load `eslint-plugin-security` and execute.
+
+## TDD Cycle Evidence
+
+| Task | Test File | Layer | Safety Net | RED | GREEN | TRIANGULATE | REFACTOR |
+|------|-----------|-------|------------|-----|-------|-------------|----------|
+| 1.1 Reporter form fields | `__tests__/app/support-pages.test.tsx` | Integration | Not reconstructable | Not reconstructable from current artifacts | Preserved by `pnpm test -- --runInBand` on 2026-06-11: 149/149 passing | Existing coverage present; ordering not reconstructable | Not reconstructable |
+| 1.2 Subject mapping / safe results | `__tests__/lib/actions/support.actions.test.ts` | Unit | Not reconstructable | Not reconstructable from current artifacts | Preserved by `pnpm test -- --runInBand` on 2026-06-11: 149/149 passing | Existing coverage present; ordering not reconstructable | Not reconstructable |
+| 1.3 Safe evidence / Sentry privacy | `__tests__/lib/support/sentry-privacy.test.ts`, `__tests__/lib/actions/support.actions.test.ts` | Unit | Not reconstructable | Not reconstructable from current artifacts | Preserved by `pnpm test -- --runInBand` on 2026-06-11: 149/149 passing | Existing coverage present; ordering not reconstructable | Not reconstructable |
+| 1.4 Reporter UX/evidence tests | `__tests__/app/support-pages.test.tsx`, `__tests__/lib/actions/support.actions.test.ts` | Integration/Unit | Not reconstructable | Not reconstructable from current artifacts | Preserved by `pnpm test -- --runInBand` on 2026-06-11: 149/149 passing | Existing coverage present; ordering not reconstructable | Not reconstructable |
+| 2.1 Inline upload progress/retry/finalize | `__tests__/app/support-pages.test.tsx`, `__tests__/app/support-attachments-route.test.ts` | Integration | Not reconstructable | Not reconstructable from current artifacts | Preserved by `pnpm test -- --runInBand` on 2026-06-11: 149/149 passing | Existing coverage present; ordering not reconstructable | Not reconstructable |
+| 2.2 Attachment metadata/downloads | `__tests__/app/support-pages.test.tsx`, `__tests__/app/support-attachments-route.test.ts` | Integration | Not reconstructable | Not reconstructable from current artifacts | Preserved by `pnpm test -- --runInBand` on 2026-06-11: 149/149 passing | Existing coverage present; ordering not reconstructable | Not reconstructable |
+| 2.3 Attachment accept/reject/retry/direct access tests | `__tests__/app/support-attachments-route.test.ts` | Integration | Not reconstructable | Not reconstructable from current artifacts | Preserved by `pnpm test -- --runInBand` on 2026-06-11: 149/149 passing | Existing coverage present; ordering not reconstructable | Not reconstructable |
+| 3.1 Capability-aware navigation | `__tests__/components/support-navigation.test.tsx` | Integration | Not reconstructable | Not reconstructable from current artifacts | Preserved by `pnpm test -- --runInBand` on 2026-06-11: 149/149 passing | Existing coverage present; ordering not reconstructable | Not reconstructable |
+| 3.2 Staff console lifecycle | `__tests__/app/support-pages.test.tsx`, `__tests__/lib/actions/support.actions.test.ts` | Integration/Unit | Not reconstructable | Not reconstructable from current artifacts | Preserved by `pnpm test -- --runInBand` on 2026-06-11: 149/149 passing | Existing coverage present; ordering not reconstructable | Not reconstructable |
+| 3.3 Capability admin grant/revoke | `__tests__/lib/actions/support-capabilities.actions.test.ts` | Unit | Not reconstructable | Not reconstructable from current artifacts | Preserved by `pnpm test -- --runInBand` on 2026-06-11: 149/149 passing | Existing coverage present; ordering not reconstructable | Not reconstructable |
+| 3.4 Staff/capability tests | `__tests__/components/support-navigation.test.tsx`, `__tests__/lib/actions/support-capabilities.actions.test.ts` | Integration/Unit | Not reconstructable | Not reconstructable from current artifacts | Preserved by `pnpm test -- --runInBand` on 2026-06-11: 149/149 passing | Existing coverage present; ordering not reconstructable | Not reconstructable |
+| 4.1 Inngest/Resend notifications | `__tests__/lib/support/inngest.test.ts`, `__tests__/app/support-inngest-route.test.ts`, `__tests__/lib/actions/support.actions.test.ts` | Unit/Route | Baseline before fix: focused tests produced RED failures for missing `dispatchSupportInngestEvent`, missing `deliverSupportNotificationEvent`, and no reporter event insert/dispatch | RED captured 2026-06-11: `dispatchSupportInngestEvent is not a function`, `deliverSupportNotificationEvent is not a function`, and `eventInsert` not called | GREEN captured 2026-06-11: focused 35/35 passing; full `pnpm test -- --runInBand` 149/149 passing | Added disabled-provider and configured-provider dispatch cases; added duplicate/no-email staff recipient case; added reporter audit/dispatch case | Dynamic email import prevents route import from loading Resend provider during tests; focused tests remained green |
+| 4.2 External bridge | `__tests__/lib/support/external-bridge.test.ts`, `__tests__/app/support-external-route.test.ts` | Unit/Route | Not reconstructable | Not reconstructable from current artifacts | Preserved by `pnpm test -- --runInBand` on 2026-06-11: 149/149 passing | Existing coverage present; ordering not reconstructable | Not reconstructable |
+| 4.3 Notification/audit/duplicate/GitHub boundary tests | `__tests__/lib/support/inngest.test.ts`, `__tests__/lib/actions/support.actions.test.ts`, `__tests__/docs/support-operations.test.ts` | Unit/Docs | Baseline before fix: existing helper tests passed but new required behavior failed | RED captured 2026-06-11 for reporter audit events and support-staff delivery | GREEN captured 2026-06-11: focused 35/35 passing; full `pnpm test -- --runInBand` 149/149 passing | Added one notification per unique active support staff recipient and no sensitive payload assertions | Provider email import delayed; tests remained green |
+| 5.1 Additive support migrations/types | `__tests__/supabase/support-ticket-system-migration.test.ts`, `pnpm lint:migrations` | Static/DB lint | Baseline before fix: migration lint passed with legacy warnings | RED not applicable to previous migrations; new reporter audit policy added after behavior tests failed | GREEN captured 2026-06-11: `pnpm lint:migrations` checked 159 files, 0 errors, 183 warnings, 121 info | New migration restricts insert to reporter-owned ticket events and specific reporter actions | No refactor needed |
+| 5.2 Support operations docs | `__tests__/docs/support-operations.test.ts` | Docs static | Not reconstructable | Not reconstructable from current artifacts | Preserved by `pnpm test -- --runInBand` on 2026-06-11: 149/149 passing | Existing coverage present; ordering not reconstructable | Not reconstructable |
+| 5.3 Verification commands/smoke | Command evidence | Command | Prior evidence from Engram `#7330`; current local rerun below | Not reconstructable for prior smoke cycle | Current GREEN: focused tests, full Jest, typecheck, migration lint, lint all executed | Command coverage covers fixed paths and full suite | Local dependency reinstall made lint executable |
+
+## Current Verification
+
+| Command | Result | Notes |
+|---------|--------|-------|
+| `pnpm exec jest __tests__/lib/actions/support.actions.test.ts --runInBand` | Passed | 22/22 |
+| `pnpm exec jest __tests__/lib/support/inngest.test.ts --runInBand` | Passed | 9/9 |
+| `pnpm exec jest __tests__/app/support-inngest-route.test.ts --runInBand` | Passed | 4/4 |
+| `pnpm exec jest __tests__/lib/support/inngest.test.ts __tests__/lib/actions/support.actions.test.ts __tests__/app/support-inngest-route.test.ts --runInBand` | Passed | 35/35 |
+| `pnpm test -- --runInBand` | Passed | 19 suites, 149 tests; existing React `act(...)` warnings remain in support page tests |
+| `pnpm exec tsc --noEmit` | Passed | No output |
+| `pnpm lint:migrations` | Passed with warnings | 159 files checked, 0 errors, 183 warnings, 121 info; warnings are legacy/existing |
+| `CI=true pnpm install --frozen-lockfile` | Passed | Recreated local `node_modules` from lockfile and installed `eslint-plugin-security` |
+| `pnpm lint` | Passed with warnings | 0 errors, 453 warnings; lint now executes instead of failing on missing plugin |
+
+## Remaining Risks
+
+- Historical Strict TDD RED evidence for the original 17 completed tasks remains unavailable and is explicitly not reconstructed.
+- No production provider call or production DB mutation was run.
+- New migration is additive and locally linted, but not applied to staging in this fix pass.
+- Existing lint warnings and React `act(...)` warnings remain outside this critical-fix scope.

--- a/openspec/changes/archive/2026-06-11-support-ticket-production-readiness/archive-report.md
+++ b/openspec/changes/archive/2026-06-11-support-ticket-production-readiness/archive-report.md
@@ -1,0 +1,80 @@
+# Archive Report: Support Ticket Production Readiness
+
+## Status
+
+Archived successfully with warnings inherited from verification.
+
+## Summary
+
+The `support-ticket-production-readiness` change was archived after confirming 17/17 implementation tasks were complete and the final verification verdict was `PASS WITH WARNINGS`. The support ticket delta spec was merged into the canonical support ticket system spec, preserving the existing requirements while applying 7 modifications and appending 4 new requirements.
+
+## Gates Checked
+
+| Gate | Result | Evidence |
+|------|--------|----------|
+| Task completion | Passed | `tasks.md` has 17/17 implementation tasks checked and no unchecked implementation task rows. |
+| Critical verification issues | Passed | `verify-report.md` lists `Severe: None` and final verdict `PASS WITH WARNINGS`. |
+| OpenSpec sync | Passed | `openspec/specs/support-ticket-system/spec.md` updated from the delta spec. |
+| Archive move | Passed | Change folder moved to `openspec/changes/archive/2026-06-11-support-ticket-production-readiness/`. |
+| Active change cleanup | Passed | `openspec/changes/support-ticket-production-readiness/` no longer exists. |
+| Production safety | Passed | No provider or database mutation was performed during archive. |
+
+## Specs Synced
+
+| Domain | Action | Details |
+|--------|--------|---------|
+| `support-ticket-system` | Updated | 4 requirements added, 7 requirements modified, 0 requirements removed. |
+
+### Added Requirements
+
+- Authenticated Support Layout and Navigation
+- Admin Support Capability Management
+- External Escalation Bridge
+- Production Rollout and Release Gates
+
+### Modified Requirements
+
+- Authenticated Ticket Submission
+- Secure R2 Attachment Handling
+- Support Capability Authorization
+- Staff Console, Search, and Lifecycle
+- Privacy-Safe Evidence Capture
+- Notifications and Audit Events
+- GitHub Sync Deferred Boundary
+
+## Archive Contents
+
+- `proposal.md`
+- `specs/support-ticket-system/spec.md`
+- `design.md`
+- `tasks.md`
+- `apply-progress.md`
+- `verify-report.md`
+- `exploration.md`
+- `archive-report.md`
+
+## Engram Traceability
+
+| Artifact | Observation |
+|----------|-------------|
+| Proposal | `#7286` |
+| Spec | `#7300` |
+| Design | `#7313` |
+| Tasks | `#7318` |
+| Apply progress | `#7330` |
+| Verify report | `#7593` |
+| Archive report | This report, topic `sdd/support-ticket-production-readiness/archive-report` |
+
+## Warnings Carried Forward
+
+- Historical Strict TDD RED/safety-net ordering remains unavailable for older task rows; recent-fix RED/GREEN evidence is recorded.
+- Outbound external escalation live provider dispatch remains optional/future wiring; inbound bridge behavior is implemented and smoke-tested.
+- Migration lint and app lint passed with warnings; React support page tests still emit non-fatal `act(...)` warnings.
+
+## Source of Truth
+
+The canonical spec now lives at `openspec/specs/support-ticket-system/spec.md` and reflects the archived production-readiness behavior.
+
+## Next Recommended
+
+None for this SDD cycle. Future work should address optional outbound escalation sender wiring and non-critical lint/React warning cleanup as separate changes.

--- a/openspec/changes/archive/2026-06-11-support-ticket-production-readiness/design.md
+++ b/openspec/changes/archive/2026-06-11-support-ticket-production-readiness/design.md
@@ -1,0 +1,62 @@
+# Design: Support Ticket Production Readiness
+
+## Technical Approach
+
+Harden the existing support MVP instead of replacing it. Supabase remains authoritative; R2 stores private blobs; Next.js App Router pages/actions own UX and authorization; live providers stay gated until smoke and release checks pass. The design follows the current `ContenedorDashboard`/server-action patterns while closing production gaps called out by the delta spec: simple reporter UX, inline attachments, staff lifecycle controls, capability administration, live ID-only notifications, safe external bridge, and rollout gates.
+
+## Architecture Decisions
+
+| Option | Tradeoff | Decision |
+|---|---|---|
+| Keep Supabase as source of truth | Requires production migration reconciliation before exposure | Use existing `support_*` tables/RLS/RPCs; add only additive reviewed migrations. |
+| Reuse existing R2 helpers | UI work remains, but storage rules are already tested | Wire `lib/support/r2*.ts` and `app/api/support/attachments/**` into reporter/detail UI; no public URLs or base64. |
+| Capability tags over new roles | Needs admin UI for grants/revokes | Keep `support.view/reply/manage` in `support_user_capabilities`; add bounded admin configuration and audit events. |
+| Live Inngest later than local helpers | Adds provider slice, avoids hidden side effects | Add real Inngest client/route/functions with ID-only events after DB commit and Resend idempotency. |
+| Config-gated bridge | Less built-in automation | No GitHub sync; external webhook/email/event bridge must sanitize, authenticate, audit, and dedupe. |
+| Chained implementation | More coordination | Required: scope is high and exceeds the 400-line review budget. |
+
+## Data Flow
+
+Reporter form -> `createSupportTicket` -> Supabase ticket/event -> Inngest event -> Resend to support staff.
+Attachments: create ticket -> intent route -> signed R2 PUT -> finalize route -> metadata visible/downloadable only after auth.
+Staff: `/ayuda/admin` -> capability check -> RPC mutation -> audit event -> revalidate/detail refresh.
+External bridge: staff-approved escalation -> sanitized outbound -> authenticated inbound update -> idempotent message/event.
+
+## File Changes
+
+| File | Action | Description |
+|------|--------|-------------|
+| `app/(auth)/ayuda/reportar/page.tsx` | Modify | Replace technical fields with subject/description/category and client-side automatic safe diagnostics plus inline upload progress/retry/finalize. |
+| `app/(auth)/ayuda/tickets/[id]/page.tsx` | Modify | Show authorized attachments, staff controls, replies, and safe evidence without object keys/signed URLs. |
+| `app/(auth)/ayuda/admin/page.tsx` | Modify | Add assignment/status controls and staff detail actions gated by capabilities. |
+| `components/ui/sidebar-moderna.tsx`, `components/ui/header-movil.tsx`, `components/ui/menu-inferior-movil.tsx`, `components/ui/desktop-header.tsx` | Modify | Preserve `/ayuda` links and add capability-aware support admin entry. |
+| `app/(auth)/configuracion/**`, `lib/actions/support-capabilities.actions.ts` | Create/Modify | Admin grant/revoke UI for support capabilities with audit and allowlist validation. |
+| `lib/actions/support.actions.ts` | Modify | Use `subject` mapping, emit post-commit support events, return safe action results. |
+| `lib/support/support-evidence.ts`, `lib/support/sentry-privacy.ts`, Sentry config files | Modify | Move from user-typed diagnostics to allowlisted automatic evidence and scrubber verification. |
+| `lib/support/inngest.ts`, `app/api/inngest/route.ts`, `emails/support-ticket.tsx`, `lib/email/support.ts` | Modify/Create | Live Inngest/Resend path for support staff notifications; payloads remain IDs only. |
+| `lib/support/external-bridge.ts`, `app/api/support/external/**` | Create | Sanitized outbound and authenticated inbound bridge with idempotency. |
+| `supabase/migrations/*support*.sql`, `lib/supabase/database.types.ts`, `docs/support-operations.md` | Modify/Add | Additive reconciliation, capability audit support, generated types, release gates. |
+
+## Interfaces / Contracts
+
+- Reporter input: `subject`, `description`, `category`, `attachments[]`; keep server DB `title` until an additive rename is reviewed.
+- Support events: `support/ticket.created`, `support/ticket.message.created`, `support/ticket.status.changed`, `support/attachment.finalized`, `support/external.update.received`; data contains IDs only.
+- Capability actions accept only `support.view`, `support.reply`, `support.manage` and record actor, target, capability, action.
+- Bridge inbound requires authentication plus idempotency key; stores sanitized message once.
+
+## Testing Strategy
+
+| Layer | What to Test | Approach |
+|-------|-------------|----------|
+| Unit | evidence scrubbers, capability allowlist, event builders, bridge sanitizer | Jest with typed fixtures; no `any`. |
+| Integration | server actions, R2 intent/finalize/download, Inngest/Resend mocks, admin grant/revoke | Existing Jest route/action tests plus provider mocks. |
+| DB/RLS | ownership, support capability gates, audited RPCs, additive migrations | `pnpm lint:migrations`, `pnpm test:rls`, migration contract tests. |
+| Smoke | non-production R2, Resend/Inngest, Sentry privacy, release gates | Manual/automated runbook checks without printing secrets, URLs, or object keys. |
+
+## Migration / Rollout
+
+Roll out in chained slices: UX/evidence, attachments/R2 smoke, staff/navigation, capability admin, Inngest/Resend, external bridge, Supabase reconciliation, release governance. Production stays degraded until DB/provider/env/privacy/RLS/smoke/rollback gates pass. No destructive production migration or data deletion; rollback hides links and disables side effects while preserving records.
+
+## Open Questions
+
+- [ ] Final retention duration and stale pending-upload cleanup cadence remain unresolved but are not required for initial readiness unless policy demands deletion.

--- a/openspec/changes/archive/2026-06-11-support-ticket-production-readiness/exploration.md
+++ b/openspec/changes/archive/2026-06-11-support-ticket-production-readiness/exploration.md
@@ -1,0 +1,120 @@
+## Exploration: support-ticket-production-readiness
+
+### Current State
+
+The archived `support-ticket-system` change delivered a local/staging-verified MVP: support tables/RLS, reporter ticket pages, staff queue, R2 signing/finalization/download routes, support email templates, Inngest-shaped event helpers, Sentry privacy scrubbers, and a documented GitHub sync boundary. The canonical spec still describes a complete support domain, but archive verification carried forward warnings: live R2 upload was not proven, assignment/status UI controls were not manually available, live Inngest/Resend provider execution was intentionally not run, and production rollout remained a reviewed manual operation.
+
+Current implementation evidence:
+- `app/(auth)/ayuda/reportar/page.tsx` asks non-technical users to type `Ruta`, `Viewport`, `Navegador`, `Sistema operativo`, and `ID de evento de Sentry`; it also states attachments are uploaded after ticket creation, so the create flow is not a simple inline user flow.
+- `lib/support/support-evidence.ts` sanitizes allowlisted evidence, but collection is form-field driven rather than automatic behind consent.
+- `app/api/support/attachments/**` and `lib/support/r2*.ts` implement private R2 intent/finalize/download helpers, but `/ayuda/reportar` and ticket detail do not expose inline attachment upload/finalize UX.
+- `lib/actions/support.actions.ts` exports staff reply, assignment, and status actions, but current app usage only calls reporter create/reply; `app/(auth)/ayuda/admin/page.tsx` is a queue/filter list without assignment/status controls.
+- `lib/support/inngest.ts` defines ID-only event contracts and email dispatch helpers, but `package.json` has no `inngest` dependency, no `/api/inngest` route, and support actions do not emit live events.
+- `docs/support-operations.md` documents provider and production rollout checks, but production Supabase was previously found missing support migrations/tables while the app had already been deployed.
+
+### Affected Areas
+
+- `app/(auth)/ayuda/reportar/page.tsx` — simplify reporter UX, auto-capture diagnostics behind consent, and add inline attachments before/around submit.
+- `app/(auth)/ayuda/tickets/[id]/page.tsx` — show attachments, staff controls when authorized, and safe evidence presentation.
+- `app/(auth)/ayuda/admin/page.tsx` — add assignment/status management and staff-only lifecycle operations.
+- `components/ui/sidebar-moderna.tsx`, `components/ui/header-movil.tsx`, `components/ui/menu-inferior-movil.tsx`, `components/ui/desktop-header.tsx`, `app/(auth)/layout.tsx` — align support navigation with normal authenticated layout/sidebar and expose staff admin entry only to authorized users.
+- `lib/actions/support.actions.ts` — emit post-commit events, preserve audit semantics, and expose user-safe action outcomes.
+- `lib/support/support-evidence.ts`, `lib/support/sentry-privacy.ts`, `instrumentation-client.ts`, `sentry.server.config.ts`, `sentry.edge.config.ts` — move from typed diagnostics to safe automatic evidence collection and privacy verification.
+- `lib/support/r2.ts`, `lib/support/r2-routes.ts`, `app/api/support/attachments/**` — connect existing R2 primitives to create/detail UI and add controlled non-production smoke evidence.
+- `lib/support/inngest.ts`, `lib/email/support.ts`, `emails/support-ticket.tsx`, future `app/api/inngest/**` — convert local contracts into live Inngest functions with Resend delivery.
+- `supabase/migrations/*support*`, `lib/supabase/database.types.ts`, `docs/support-operations.md` — production rollout reconciliation, migration drift checks, and release gates.
+- Future GitHub integration files — only after staff-approved sanitized sync is specified.
+
+### Gap Analysis
+
+**UX**
+- The reporter form is still technical. Users should describe the problem and optionally consent to diagnostics; route, browser, OS, viewport, build version, and Sentry reference should be captured automatically where safe.
+- Attachments are not part of immediate ticket creation. The product expectation is upload/finalize in the support flow, not a separate hidden API capability.
+- Spanish UI copy exists, but accent omissions and technical labels should be reviewed with product polish before production exposure.
+
+**Staff/Admin**
+- Staff queue/search exists and backend actions/RPCs support reply, assign, and status changes.
+- UI lacks visible assignment/status controls and likely lacks a staff-specific detail surface for internal triage.
+- Staff admin navigation is not capability-aware; `/ayuda/admin` exists but authorized staff do not get a dedicated sidebar/menu entry.
+
+**R2**
+- R2 signing, object-key rules, validation, and mocked tests exist.
+- No create-form upload/finalize UX exists.
+- Live R2 behavior remains unproven; production readiness needs a controlled non-production smoke that avoids printing secrets, object keys, signed URLs, or private payloads.
+
+**Inngest/Resend**
+- Safe email templates, Resend helper usage, and Inngest-shaped event factories exist.
+- There is no live Inngest package/client, route, function registry, or action emission path.
+- Support actions currently mutate Supabase without dispatching `support/ticket.*` events, so production notifications are not live.
+
+**Sentry/Privacy/Observability**
+- Sentry scrubbers and tests exist, and replay is documented as disabled/default-masked.
+- Evidence capture remains user-typed and therefore low-quality for diagnostics while also exposing technical concepts to users.
+- Production observability still needs confirmation through configuration/static evidence and safe smoke checks, not raw payload or replay inspection.
+
+**GitHub Sync**
+- MVP correctly has no GitHub issue creation.
+- Future sync should remain out of the immediate readiness slice unless product explicitly wants it; when added, it must be staff-approved, sanitized, and downstream from Supabase, not the support source of truth.
+
+**Supabase Production Rollout**
+- Repo migrations include support schema/RPC follow-ups, but prior read-only production checks found production migrations only up to `20260609013148_scope_user_stats_by_campus` and no support tables/capabilities.
+- Production rollout must reconcile migration history before exposing app routes. Do not edit already-applied migrations; use additive migrations and explicit drift review.
+- Generated types and RLS tests need to be checked against the target environment before launch.
+
+**Release Governance**
+- The app reached `main`/deployment while production DB/provider readiness was incomplete. This is the main process failure to correct.
+- Future release must gate app exposure, DB migrations, provider variables, R2 smoke, notification smoke, Sentry privacy checks, and rollback readiness as one coordinated release checklist.
+
+### Approaches
+
+1. **Production-readiness hardening in sequenced slices** — Keep Supabase as source of truth, finish UX/admin/provider wiring, then run controlled rollout gates.
+   - Pros: Matches existing architecture; protects production data; allows chained PRs under the 400-line review budget; validates one risk boundary at a time.
+   - Cons: More orchestration and QA steps; users wait longer for the fully polished experience.
+   - Effort: High.
+
+2. **Patch only the visible UX gaps** — Simplify form, add attachments, and leave provider/production rollout for later.
+   - Pros: Fastest visible improvement; smaller short-term diff.
+   - Cons: Still not production-ready; repeats the mistake of shipping app UI ahead of DB/provider readiness.
+   - Effort: Medium.
+
+3. **Provider-first rollout before UX polish** — Apply production DB/provider wiring first, then improve UI.
+   - Pros: Resolves infrastructure drift early.
+   - Cons: Risks exposing a poor/technical user flow and staff workflow gaps; harder to validate end-to-end product acceptance.
+   - Effort: Medium.
+
+### Recommendation
+
+Proceed with approach 1. Sequence the proposal around release-safe work units:
+
+1. UX/evidence slice: simplify reporter form, implement consent-based browser diagnostics capture, preserve privacy scrubbers, and remove user-facing technical fields.
+2. R2 attachment slice: add inline upload/finalize/download UI and run one controlled non-production R2 smoke without leaking secrets, object keys, or signed URLs.
+3. Staff/admin slice: add capability-aware admin navigation plus assignment/status controls on the staff workflow.
+4. Inngest/Resend slice: add live Inngest dependency/client/route/functions and emit ID-only events after committed support actions; verify idempotent Resend delivery in non-production.
+5. Supabase production rollout slice: reconcile migration state, dry-run/review additive migrations, apply only after approval, seed/grant support capabilities intentionally, and verify RLS/types.
+6. Release governance slice: add explicit gates for app exposure, DB readiness, providers, observability, rollback, and post-release checks.
+7. Future GitHub sync slice: only after production support is stable and product approves manual sanitized engineering escalation.
+
+### Risks
+
+- Privacy leakage if automatic diagnostics include query strings, headers, cookies, localStorage, raw Sentry payloads, replay media, attachment object keys, or signed URLs.
+- Production outage or 500s if app routes assume support tables before production migrations are applied.
+- Duplicate or unsafe emails if Inngest/Resend idempotency is not persisted and workers include user text/evidence in payloads.
+- R2 object orphaning if inline upload creates pending rows without cleanup/retry semantics.
+- Staff overexposure if admin navigation or controls are not capability-gated.
+- Review overload if the next change ignores chained delivery despite the high cross-cutting scope.
+
+### Open Product Questions
+
+- What is the minimum reporter form: title plus description only, or should category/severity remain user-selectable?
+- What exact consent copy should authorize automatic diagnostics, and should consent default off?
+- Should attachments be allowed before the ticket row exists, or should the UI create the ticket first and then finalize attachments inline on the same screen?
+- Who receives support emails: reporter only, assigned staff, all `support.view`, or a configured support inbox?
+- What staff statuses/transitions are allowed, and should closing/resolving require a reply?
+- How should support capabilities be granted in production, and who is the first support staff cohort?
+- What is the production attachment/ticket retention policy and stale pending-upload cleanup cadence?
+- Should GitHub sync be manual staff approval only, and what role/capability can approve it?
+- What release gate must block Vercel/app exposure until production Supabase and providers are ready?
+
+### Ready for Proposal
+
+Yes. The proposal should be framed as production-readiness hardening and rollout governance, not a replacement for the archived MVP. The proposal must explicitly state that no production Supabase/provider mutation occurs until reviewed rollout gates pass, and it should forecast chained PRs because the combined scope is above the 400-line review budget.

--- a/openspec/changes/archive/2026-06-11-support-ticket-production-readiness/proposal.md
+++ b/openspec/changes/archive/2026-06-11-support-ticket-production-readiness/proposal.md
@@ -1,0 +1,76 @@
+# Proposal: Support Ticket Production Readiness
+
+## Intent
+
+The archived MVP is not production-ready because app UX, Supabase rollout, providers, staff operations, privacy evidence, and release gates are not coordinated. This hardens support while keeping Supabase authoritative and avoiding GitHub coupling.
+
+## Scope
+
+### In Scope
+- Replace technical fields with `subject`, `description`, `category`, and inline `attachments`.
+- Auto-capture privacy-safe diagnostics by default; never collect cookies, passwords, localStorage, raw payloads, signed URLs, object keys, or sensitive content.
+- Keep `/ayuda` in the authenticated desktop layout and mobile menu.
+- Add staff admin entry, assignment/status controls, and admin configuration for granting/revoking `support.view`, `support.reply`, and `support.manage` to admin/staff users.
+- Wire non-production Inngest/Resend notifications to support staff with ID-only events.
+- Add external escalation via webhook/email/event plus safe inbound updates/messages.
+- Define production Supabase reconciliation, additive reviewed migrations, non-destructive rollout steps, and release gates for real production data.
+
+### Out of Scope
+- Built-in GitHub Issues sync.
+- Retention automation unless required for readiness.
+- Advanced SLA dashboards/escalations.
+
+## Capabilities
+
+### New Capabilities
+- None.
+
+### Modified Capabilities
+- `support-ticket-system`: production-ready UX, attachments, navigation, capability administration, lifecycle controls, live notifications, external escalation, and rollout gates.
+
+## Approach
+
+Use chained slices to protect the 400-line budget: UX/evidence, attachments/R2 smoke, staff controls/navigation, admin capability configuration, Inngest/Resend, external bridge, Supabase reconciliation, and release governance. Each slice must be reviewable, reversible, and verified before exposure. Capability provisioning must be available through admin configuration, not SQL-only grants.
+
+## Affected Areas
+
+| Area | Impact | Description |
+|------|--------|-------------|
+| `app/(auth)/ayuda/**` | Modified | UX, attachments, staff controls, capability configuration, layout. |
+| `components/ui/*` | Modified | `/ayuda` and admin navigation. |
+| `lib/actions/support.actions.ts` | Modified | Events and lifecycle. |
+| `lib/support/**`, `app/api/support/**` | Modified/New | Diagnostics, R2, Inngest, bridge. |
+| `supabase/migrations/**`, `lib/supabase/database.types.ts` | Modified | Additive RLS/types reconciliation; no destructive production changes. |
+| `docs/support-operations.md` | Modified | Safe rollout, release gates, rollback. |
+
+## Risks
+
+| Risk | Likelihood | Mitigation |
+|------|------------|------------|
+| Privacy leakage | Med | Allowlist diagnostics; test scrubbers. |
+| Production DB drift | High | Reconcile migrations before app exposure. |
+| Data loss in production | High | Additive reviewed migrations only; no deletion/destructive changes. |
+| Provider duplicates | Med | ID-only events, idempotency keys, smoke. |
+| Oversized review | High | Chained PR slices under budget. |
+| Unsafe bridge | Med | Signed/authenticated inbound API. |
+| SQL-only support access | Med | Admin UI/config must grant and revoke support capabilities. |
+
+## Rollback Plan
+
+Keep providers and bridge behind config gates. Roll back app slices, disable Inngest/webhook dispatch, preserve Supabase data, and only ship additive reviewed migrations. Production rollback must not delete data or apply destructive schema changes.
+
+## Dependencies
+
+- Supabase production reconciliation.
+- Reviewed non-destructive production migration plan.
+- Non-production R2, Inngest, Resend, Sentry privacy validation.
+- Admin capability configuration for support staff grants/revocation.
+
+## Success Criteria
+
+- [ ] Reporter creates tickets with non-technical fields and inline attachments.
+- [ ] Admins can grant/revoke `support.view`, `support.reply`, and `support.manage` without SQL-only provisioning.
+- [ ] Staff can reach admin tools and manage lifecycle safely according to assigned capabilities.
+- [ ] All support staff receive safe non-production notifications.
+- [ ] External escalation sends and receives safe updates without GitHub coupling.
+- [ ] Release waits for app, DB, providers, privacy, smoke, additive migration review, and rollback gates.

--- a/openspec/changes/archive/2026-06-11-support-ticket-production-readiness/specs/support-ticket-system/spec.md
+++ b/openspec/changes/archive/2026-06-11-support-ticket-production-readiness/specs/support-ticket-system/spec.md
@@ -1,131 +1,6 @@
-# Support Ticket System Specification
+# Delta for Support Ticket System
 
-## Requirements
-
-### Requirement: Authenticated Ticket Submission
-
-The system MUST provide `/ayuda` creation, history, detail, messages, and statuses `received`, `in_review`, `in_progress`, `resolved`, `closed`. Reporter creation MUST expose only `subject`, `description`, `category`, and `attachments`; technical diagnostics MUST be auto-captured by default using privacy-safe allowlists.
-
-#### Scenario: Submit ticket
-- GIVEN an authenticated user enters subject, description, category, and optional attachments
-- WHEN they submit from `/ayuda`
-- THEN a ticket is created with status `received`
-- AND privacy-safe diagnostics are attached automatically by default
-
-#### Scenario: Reject anonymous
-- GIVEN an anonymous visitor
-- WHEN they attempt to create or read a ticket
-- THEN the request is denied
-
-#### Scenario: Hide technical fields
-- GIVEN an authenticated reporter opens the creation form
-- WHEN the form renders
-- THEN route, viewport, browser, OS, Sentry id, payload, cookie, and storage fields are not user-editable visible fields
-
-### Requirement: Secure R2 Attachment Handling
-
-The system MUST keep blobs in private R2, metadata in Supabase, issue signed URLs after authorization, and enforce screenshots PNG/JPG/WebP up to 10MB each, max 5; video MP4/WebM/MOV up to 100MB, max 1; total 150MB per ticket; no base64. Creation MUST support inline upload with progress, retry, and finalize states and MUST NOT expose public permanent bucket URLs.
-
-#### Scenario: Accept attachment
-- GIVEN an authenticated reporter owns the ticket creation session
-- WHEN they upload allowed files inline
-- THEN metadata is recorded, private upload is authorized, progress is shown, and finalized files attach to the ticket
-
-#### Scenario: Reject attachment
-- GIVEN files exceed limits or fail MIME sniffing
-- WHEN intent or finalization is checked
-- THEN files are rejected and no attachment is exposed
-
-#### Scenario: Forbid direct access
-- GIVEN a private R2 object key or signed URL
-- WHEN any user bypasses authorization or views payloads
-- THEN permanent public bucket URLs, object keys, and signed URLs are not exposed
-
-#### Scenario: Retry failed upload
-- GIVEN an inline attachment upload fails before finalization
-- WHEN the reporter retries
-- THEN the upload can continue or restart without duplicating finalized attachments
-
-### Requirement: Support Capability Authorization
-
-The system MUST authorize staff through existing global admin capabilities: `support.view`, `support.reply`, and `support.manage`. Capability checks MUST gate UI visibility, server actions, and RLS-backed access.
-
-#### Scenario: Gated action
-- GIVEN a global admin has the required support capability
-- WHEN they view, reply, assign, or manage tickets
-- THEN the action succeeds within that boundary
-
-#### Scenario: Deny unauthorized
-- GIVEN a user lacks the required capability
-- WHEN they access another ticket, staff route, or staff action
-- THEN UI, server authorization, and RLS deny access
-
-### Requirement: Staff Console, Search, and Lifecycle
-
-The system MUST provide a console with filters, Postgres FTS, ticket detail, replies, assignments, and validated status transitions. Staff MUST be able to view, reply, assign, and change status from UI only according to assigned capabilities.
-
-#### Scenario: Search and filter queue
-- GIVEN support staff can view tickets
-- WHEN they search text or filter by status/category/campus/assignee
-- THEN matching authorized tickets are returned
-
-#### Scenario: Reply from UI
-- GIVEN support staff has `support.reply`
-- WHEN they submit a ticket reply from the staff UI
-- THEN the reply is saved, visible in ticket history, and audited
-
-#### Scenario: Validate status
-- GIVEN support staff has `support.manage`
-- WHEN they change ticket status or assignee from UI
-- THEN only supported lifecycle values are saved and audited
-
-### Requirement: Privacy-Safe Evidence Capture
-
-The system MUST capture only privacy-safe allowlisted diagnostics such as route path, browser family, OS family, viewport, timestamp, user id, capabilities, build version, Sentry event reference, user steps, and attachment metadata. The system MUST NOT capture raw replays, raw payloads, cookies, localStorage, passwords, signed URLs, object keys, or sensitive content.
-
-#### Scenario: Allow diagnostics
-- GIVEN a user submits a ticket with default diagnostics enabled
-- WHEN evidence is collected
-- THEN only allowlisted diagnostics and Sentry references are stored
-
-#### Scenario: Block evidence
-- GIVEN evidence contains tokens, cookies, passwords, localStorage, raw Sentry payloads, raw replay data, signed URLs, object keys, or sensitive payloads
-- WHEN the ticket is processed
-- THEN evidence is rejected or scrubbed before storage or notification
-
-### Requirement: Notifications and Audit Events
-
-The system MUST emit append-only audit events and MUST send safe, idempotent Inngest/Resend notifications to all support staff for new tickets without sensitive evidence.
-
-#### Scenario: Send safe notification
-- GIVEN a ticket is created
-- WHEN the committed event dispatches through Inngest and Resend
-- THEN each support staff recipient receives one safe notification linking to the authenticated ticket
-- AND payloads exclude evidence, attachments, raw diagnostics, and unintended PII
-
-#### Scenario: Record audit trail
-- GIVEN a relevant action occurs
-- WHEN it is committed
-- THEN an immutable event records actor, action, target, timestamp
-
-#### Scenario: Avoid duplicate notifications
-- GIVEN the notification workflow is retried
-- WHEN the same ticket event is processed again
-- THEN idempotency prevents duplicate recipient notifications
-
-### Requirement: GitHub Sync Deferred Boundary
-
-The system MUST NOT create GitHub issues or perform direct GitHub built-in sync for support tickets. Any future engineering escalation MUST flow through the external escalation bridge with sanitized, staff-approved content.
-
-#### Scenario: MVP does not sync to GitHub
-- GIVEN a ticket is submitted, triaged, or escalated
-- WHEN the support workflow completes
-- THEN no built-in GitHub issue is created
-
-#### Scenario: Future sync remains sanitized
-- GIVEN a later external workflow prepares engineering escalation
-- WHEN a payload is generated
-- THEN only sanitized summary, steps, environment, references, and internal ticket link are allowed
+## ADDED Requirements
 
 ### Requirement: Authenticated Support Layout and Navigation
 
@@ -185,3 +60,137 @@ The system MUST remain visible only in a safe degraded state until DB, provider,
 - GIVEN additive migrations are reviewed, RLS and smoke tests pass, providers are configured, and rollback is documented
 - WHEN release gates are checked
 - THEN support may be marked production ready
+
+## MODIFIED Requirements
+
+### Requirement: Authenticated Ticket Submission
+
+The system MUST provide `/ayuda` creation, history, detail, messages, and statuses `received`, `in_review`, `in_progress`, `resolved`, `closed`. Reporter creation MUST expose only `subject`, `description`, `category`, and `attachments`; technical diagnostics MUST be auto-captured by default using privacy-safe allowlists.
+(Previously: reporters could submit required ticket fields and view created tickets, without requiring the production-ready simple form contract.)
+
+#### Scenario: Submit ticket
+- GIVEN an authenticated user enters subject, description, category, and optional attachments
+- WHEN they submit from `/ayuda`
+- THEN a ticket is created with status `received`
+- AND privacy-safe diagnostics are attached automatically by default
+
+#### Scenario: Reject anonymous
+- GIVEN an anonymous visitor
+- WHEN they attempt to create or read a ticket
+- THEN the request is denied
+
+#### Scenario: Hide technical fields
+- GIVEN an authenticated reporter opens the creation form
+- WHEN the form renders
+- THEN route, viewport, browser, OS, Sentry id, payload, cookie, and storage fields are not user-editable visible fields
+
+### Requirement: Secure R2 Attachment Handling
+
+The system MUST keep blobs in private R2, metadata in Supabase, issue signed URLs after authorization, and enforce screenshots PNG/JPG/WebP up to 10MB each, max 5; video MP4/WebM/MOV up to 100MB, max 1; total 150MB per ticket; no base64. Creation MUST support inline upload with progress, retry, and finalize states and MUST NOT expose public permanent bucket URLs.
+(Previously: attachment intent/finalization existed, but inline creation progress/retry/finalize UX was not required.)
+
+#### Scenario: Accept attachment
+- GIVEN an authenticated reporter owns the ticket creation session
+- WHEN they upload allowed files inline
+- THEN metadata is recorded, private upload is authorized, progress is shown, and finalized files attach to the ticket
+
+#### Scenario: Reject attachment
+- GIVEN files exceed limits or fail MIME sniffing
+- WHEN intent or finalization is checked
+- THEN files are rejected and no attachment is exposed
+
+#### Scenario: Forbid direct access
+- GIVEN a private R2 object key or signed URL
+- WHEN any user bypasses authorization or views payloads
+- THEN permanent public bucket URLs, object keys, and signed URLs are not exposed
+
+#### Scenario: Retry failed upload
+- GIVEN an inline attachment upload fails before finalization
+- WHEN the reporter retries
+- THEN the upload can continue or restart without duplicating finalized attachments
+
+### Requirement: Support Capability Authorization
+
+The system MUST authorize staff through existing global admin capabilities: `support.view`, `support.reply`, and `support.manage`. Capability checks MUST gate UI visibility, server actions, and RLS-backed access.
+(Previously: staff authorization was required for actions, but UI visibility and capability administration were not production-readiness requirements.)
+
+#### Scenario: Gated action
+- GIVEN a global admin has the required support capability
+- WHEN they view, reply, assign, or manage tickets
+- THEN the action succeeds within that boundary
+
+#### Scenario: Deny unauthorized
+- GIVEN a user lacks the required capability
+- WHEN they access another ticket, staff route, or staff action
+- THEN UI, server authorization, and RLS deny access
+
+### Requirement: Staff Console, Search, and Lifecycle
+
+The system MUST provide a console with filters, Postgres FTS, ticket detail, replies, assignments, and validated status transitions. Staff MUST be able to view, reply, assign, and change status from UI only according to assigned capabilities.
+(Previously: backend lifecycle behavior was specified, but production-ready visible staff lifecycle controls were not explicit.)
+
+#### Scenario: Search and filter queue
+- GIVEN support staff can view tickets
+- WHEN they search text or filter by status/category/campus/assignee
+- THEN matching authorized tickets are returned
+
+#### Scenario: Reply from UI
+- GIVEN support staff has `support.reply`
+- WHEN they submit a ticket reply from the staff UI
+- THEN the reply is saved, visible in ticket history, and audited
+
+#### Scenario: Validate status
+- GIVEN support staff has `support.manage`
+- WHEN they change ticket status or assignee from UI
+- THEN only supported lifecycle values are saved and audited
+
+### Requirement: Privacy-Safe Evidence Capture
+
+The system MUST capture only privacy-safe allowlisted diagnostics such as route path, browser family, OS family, viewport, timestamp, user id, capabilities, build version, Sentry event reference, user steps, and attachment metadata. The system MUST NOT capture raw replays, raw payloads, cookies, localStorage, passwords, signed URLs, object keys, or sensitive content.
+(Previously: evidence capture allowed user steps and attachments, but automatic default diagnostics and stricter production privacy exclusions were not explicit.)
+
+#### Scenario: Allow diagnostics
+- GIVEN a user submits a ticket with default diagnostics enabled
+- WHEN evidence is collected
+- THEN only allowlisted diagnostics and Sentry references are stored
+
+#### Scenario: Block evidence
+- GIVEN evidence contains tokens, cookies, passwords, localStorage, raw Sentry payloads, raw replay data, signed URLs, object keys, or sensitive payloads
+- WHEN the ticket is processed
+- THEN evidence is rejected or scrubbed before storage or notification
+
+### Requirement: Notifications and Audit Events
+
+The system MUST emit append-only audit events and MUST send safe, idempotent Inngest/Resend notifications to all support staff for new tickets without sensitive evidence.
+(Previously: notifications were SHOULD-level and did not require live workflow delivery to all support staff.)
+
+#### Scenario: Send safe notification
+- GIVEN a ticket is created
+- WHEN the committed event dispatches through Inngest and Resend
+- THEN each support staff recipient receives one safe notification linking to the authenticated ticket
+- AND payloads exclude evidence, attachments, raw diagnostics, and unintended PII
+
+#### Scenario: Record audit trail
+- GIVEN a relevant action occurs
+- WHEN it is committed
+- THEN an immutable event records actor, action, target, timestamp
+
+#### Scenario: Avoid duplicate notifications
+- GIVEN the notification workflow is retried
+- WHEN the same ticket event is processed again
+- THEN idempotency prevents duplicate recipient notifications
+
+### Requirement: GitHub Sync Deferred Boundary
+
+The system MUST NOT create GitHub issues or perform direct GitHub built-in sync for support tickets. Any future engineering escalation MUST flow through the external escalation bridge with sanitized, staff-approved content.
+(Previously: future GitHub sync was deferred but not explicitly replaced by a flexible external bridge boundary.)
+
+#### Scenario: MVP does not sync to GitHub
+- GIVEN a ticket is submitted, triaged, or escalated
+- WHEN the support workflow completes
+- THEN no built-in GitHub issue is created
+
+#### Scenario: Future sync remains sanitized
+- GIVEN a later external workflow prepares engineering escalation
+- WHEN a payload is generated
+- THEN only sanitized summary, steps, environment, references, and internal ticket link are allowed

--- a/openspec/changes/archive/2026-06-11-support-ticket-production-readiness/tasks.md
+++ b/openspec/changes/archive/2026-06-11-support-ticket-production-readiness/tasks.md
@@ -1,0 +1,59 @@
+# Tasks: Support Ticket Production Readiness
+
+## Review Workload Forecast
+
+| Field | Value |
+|--|--|
+| Estimated changed lines | 1,400-2,200 |
+| 400-line budget risk | High |
+| Chained PRs recommended | Yes |
+| Suggested split | PR 1 UX/evidence -> PR 2 R2 -> PR 3 staff/capabilities -> PR 4 providers/bridge -> PR 5 rollout gates |
+| Delivery strategy | auto-forecast |
+| Chain strategy | feature-branch-chain |
+
+Decision needed before apply: Yes
+Chained PRs recommended: Yes
+Chain strategy: feature-branch-chain
+400-line budget risk: High
+
+### Suggested Work Units
+
+| Unit | Goal | Likely PR | Notes |
+|--|--|--|--|
+| 1 | Reporter UX + safe evidence | PR 1 | Finish with Jest scrubber/form tests. |
+| 2 | Private R2 attachments | PR 2 | Depends PR 1; verify intent/finalize/download. |
+| 3 | Staff navigation + lifecycle + capability admin | PR 3 | Depends PR 1; verify UI/server/RLS gates. |
+| 4 | Inngest/Resend + external bridge | PR 4 | Depends PR 3; mocks prove ID-only/idempotent flows. |
+| 5 | Supabase reconciliation + release gates | PR 5 | Additive migrations/types/docs; no destructive production steps. |
+
+## Phase 1: Reporter UX and Evidence
+
+- [x] 1.1 Modify `app/(auth)/ayuda/reportar/page.tsx` to show `subject`, `description`, `category`, `attachments` only.
+- [x] 1.2 Update `lib/actions/support.actions.ts` to map `subject` to current DB fields and return safe typed action results.
+- [x] 1.3 Update `lib/support/support-evidence.ts`, `lib/support/sentry-privacy.ts`, and Sentry config to collect/scrub allowlisted diagnostics only.
+- [x] 1.4 Test submit, reject anonymous, hide technical fields, allow diagnostics, and block sensitive evidence scenarios.
+
+## Phase 2: R2 Attachment Flow
+
+- [x] 2.1 Wire inline upload progress/retry/finalize in `app/(auth)/ayuda/reportar/page.tsx` using `app/api/support/attachments/**`.
+- [x] 2.2 Modify `app/(auth)/ayuda/tickets/[id]/page.tsx` to show authorized attachment metadata/downloads without keys or signed URLs.
+- [x] 2.3 Test accept, reject, retry, and forbid direct-access attachment scenarios with R2 mocks/smoke notes.
+
+## Phase 3: Staff Operations and Capabilities
+
+- [x] 3.1 Update navigation components to preserve `/ayuda` and show support admin links only for support capabilities.
+- [x] 3.2 Modify `app/(auth)/ayuda/admin/page.tsx` for search, filters, replies, assignments, and status transitions.
+- [x] 3.3 Create/modify `app/(auth)/configuracion/**` and `lib/actions/support-capabilities.actions.ts` for allowlisted grant/revoke with audit.
+- [x] 3.4 Test staff visibility, denied access, reply, status validation, capability grant, and unsupported capability rejection.
+
+## Phase 4: Providers and External Bridge
+
+- [x] 4.1 Create/modify `lib/support/inngest.ts`, `app/api/inngest/route.ts`, `emails/support-ticket.tsx`, and `lib/email/support.ts`.
+- [x] 4.2 Create `lib/support/external-bridge.ts` and `app/api/support/external/**` with sanitized outbound and authenticated idempotent inbound updates.
+- [x] 4.3 Test safe notification, audit trail, duplicate prevention, no GitHub sync, sanitized escalation, and inbound update scenarios.
+
+## Phase 5: Rollout and Release Gates
+
+- [x] 5.1 Add reviewed additive `supabase/migrations/*support*.sql` reconciliation and regenerate `lib/supabase/database.types.ts`.
+- [x] 5.2 Update `docs/support-operations.md` with DB/provider/env/RLS/privacy/smoke/rollback gates and safe degraded behavior.
+- [x] 5.3 Run `pnpm lint:migrations`, `pnpm test:rls`, relevant Jest suites, and non-production provider smoke checks.

--- a/openspec/changes/archive/2026-06-11-support-ticket-production-readiness/verify-report.md
+++ b/openspec/changes/archive/2026-06-11-support-ticket-production-readiness/verify-report.md
@@ -1,0 +1,184 @@
+## Verification Report
+
+**Change**: `support-ticket-production-readiness`  
+**Version**: N/A — OpenSpec delta  
+**Mode**: Strict TDD  
+**Artifact Store**: Hybrid — OpenSpec + Engram  
+**Verifier**: dedicated `sdd-verify` executor  
+**Final Verdict**: PASS WITH WARNINGS
+
+### Inputs Reviewed
+
+- OpenSpec proposal, spec, design, tasks, apply-progress, and prior verify report under `openspec/changes/support-ticket-production-readiness/`.
+- Engram apply-progress topic `sdd/support-ticket-production-readiness/apply-progress`, observation `#7330`.
+- Changed support implementation and tests for reporter UX, R2 attachments, staff operations, capability administration, Inngest/Resend notifications, external bridge, Sentry privacy, Supabase migrations/types, and operations docs.
+
+### Completeness
+
+| Metric | Value |
+|--------|-------|
+| Tasks total | 17 |
+| Tasks complete | 17 |
+| Tasks incomplete | 0 |
+| Apply progress | Present in OpenSpec and Engram; records all original tasks complete plus recent-fix evidence. |
+| Strict TDD evidence table | Present. Current behavior tests exist and pass; historical original RED/safety-net ordering remains unavailable and is recorded as a warning rather than fabricated. |
+
+### Build & Tests Execution
+
+| Command | Result | Evidence |
+|---------|--------|----------|
+| `pnpm exec jest __tests__/lib/actions/support.actions.test.ts __tests__/lib/support/inngest.test.ts __tests__/app/support-inngest-route.test.ts __tests__/lib/support/external-bridge.test.ts __tests__/app/support-external-route.test.ts --runInBand` | ✅ Passed | Executor run: 5 suites, 43 tests. Covers reporter audit events, ID-only dispatch, support staff notification delivery, external bridge auth/sanitization/idempotency. |
+| `pnpm exec tsc --noEmit` | ✅ Passed | Executor run completed with no output. Orchestrator evidence also passed. |
+| `pnpm lint:migrations` | ✅ Passed with warnings | Executor run: 159 files checked, 0 errors, 183 warnings, 121 info. Warnings are legacy/review items, not new hard stops. |
+| `pnpm exec jest --coverage --runInBand --runTestsByPath <support suites> ...` | ✅ Passed with warnings | Executor run: 12 suites, 101 tests, support-focused aggregate 89.6% line coverage. React emitted non-fatal `act(...)` warnings in support page tests. |
+| `pnpm support:smoke:staging` | ✅ Passed | Orchestrator run: `inngest`, `external`, `r2`, and `resend` all passed against the fresh Vercel preview. |
+| `pnpm test:rls` | ✅ Passed | Orchestrator run: 12/12 staging RLS checks. |
+| `pnpm lint` | ✅ Passed with warnings | Orchestrator run: 0 errors, 453 warnings after dependencies were reinstalled from the frozen lockfile. |
+| `pnpm test -- --runInBand` | ✅ Passed | Orchestrator run: 19 suites, 149 tests. |
+
+### TDD Compliance
+
+| Check | Result | Details |
+|-------|--------|---------|
+| TDD evidence reported | ✅ | `apply-progress.md` contains the required `TDD Cycle Evidence` table. |
+| All tasks have test files | ✅ | 17/17 task rows name existing test files or command evidence. |
+| RED confirmed | ⚠️ | Recent-fix RED evidence is recorded for notification/audit fixes. Historical RED ordering for most original completed tasks is unavailable and was not fabricated. |
+| GREEN confirmed | ✅ | Focused Jest, support coverage, full Jest, typecheck, migration lint, RLS, lint, and provider smoke evidence passed. |
+| Triangulation adequate | ✅ | 123 support-related test cases exist across Jest/Node files, plus RLS and provider smoke checks. Recent notification/audit fixes include duplicate/no-email/idempotency and ID-only payload variants. |
+| Safety net for modified files | ⚠️ | Recent-fix safety evidence is present; historical safety-net sequencing for older task rows remains unavailable. |
+
+**TDD Compliance**: PASS WITH WARNINGS — current behavior is covered and passing; historical ordering evidence remains a documented warning.
+
+---
+
+### Test Layer Distribution
+
+| Layer | Tests / Checks | Files / Runner | Tools |
+|-------|----------------|----------------|-------|
+| Unit / static contract | 80 related Jest/Node tests | support actions, capability actions, Inngest helpers, email helpers/templates, external bridge sanitizer, Sentry privacy, docs, smoke script | Jest, Node test |
+| Integration / UI / route | 43 related Jest tests | support pages, navigation, attachment routes, Inngest route, external route | Jest + Testing Library |
+| DB/RLS | 12 staging checks | `supabase/tests/run-rls-tests.mjs` | Supabase staging |
+| Provider smoke | 4 guarded checks | `scripts/support-smoke-staging.mjs` | Vercel preview, R2, Resend, app routes |
+| Browser E2E | 0 | Not present for this slice | N/A |
+
+---
+
+### Changed File Coverage
+
+Support-focused coverage command passed with **89.6%** aggregate line coverage for the explicitly collected support slice.
+
+| File / Area | Line % | Branch % | Rating |
+|-------------|--------|----------|--------|
+| `app/api/inngest/route.ts` | 100% | 100% | ✅ Excellent |
+| `app/api/support/**/route.ts` thin wrappers | 0% | 0% | ⚠️ Wrapper coverage gap; underlying helpers/routes are exercised. |
+| `components/ui/header-movil.tsx` | 93.01% | 61.84% | ✅ Lines / ⚠️ Branches |
+| `components/ui/sidebar-moderna.tsx` | 90.36% | 50.66% | ✅ Lines / ⚠️ Branches |
+| `components/ui/menu-inferior-movil.tsx` | 100% | 100% | ✅ Excellent |
+| `emails/support-ticket.tsx` | 100% | 100% | ✅ Excellent |
+| `hooks/useCurrentUser.ts` | 0% | 0% | ⚠️ Mocked in focused support run; covered indirectly by navigation integration behavior. |
+| `lib/actions/support-capabilities.actions.ts` | 96.2% | 77.27% | ✅ Lines / ⚠️ Branches |
+| `lib/actions/support.actions.ts` | 99.48% | 65.97% | ✅ Lines / ⚠️ Branches |
+| `lib/email/support.ts` | 100% | 83.33% | ✅ Excellent |
+| `lib/support/external-bridge.ts` | 95.03% | 72.41% | ✅ Lines / ⚠️ Branches |
+| `lib/support/inngest-route.ts` | 79.5% | 57.14% | ⚠️ Slightly below 80% lines in focused run; route behavior has passing tests and smoke evidence. |
+| `lib/support/inngest.ts` | 100% | 81.39% | ✅ Excellent |
+| `lib/support/r2-routes.ts` | 95.67% | 70.49% | ✅ Lines / ⚠️ Branches |
+| `lib/support/r2.ts` | 90.32% | 76.47% | ✅ Lines / ⚠️ Branches |
+| `lib/support/sentry-privacy.ts` | 92.89% | 83.67% | ✅ Excellent |
+| `lib/support/support-evidence.ts` | 100% | 70.83% | ✅ Lines / ⚠️ Branches |
+
+---
+
+### Assertion Quality
+
+**Assertion quality**: ✅ Support-related changed tests contain no tautology assertions, ghost loops, assertion-only tests, or meaningless `expect(true).toBe(true)` patterns. The one support empty-array assertion is paired with value/behavior assertions in adjacent tests; unrelated `toBeDefined()` assertions are outside the support change.
+
+---
+
+### Quality Metrics
+
+**Linter**: ✅ `pnpm lint` completed with 0 errors and warnings only.  
+**Type Checker**: ✅ `pnpm exec tsc --noEmit` passed.  
+**Migration Linter**: ✅ 0 errors; legacy warnings remain.  
+**Runtime Notes**: ⚠️ React `act(...)` warnings appeared in support page tests; test assertions still passed.
+
+### Spec Compliance Matrix
+
+| Requirement | Scenario | Runtime Evidence | Result |
+|-------------|----------|------------------|--------|
+| Authenticated Support Layout and Navigation | Reporter uses normal layout | `support-pages.test.tsx`, navigation tests | ✅ COMPLIANT |
+| Authenticated Support Layout and Navigation | Staff sees admin entry | `support-navigation.test.tsx` show/hide tests for desktop/mobile | ✅ COMPLIANT |
+| Admin Support Capability Management | Grant allowed support capability | `support-capabilities.actions.test.ts`, config page tests, migration static tests | ✅ COMPLIANT |
+| Admin Support Capability Management | Reject unsupported capability | `support-capabilities.actions.test.ts` | ✅ COMPLIANT |
+| External Escalation Bridge | Send sanitized escalation | `external-bridge.test.ts`, docs boundary; outbound sender remains a warning because the spec says the bridge MAY expose this path | ⚠️ COMPLIANT WITH WARNING |
+| External Escalation Bridge | Accept authenticated inbound update | `external-bridge.test.ts`, `support-external-route.test.ts`, staging smoke `external` | ✅ COMPLIANT |
+| Production Rollout and Release Gates | Unsafe readiness gate | `docs/support-operations.test.ts`, staging smoke guards, non-production host refusal | ✅ COMPLIANT |
+| Production Rollout and Release Gates | Approve readiness when gates pass | staging migration applied, `test:rls`, provider smokes, runbook gates | ✅ COMPLIANT |
+| Authenticated Ticket Submission | Submit ticket | `support.actions.test.ts`, `support-pages.test.tsx` | ✅ COMPLIANT |
+| Authenticated Ticket Submission | Reject anonymous | `support.actions.test.ts` | ✅ COMPLIANT |
+| Authenticated Ticket Submission | Hide technical fields | `support-pages.test.tsx` | ✅ COMPLIANT |
+| Secure R2 Attachment Handling | Accept attachment | `support-attachments-route.test.ts`, `support-pages.test.tsx`, staging R2 smoke | ✅ COMPLIANT |
+| Secure R2 Attachment Handling | Reject attachment | `support-attachments-route.test.ts` | ✅ COMPLIANT |
+| Secure R2 Attachment Handling | Forbid direct access | route/helper tests for auth, no object key/signed URL exposure, streamed downloads only after app authorization | ✅ COMPLIANT |
+| Secure R2 Attachment Handling | Retry interrupted upload | `support-pages.test.tsx`, `support-attachments-route.test.ts` | ✅ COMPLIANT |
+| Support Capability Authorization | Gated action | `support.actions.test.ts`, capability tests, migration static tests | ✅ COMPLIANT |
+| Support Capability Authorization | Deny unauthorized | UI hide tests, action denial tests, RLS/migration checks | ✅ COMPLIANT |
+| Staff Console, Search, and Lifecycle | Search and filter queue | `support.actions.test.ts`, `support-pages.test.tsx` | ✅ COMPLIANT |
+| Staff Console, Search, and Lifecycle | Reply from UI | `support-pages.test.tsx`, `support.actions.test.ts` | ✅ COMPLIANT |
+| Staff Console, Search, and Lifecycle | Validate status | `support.actions.test.ts`, staff RPC migration tests | ✅ COMPLIANT |
+| Privacy-Safe Evidence Capture | Allow diagnostics | `support.actions.test.ts`, `sentry-privacy.test.ts` | ✅ COMPLIANT |
+| Privacy-Safe Evidence Capture | Scrub sensitive evidence | `sentry-privacy.test.ts`, `support.actions.test.ts` | ✅ COMPLIANT |
+| Notifications and Audit Events | Send safe notification | `support.actions.test.ts`, `inngest.test.ts`, `support-inngest-route.test.ts`, staging `inngest`/`resend` smokes | ✅ COMPLIANT |
+| Notifications and Audit Events | Record audit trail | reporter creation/message audit tests, staff/capability/external audit RPC tests, additive reporter audit migration | ✅ COMPLIANT |
+| Notifications and Audit Events | Avoid duplicate notifications | `inngest.test.ts` idempotency/recipient dedupe tests | ✅ COMPLIANT |
+| GitHub Sync Deferred Boundary | MVP does not sync to GitHub | source search, external bridge/docs tests, no support runtime GitHub issue creation path | ✅ COMPLIANT |
+| GitHub Sync Deferred Boundary | Future sync remains sanitized | docs and sanitizer/email/event tests exclude GitHub details and sensitive evidence | ✅ COMPLIANT |
+
+**Compliance summary**: 27/27 scenarios covered by passing runtime evidence; 1 scenario carries an operational warning for optional outbound bridge sender wiring.
+
+### Correctness (Static Evidence)
+
+| Area | Status | Notes |
+|------|--------|-------|
+| Reporter UX | ✅ Implemented | `SupportTicketCreateForm` exposes subject, description, category, and attachments only; diagnostics fields are hidden and allowlisted. |
+| Reporter audit events | ✅ Implemented | `createSupportTicket` and `createSupportTicketMessage` append `support_ticket_events` after committed reporter actions. |
+| Post-commit ID-only dispatch | ✅ Implemented | `createSupportTicket` dispatches `support/ticket.created` using the audit event ID and ticket/user IDs only. |
+| Support staff notification delivery | ✅ Implemented | `deliverSupportNotificationEvent` loads active support staff recipients, deduplicates normalized emails, and uses Resend helpers with event-recipient idempotency. |
+| R2 attachments | ✅ Implemented | Private key generation, signed PUT/GET, MIME sniffing, size limits, retry metadata, and no public URL/object-key display are implemented. |
+| Staff capabilities and lifecycle | ✅ Implemented | UI visibility and server actions use `support.view`, `support.reply`, and `support.manage`; staff actions route through audited RPCs. |
+| External bridge | ✅ Implemented with warning | Inbound auth/sanitization/idempotency is implemented and smoke-tested. Outbound payload sanitization exists; live outbound provider dispatch remains optional/future wiring. |
+| Supabase rollout gates | ✅ Implemented/documented | Additive migrations, generated types, runbook, migration lint, staging RLS, and guarded provider smoke evidence exist. |
+
+### Coherence (Design)
+
+| Design Decision | Followed? | Notes |
+|-----------------|-----------|-------|
+| Supabase remains source of truth with additive migrations | ✅ Yes | Support migrations are additive/reconciliatory; verification did not mutate production. |
+| R2 private blobs, metadata in Supabase, signed URLs after auth | ✅ Yes | Helpers/routes enforce private storage and app authorization before downloads. |
+| Capability tags over new roles with admin grant/revoke | ✅ Yes | `support.view/reply/manage` are bounded, UI-gated, action-gated, and audited. |
+| Live notification side effects use ID-only events | ✅ Yes | Ticket-created event payloads are IDs only; worker route fetches ticket/recipient data server-side. |
+| Config-gated external bridge | ✅ Yes with warning | Inbound is config-gated and smoke-tested; outbound remains sanitizer/runbook only. |
+| Chained implementation / review guard | ✅ Yes | Tasks forecast high review size risk and all 17 tasks are checked complete. |
+
+### Issues Found
+
+**Severe**: None.
+
+**Warnings**
+
+1. Historical Strict TDD RED/safety-net ordering for many original task rows is unavailable; recent-fix RED/GREEN evidence is present and current tests pass.
+2. Outbound external escalation has sanitizer/runbook coverage, but live outbound provider dispatch remains optional/future wiring.
+3. Focused coverage still shows thin App Router wrappers and `hooks/useCurrentUser.ts` below the desired threshold because route helpers and hook consumers are the tested boundaries.
+4. Migration lint and app lint both pass with warnings; the warnings should be reviewed separately.
+5. React support page tests emit non-fatal `act(...)` warnings.
+6. No production DB/provider mutation was performed during verification.
+
+**Suggestions**
+
+1. Add direct thin-wrapper coverage or exclude wrappers from coverage if route helper testing remains the chosen boundary.
+2. Add an authenticated non-owner attachment route test as extra defense-in-depth around RLS-filtered metadata.
+3. When outbound escalation becomes product-required, add a staff-approved dispatch action and provider smoke.
+
+### Verdict
+
+PASS WITH WARNINGS — all tasks are complete, prior severe behavior gaps are now covered by implementation and passing runtime evidence, and the remaining items are warnings/suggestions rather than archive stoppers.

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "migrate:staging": "node scripts/apply-migrations-staging.mjs",
     "test:smoke:members": "node scripts/smoke-members-api.mjs",
     "test:smoke:audit": "node scripts/smoke-audit-members.mjs",
+    "support:smoke:staging": "node scripts/support-smoke-staging.mjs --all",
     "test:rpc:asistencia": "ts-node scripts/test-rpc-asistencia.ts",
     "test:grupos-permisos": "node scripts/test-grupos-permisos.mjs",
     "test:ciudades": "node scripts/test-ciudades.mjs",

--- a/scripts/support-smoke-staging.mjs
+++ b/scripts/support-smoke-staging.mjs
@@ -1,0 +1,418 @@
+#!/usr/bin/env node
+
+import { createHash, createHmac, randomUUID } from 'node:crypto'
+import { existsSync, readFileSync } from 'node:fs'
+import { resolve } from 'node:path'
+
+const ENV_FILE = '.env.staging.local'
+const SUPPORT_R2_BUCKET = 'global-connect-support'
+const SMOKE_PREFIX = 'support-smoke'
+const DEFAULT_TIMEOUT_MS = 30_000
+const VERCEL_PROTECTION_BYPASS_HEADER = 'x-vercel-protection-bypass'
+
+const CHECKS = new Set(['inngest', 'external', 'r2', 'resend'])
+const PRODUCTION_HOST_PATTERNS = [
+  /^connect\.yosoyglobal\.org$/i,
+  /^yosoyglobal\.org$/i,
+  /^globalconnect\.org$/i,
+]
+
+export function parseArgs(argv = process.argv.slice(2)) {
+  const selected = new Set()
+  let envFile = ENV_FILE
+
+  for (const arg of argv) {
+    if (arg === '--all') {
+      for (const check of CHECKS) selected.add(check)
+      continue
+    }
+
+    if (arg.startsWith('--only=')) {
+      selected.clear()
+      for (const value of arg.slice('--only='.length).split(',')) {
+        const check = value.trim()
+        if (!CHECKS.has(check)) throw new Error(`Unknown smoke check: ${check}`)
+        selected.add(check)
+      }
+      continue
+    }
+
+    if (arg.startsWith('--env-file=')) {
+      envFile = arg.slice('--env-file='.length)
+      continue
+    }
+
+    if (arg === '--help' || arg === '-h') {
+      return { help: true, checks: [], envFile }
+    }
+
+    throw new Error(`Unknown argument: ${arg}`)
+  }
+
+  return { help: false, checks: [...(selected.size ? selected : CHECKS)], envFile }
+}
+
+export function loadEnvFile(filePath = ENV_FILE) {
+  const absolutePath = resolve(process.cwd(), filePath)
+  if (!existsSync(absolutePath)) return []
+
+  const loaded = []
+  for (const line of readFileSync(absolutePath, 'utf8').split(/\r?\n/)) {
+    const trimmed = line.trim()
+    if (!trimmed || trimmed.startsWith('#')) continue
+    const separatorIndex = trimmed.indexOf('=')
+    if (separatorIndex === -1) continue
+    const key = trimmed.slice(0, separatorIndex).trim()
+    const value = unquoteEnvValue(trimmed.slice(separatorIndex + 1).trim())
+    if (key && process.env[key] === undefined) {
+      process.env[key] = value
+      loaded.push(key)
+    }
+  }
+  return loaded
+}
+
+export function assertStagingEnvironment(env = process.env) {
+  if (env.RLS_ENV !== 'staging') {
+    throw new Error('Refusing smoke run: RLS_ENV must be exactly "staging".')
+  }
+
+  assertNoPublicSecrets(env)
+}
+
+export function assertSafeBaseUrl(value) {
+  if (!value) throw new Error('SUPPORT_SMOKE_BASE_URL is required for route smoke checks.')
+
+  const url = new URL(value)
+  if (url.protocol !== 'http:' && url.protocol !== 'https:') {
+    throw new Error('SUPPORT_SMOKE_BASE_URL must use http or https.')
+  }
+
+  if (isObviousProductionHost(url.hostname)) {
+    throw new Error(`Refusing production-looking smoke base URL: ${url.hostname}`)
+  }
+
+  return url.origin
+}
+
+export function isObviousProductionHost(hostname) {
+  return PRODUCTION_HOST_PATTERNS.some((pattern) => pattern.test(hostname))
+}
+
+export function redact(value) {
+  if (!value) return '[missing]'
+  if (value.length <= 8) return '[redacted]'
+  return `${value.slice(0, 4)}...[redacted]...${value.slice(-4)}`
+}
+
+export function withRouteProtectionBypass(url, headers = {}, env = process.env) {
+  const secret = env.VERCEL_AUTOMATION_BYPASS_SECRET
+  if (!secret || !env.SUPPORT_SMOKE_BASE_URL) return headers
+
+  const routeOrigin = new URL(assertSafeBaseUrl(env.SUPPORT_SMOKE_BASE_URL)).origin
+  const requestOrigin = new URL(url).origin
+  if (requestOrigin !== routeOrigin) return headers
+
+  return { ...headers, [VERCEL_PROTECTION_BYPASS_HEADER]: secret }
+}
+
+async function main() {
+  const args = parseArgs()
+  if (args.help) {
+    printHelp()
+    return
+  }
+
+  const loadedKeys = loadEnvFile(args.envFile)
+  assertStagingEnvironment()
+
+  const smokeId = `smoke-${new Date().toISOString().replace(/[^0-9]/g, '').slice(0, 14)}-${randomUUID()}`
+  const logger = createLogger(smokeId)
+  logger.info(`Loaded env keys from ${args.envFile}: ${loadedKeys.length}`)
+  logger.info(`Running checks: ${args.checks.join(', ')}`)
+
+  const results = []
+  for (const check of args.checks) {
+    results.push(await runCheck(check, smokeId, logger))
+  }
+
+  logger.info('Smoke summary')
+  for (const result of results) {
+    logger.info(`${result.name}: ${result.ok ? 'PASS' : 'FAIL'}${result.detail ? ` (${result.detail})` : ''}`)
+  }
+
+  if (results.some((result) => !result.ok)) process.exitCode = 1
+}
+
+async function runCheck(check, smokeId, logger) {
+  try {
+    if (check === 'inngest') await smokeInngest(smokeId, logger)
+    if (check === 'external') await smokeExternalBridge(smokeId, logger)
+    if (check === 'r2') await smokeR2(smokeId, logger)
+    if (check === 'resend') await smokeResend(smokeId, logger)
+    return { name: check, ok: true }
+  } catch (error) {
+    return { name: check, ok: false, detail: error instanceof Error ? error.message : String(error) }
+  }
+}
+
+async function smokeInngest(smokeId, logger) {
+  const baseUrl = assertSafeBaseUrl(process.env.SUPPORT_SMOKE_BASE_URL)
+  const secret = requireEnv('SUPPORT_INNGEST_WEBHOOK_SECRET')
+  const endpoint = new URL('/api/inngest', baseUrl)
+  const payload = {
+    name: 'support/ticket.created',
+    id: `${SMOKE_PREFIX}:inngest:${smokeId}`,
+    data: {
+      eventId: `${SMOKE_PREFIX}:inngest:${smokeId}`,
+      ticketId: '00000000-0000-0000-0000-000000000000',
+    },
+  }
+
+  const missingAuth = await postJson(endpoint, payload)
+  assertStatus('Inngest missing auth', missingAuth, [401])
+
+  const invalidAuth = await postJson(endpoint, payload, { authorization: 'Bearer invalid-smoke-token' })
+  assertStatus('Inngest invalid auth', invalidAuth, [401])
+
+  const validAuth = await postJson(endpoint, payload, { authorization: `Bearer ${secret}` })
+  assertStatus('Inngest signed auth', validAuth, [202])
+  assertResponseField(validAuth.body, 'accepted', true, 'Inngest accepted flag')
+
+  logger.info(`Inngest endpoint accepted signed ID-only event and rejected missing/invalid auth at ${endpoint.origin}`)
+}
+
+async function smokeExternalBridge(smokeId, logger) {
+  const baseUrl = assertSafeBaseUrl(process.env.SUPPORT_SMOKE_BASE_URL)
+  const token = requireEnv('SUPPORT_EXTERNAL_BRIDGE_TOKEN')
+  const ticketId = requireEnv('SUPPORT_SMOKE_TICKET_ID')
+  assertUuid(ticketId, 'SUPPORT_SMOKE_TICKET_ID')
+
+  const endpoint = new URL('/api/support/external/inbound', baseUrl)
+  const idempotencyKey = `${SMOKE_PREFIX}:external:${smokeId}`
+  const payload = {
+    ticketId,
+    idempotencyKey,
+    message: `Staging smoke bridge update ${smokeId}. No user evidence, attachments, diagnostics, secrets, or PII included.`,
+  }
+
+  const invalidAuth = await postJson(endpoint, payload, { authorization: 'Bearer invalid-smoke-token' })
+  assertStatus('External bridge invalid auth', invalidAuth, [401])
+
+  const first = await postJson(endpoint, payload, { authorization: `Bearer ${token}` })
+  assertStatus('External bridge first delivery', first, [200])
+  assertResponseField(first.body, 'success', true, 'External bridge first success flag')
+  assertResponseField(first.body, 'duplicate', false, 'External bridge first duplicate flag')
+
+  const duplicate = await postJson(endpoint, payload, { authorization: `Bearer ${token}` })
+  assertStatus('External bridge duplicate delivery', duplicate, [200])
+  assertResponseField(duplicate.body, 'success', true, 'External bridge duplicate success flag')
+  assertResponseField(duplicate.body, 'duplicate', true, 'External bridge duplicate flag')
+
+  logger.info(`External bridge accepted staging ticket ${redact(ticketId)} and enforced idempotency key ${redact(idempotencyKey)}`)
+}
+
+async function smokeR2(smokeId, logger) {
+  const config = getR2Config()
+  const objectKey = `${SMOKE_PREFIX}/${smokeId}/attachment.png`
+  const objectBytes = Buffer.from('89504e470d0a1a0a0000000d49484452', 'hex')
+  const contentType = 'image/png'
+
+  const putUrl = createR2SignedUrl({ method: 'PUT', key: objectKey, expiresInSeconds: 60, config })
+  const getUrl = createR2SignedUrl({ method: 'GET', key: objectKey, expiresInSeconds: 60, config })
+  const deleteUrl = createR2SignedUrl({ method: 'DELETE', key: objectKey, expiresInSeconds: 60, config })
+
+  try {
+    const put = await fetchWithTimeout(putUrl, { method: 'PUT', headers: { 'content-type': contentType }, body: objectBytes })
+    assertHttpOk('R2 PUT', put, [200, 201])
+
+    const get = await fetchWithTimeout(getUrl)
+    assertHttpOk('R2 GET', get, [200])
+    const downloaded = Buffer.from(await get.arrayBuffer())
+    if (!downloaded.equals(objectBytes)) throw new Error('R2 GET content mismatch')
+  } finally {
+    const cleanup = await fetchWithTimeout(deleteUrl, { method: 'DELETE' })
+    assertHttpOk('R2 DELETE cleanup', cleanup, [200, 204])
+  }
+
+  logger.info(`R2 put/get/delete passed in bucket ${SUPPORT_R2_BUCKET} with key prefix ${SMOKE_PREFIX}/[redacted]`)
+}
+
+async function smokeResend(smokeId, logger) {
+  const apiKey = requireEnv('RESEND_API_KEY')
+  const to = requireEnv('SUPPORT_SMOKE_EMAIL_TO')
+  const fromEmail = process.env.RESEND_FROM_EMAIL || 'team@connect.yosoyglobal.org'
+  const fromName = process.env.RESEND_FROM_NAME || 'GlobalConnect'
+  const siteUrl = process.env.NEXT_PUBLIC_SITE_URL ? assertSafeBaseUrl(process.env.NEXT_PUBLIC_SITE_URL) : assertSafeBaseUrl(process.env.SUPPORT_SMOKE_BASE_URL)
+  const idempotencyKey = `${SMOKE_PREFIX}:resend:${smokeId}`
+
+  const response = await fetchWithTimeout('https://api.resend.com/emails', {
+    method: 'POST',
+    headers: {
+      authorization: `Bearer ${apiKey}`,
+      'content-type': 'application/json',
+      'idempotency-key': idempotencyKey,
+    },
+    body: JSON.stringify({
+      from: `${fromName} <${fromEmail}>`,
+      to: [to],
+      subject: `[Staging smoke] Support notification ${smokeId}`,
+      html: renderSmokeEmail({ smokeId, siteUrl }),
+      text: `Staging smoke support notification ${smokeId}. Contains no evidence, attachments, diagnostics, secrets, or user PII.`,
+    }),
+  })
+
+  assertHttpOk('Resend delivery', response, [200])
+  logger.info(`Resend accepted staging-safe email to ${redact(to)} with idempotency key ${redact(idempotencyKey)}`)
+}
+
+function renderSmokeEmail({ smokeId, siteUrl }) {
+  return `<!doctype html><html><body><h1>GlobalConnect support staging smoke</h1><p>Smoke ID: ${escapeHtml(smokeId)}</p><p>This staging-only message verifies delivery wiring and intentionally excludes evidence, attachments, diagnostics, secrets, object keys, and user PII.</p><p>Support link shape: <a href="${escapeHtml(siteUrl)}/ayuda/tickets/smoke">authenticated support ticket link</a></p></body></html>`
+}
+
+function assertNoPublicSecrets(env) {
+  const publicSecretKeys = Object.keys(env).filter((key) => key.startsWith('NEXT_PUBLIC_') && /(SECRET|SERVICE|TOKEN|PRIVATE|PASSWORD)/i.test(key))
+  if (publicSecretKeys.length) {
+    throw new Error(`Refusing smoke run: public secret-looking env keys detected: ${publicSecretKeys.join(', ')}`)
+  }
+}
+
+function requireEnv(name) {
+  const value = process.env[name]
+  if (!value) throw new Error(`${name} is required.`)
+  return value
+}
+
+function getR2Config() {
+  const accountId = requireEnv('R2_ACCOUNT_ID')
+  const accessKeyId = requireEnv('R2_ACCESS_KEY_ID')
+  const secretAccessKey = requireEnv('R2_SECRET_ACCESS_KEY')
+  return {
+    accountId,
+    accessKeyId,
+    secretAccessKey,
+    bucket: SUPPORT_R2_BUCKET,
+  }
+}
+
+function createR2SignedUrl({ method, key, expiresInSeconds, config }) {
+  const now = new Date()
+  const date = now.toISOString().slice(0, 10).replace(/-/g, '')
+  const amzDate = `${date}T${now.toISOString().slice(11, 19).replace(/:/g, '')}Z`
+  const host = `${config.bucket}.${config.accountId}.r2.cloudflarestorage.com`
+  const credential = `${config.accessKeyId}/${date}/auto/s3/aws4_request`
+  const signedHeaders = 'host'
+  const path = `/${encodeURIComponent(key).replace(/%2F/g, '/')}`
+  const params = new URLSearchParams({
+    'X-Amz-Algorithm': 'AWS4-HMAC-SHA256',
+    'X-Amz-Credential': credential,
+    'X-Amz-Date': amzDate,
+    'X-Amz-Expires': String(expiresInSeconds),
+    'X-Amz-SignedHeaders': signedHeaders,
+  })
+  const canonicalRequest = [method, path, params.toString(), `host:${host}\n`, signedHeaders, 'UNSIGNED-PAYLOAD'].join('\n')
+  const stringToSign = ['AWS4-HMAC-SHA256', amzDate, `${date}/auto/s3/aws4_request`, sha256(canonicalRequest)].join('\n')
+  const signingKey = hmac(hmac(hmac(hmac(`AWS4${config.secretAccessKey}`, date), 'auto'), 's3'), 'aws4_request')
+  params.set('X-Amz-Signature', hmac(signingKey, stringToSign).toString('hex'))
+  return `https://${host}${path}?${params.toString()}`
+}
+
+async function postJson(url, body, headers = {}) {
+  const response = await fetchWithTimeout(url, {
+    method: 'POST',
+    headers: withRouteProtectionBypass(url, { 'content-type': 'application/json', ...headers }),
+    body: JSON.stringify(body),
+  })
+  return { status: response.status, body: await readResponseBody(response) }
+}
+
+async function readResponseBody(response) {
+  const contentType = response.headers.get('content-type') || ''
+  if (!contentType.includes('application/json')) return null
+  return response.json()
+}
+
+async function fetchWithTimeout(url, init = {}) {
+  const controller = new AbortController()
+  const timeout = setTimeout(() => controller.abort(), DEFAULT_TIMEOUT_MS)
+  try {
+    return await fetch(url, { ...init, signal: controller.signal })
+  } finally {
+    clearTimeout(timeout)
+  }
+}
+
+function assertStatus(name, response, allowedStatuses) {
+  if (!allowedStatuses.includes(response.status)) {
+    throw new Error(`${name} expected ${allowedStatuses.join('/')} but got ${response.status}`)
+  }
+}
+
+function assertHttpOk(name, response, allowedStatuses) {
+  if (!allowedStatuses.includes(response.status)) {
+    throw new Error(`${name} expected ${allowedStatuses.join('/')} but got ${response.status}`)
+  }
+}
+
+function assertResponseField(body, key, expected, name) {
+  if (!body || body[key] !== expected) {
+    throw new Error(`${name} expected ${String(expected)}`)
+  }
+}
+
+function assertUuid(value, name) {
+  if (!/^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i.test(value)) {
+    throw new Error(`${name} must be a UUID from staging support data.`)
+  }
+}
+
+function sha256(value) {
+  return createHash('sha256').update(value).digest('hex')
+}
+
+function hmac(key, value) {
+  return createHmac('sha256', key).update(value).digest()
+}
+
+function unquoteEnvValue(value) {
+  if ((value.startsWith('"') && value.endsWith('"')) || (value.startsWith("'") && value.endsWith("'"))) {
+    return value.slice(1, -1)
+  }
+  return value
+}
+
+function escapeHtml(value) {
+  return value.replace(/[&<>"]/g, (char) => ({ '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;' })[char])
+}
+
+function createLogger(smokeId) {
+  return {
+    info(message) {
+      console.log(`[support-smoke:${smokeId}] ${message}`)
+    },
+  }
+}
+
+function printHelp() {
+  console.log(`Usage: pnpm support:smoke:staging [--all|--only=inngest,external,r2,resend] [--env-file=.env.staging.local]
+
+Required guard:
+  RLS_ENV=staging
+
+Route checks require:
+  SUPPORT_SMOKE_BASE_URL=<staging or localhost origin>
+
+External bridge requires:
+  SUPPORT_SMOKE_TICKET_ID=<safe staging support ticket UUID>
+
+Resend requires:
+  SUPPORT_SMOKE_EMAIL_TO=<safe staging recipient>
+`)
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  main().catch((error) => {
+    console.error(error instanceof Error ? error.message : error)
+    process.exitCode = 1
+  })
+}

--- a/scripts/support-smoke-staging.test.mjs
+++ b/scripts/support-smoke-staging.test.mjs
@@ -1,0 +1,57 @@
+import assert from 'node:assert/strict'
+import { describe, it } from 'node:test'
+
+import {
+  assertSafeBaseUrl,
+  assertStagingEnvironment,
+  isObviousProductionHost,
+  parseArgs,
+  redact,
+  withRouteProtectionBypass,
+} from './support-smoke-staging.mjs'
+
+describe('support smoke staging guards', () => {
+  it('requires explicit staging RLS guard', () => {
+    assert.throws(() => assertStagingEnvironment({ RLS_ENV: 'production' }), /RLS_ENV must be exactly "staging"/)
+    assert.doesNotThrow(() => assertStagingEnvironment({ RLS_ENV: 'staging' }))
+  })
+
+  it('refuses obvious production hosts', () => {
+    assert.equal(isObviousProductionHost('connect.yosoyglobal.org'), true)
+    assert.throws(() => assertSafeBaseUrl('https://connect.yosoyglobal.org'), /production-looking/)
+    assert.equal(assertSafeBaseUrl('https://staging-connect.example.test'), 'https://staging-connect.example.test')
+  })
+
+  it('refuses public secret-looking environment keys', () => {
+    assert.throws(() => assertStagingEnvironment({ RLS_ENV: 'staging', NEXT_PUBLIC_SECRET_TOKEN: 'x' }), /public secret-looking env keys/)
+  })
+
+  it('parses focused check flags and redacts values', () => {
+    assert.deepEqual(parseArgs(['--only=inngest,r2']).checks, ['inngest', 'r2'])
+    assert.equal(redact('abc123'), '[redacted]')
+    assert.equal(redact('smoke-1234567890'), 'smok...[redacted]...7890')
+  })
+
+  it('adds Vercel protection bypass only to app route requests', () => {
+    const env = {
+      SUPPORT_SMOKE_BASE_URL: 'https://staging-connect.example.test',
+      VERCEL_AUTOMATION_BYPASS_SECRET: 'vercel-bypass-secret',
+    }
+
+    assert.deepEqual(
+      withRouteProtectionBypass('https://staging-connect.example.test/api/inngest', { authorization: 'Bearer smoke' }, env),
+      {
+        authorization: 'Bearer smoke',
+        'x-vercel-protection-bypass': 'vercel-bypass-secret',
+      }
+    )
+    assert.deepEqual(
+      withRouteProtectionBypass('https://api.resend.com/emails', { authorization: 'Bearer provider' }, env),
+      { authorization: 'Bearer provider' }
+    )
+    assert.deepEqual(
+      withRouteProtectionBypass('https://bucket.account.r2.cloudflarestorage.com/object', {}, env),
+      {}
+    )
+  })
+})

--- a/supabase/migrations/20260610172000_add_support_capability_admin_rpcs.sql
+++ b/supabase/migrations/20260610172000_add_support_capability_admin_rpcs.sql
@@ -1,0 +1,131 @@
+-- Add audited support capability administration RPCs.
+-- Production safety: additive function definitions plus nullable audit ticket reference; no data deletion.
+-- noqa: insert-into
+
+ALTER TABLE public.support_ticket_events
+  ALTER COLUMN ticket_id DROP NOT NULL;
+
+DROP POLICY IF EXISTS support_events_select ON public.support_ticket_events;
+CREATE POLICY support_events_select ON public.support_ticket_events
+  FOR SELECT TO authenticated
+  USING (
+    (
+      ticket_id IS NULL
+      AND target_type = 'support_user_capability'
+      AND support_private.has_capability('support.manage')
+    )
+    OR EXISTS (
+      SELECT 1 FROM public.support_tickets st
+      WHERE st.id = ticket_id
+        AND (st.reporter_usuario_id = support_private.current_usuario_id() OR support_private.has_capability('support.view'))
+    )
+  );
+
+CREATE OR REPLACE FUNCTION public.grant_support_capability(p_target_usuario_id uuid, p_capability text)
+RETURNS void
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path TO 'public', 'support_private'
+AS $$
+DECLARE
+  v_actor_usuario_id uuid;
+  v_capability_id uuid;
+BEGIN
+  v_actor_usuario_id := support_private.current_usuario_id();
+
+  IF v_actor_usuario_id IS NULL OR NOT support_private.has_capability('support.manage') THEN
+    RAISE EXCEPTION 'not authorized';
+  END IF;
+
+  IF NOT EXISTS (
+    SELECT 1
+    FROM public.usuario_roles ur
+    JOIN public.roles_sistema rs ON rs.id = ur.rol_id
+    WHERE ur.usuario_id = v_actor_usuario_id
+      AND rs.nombre_interno IN ('admin', 'pastor', 'director-general')
+  ) THEN
+    RAISE EXCEPTION 'not authorized';
+  END IF;
+
+  IF p_capability NOT IN ('support.view', 'support.reply', 'support.manage') THEN
+    RAISE EXCEPTION 'invalid support capability';
+  END IF;
+
+  INSERT INTO public.support_user_capabilities (usuario_id, capability, granted_by_usuario_id, granted_at, revoked_at)
+  VALUES (p_target_usuario_id, p_capability, v_actor_usuario_id, now(), NULL)
+  ON CONFLICT (usuario_id, capability)
+  DO UPDATE SET granted_by_usuario_id = EXCLUDED.granted_by_usuario_id,
+                granted_at = now(),
+                revoked_at = NULL
+  RETURNING id INTO v_capability_id;
+
+  INSERT INTO public.support_ticket_events (ticket_id, actor_usuario_id, action, target_type, target_id, metadata)
+  VALUES (
+    NULL,
+    v_actor_usuario_id,
+    'support.capability.granted',
+    'support_user_capability',
+    v_capability_id,
+    jsonb_build_object('targetUsuarioId', p_target_usuario_id, 'capability', p_capability)
+  );
+END;
+$$;
+
+REVOKE ALL ON FUNCTION public.grant_support_capability(uuid, text) FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION public.grant_support_capability(uuid, text) TO authenticated;
+
+CREATE OR REPLACE FUNCTION public.revoke_support_capability(p_target_usuario_id uuid, p_capability text)
+RETURNS void
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path TO 'public', 'support_private'
+AS $$
+DECLARE
+  v_actor_usuario_id uuid;
+  v_capability_id uuid;
+BEGIN
+  v_actor_usuario_id := support_private.current_usuario_id();
+
+  IF v_actor_usuario_id IS NULL OR NOT support_private.has_capability('support.manage') THEN
+    RAISE EXCEPTION 'not authorized';
+  END IF;
+
+  IF NOT EXISTS (
+    SELECT 1
+    FROM public.usuario_roles ur
+    JOIN public.roles_sistema rs ON rs.id = ur.rol_id
+    WHERE ur.usuario_id = v_actor_usuario_id
+      AND rs.nombre_interno IN ('admin', 'pastor', 'director-general')
+  ) THEN
+    RAISE EXCEPTION 'not authorized';
+  END IF;
+
+  IF p_capability NOT IN ('support.view', 'support.reply', 'support.manage') THEN
+    RAISE EXCEPTION 'invalid support capability';
+  END IF;
+
+  UPDATE public.support_user_capabilities
+  SET revoked_at = now()
+  WHERE usuario_id = p_target_usuario_id
+    AND capability = p_capability
+    AND revoked_at IS NULL
+  RETURNING id INTO v_capability_id;
+
+  IF v_capability_id IS NULL THEN
+    RAISE EXCEPTION 'support capability not found';
+  END IF;
+
+  INSERT INTO public.support_ticket_events (ticket_id, actor_usuario_id, action, target_type, target_id, metadata)
+  VALUES (
+    NULL,
+    v_actor_usuario_id,
+    'support.capability.revoked',
+    'support_user_capability',
+    v_capability_id,
+    jsonb_build_object('targetUsuarioId', p_target_usuario_id, 'capability', p_capability)
+  );
+END;
+$$;
+
+REVOKE ALL ON FUNCTION public.revoke_support_capability(uuid, text) FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION public.revoke_support_capability(uuid, text) TO authenticated;

--- a/supabase/migrations/20260610182000_add_support_external_inbound_rpc.sql
+++ b/supabase/migrations/20260610182000_add_support_external_inbound_rpc.sql
@@ -1,0 +1,54 @@
+-- Add atomic external inbound support update persistence.
+-- Production safety: additive service-role RPC only; no data mutation outside RPC execution.
+-- noqa: insert-into
+
+CREATE OR REPLACE FUNCTION public.record_support_external_inbound_update(
+  p_ticket_id uuid,
+  p_author_usuario_id uuid,
+  p_message_body text,
+  p_idempotency_key text
+)
+RETURNS TABLE(event_id uuid, message_id uuid, duplicate boolean)
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path TO 'public', 'support_private'
+AS $$
+DECLARE
+  v_event_id uuid;
+  v_message_id uuid;
+BEGIN
+  IF nullif(btrim(p_message_body), '') IS NULL THEN
+    RAISE EXCEPTION 'invalid external support update';
+  END IF;
+
+  INSERT INTO public.support_ticket_events (ticket_id, actor_usuario_id, action, target_type, idempotency_key)
+  VALUES (p_ticket_id, p_author_usuario_id, 'external.update.received', 'support_external_update', p_idempotency_key)
+  ON CONFLICT (idempotency_key) DO NOTHING
+  RETURNING id INTO v_event_id;
+
+  IF v_event_id IS NULL THEN
+    SELECT ste.id INTO v_event_id
+    FROM public.support_ticket_events ste
+    WHERE ste.idempotency_key = p_idempotency_key
+      AND ste.ticket_id = p_ticket_id
+      AND ste.action = 'external.update.received'
+      AND ste.target_type = 'support_external_update';
+
+    IF v_event_id IS NULL THEN
+      RAISE EXCEPTION 'idempotency key conflict for different support event';
+    END IF;
+
+    RETURN QUERY SELECT v_event_id, NULL::uuid, true;
+    RETURN;
+  END IF;
+
+  INSERT INTO public.support_ticket_messages (ticket_id, author_usuario_id, body, is_internal)
+  VALUES (p_ticket_id, p_author_usuario_id, p_message_body, false)
+  RETURNING id INTO v_message_id;
+
+  RETURN QUERY SELECT v_event_id, v_message_id, false;
+END;
+$$;
+
+REVOKE ALL ON FUNCTION public.record_support_external_inbound_update(uuid, uuid, text, text) FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION public.record_support_external_inbound_update(uuid, uuid, text, text) TO service_role;

--- a/supabase/migrations/20260610190000_align_support_capability_hierarchy.sql
+++ b/supabase/migrations/20260610190000_align_support_capability_hierarchy.sql
@@ -1,0 +1,67 @@
+-- Align support staff capability hierarchy for RLS and audited RPC gates.
+-- Production safety: replaces only the private helper used by existing policies/RPCs; no data mutation.
+
+CREATE OR REPLACE FUNCTION support_private.has_capability(required_capability text)
+RETURNS boolean
+LANGUAGE sql
+STABLE
+SECURITY DEFINER
+SET search_path TO 'public', 'support_private'
+AS $$
+  SELECT EXISTS (
+    SELECT 1
+    FROM public.usuarios u
+    JOIN public.support_user_capabilities suc ON suc.usuario_id = u.id
+    WHERE u.auth_id = (select auth.uid())
+      AND suc.revoked_at IS NULL
+      AND (
+        suc.capability = required_capability
+        OR (suc.capability = 'support.reply' AND required_capability IN ('support.view', 'support.reply'))
+        OR (suc.capability = 'support.manage' AND required_capability IN ('support.view', 'support.reply', 'support.manage'))
+      )
+  )
+$$;
+
+REVOKE ALL ON FUNCTION support_private.has_capability(text) FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION support_private.has_capability(text) TO authenticated, service_role;
+
+CREATE OR REPLACE FUNCTION support_private.has_support_configuration_access()
+RETURNS boolean
+LANGUAGE sql
+STABLE
+SECURITY DEFINER
+SET search_path TO 'public', 'support_private'
+AS $$
+  SELECT support_private.has_capability('support.manage')
+    AND EXISTS (
+      SELECT 1
+      FROM public.usuario_roles ur
+      JOIN public.roles_sistema rs ON rs.id = ur.rol_id
+      WHERE ur.usuario_id = support_private.current_usuario_id()
+        AND rs.nombre_interno IN ('admin', 'pastor', 'director-general')
+    )
+$$;
+
+REVOKE ALL ON FUNCTION support_private.has_support_configuration_access() FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION support_private.has_support_configuration_access() TO authenticated, service_role;
+
+DROP POLICY IF EXISTS support_capabilities_select ON public.support_user_capabilities;
+CREATE POLICY support_capabilities_select ON public.support_user_capabilities
+  FOR SELECT TO authenticated
+  USING (usuario_id = support_private.current_usuario_id() OR support_private.has_support_configuration_access());
+
+DROP POLICY IF EXISTS support_events_select ON public.support_ticket_events;
+CREATE POLICY support_events_select ON public.support_ticket_events
+  FOR SELECT TO authenticated
+  USING (
+    (
+      ticket_id IS NULL
+      AND target_type = 'support_user_capability'
+      AND support_private.has_support_configuration_access()
+    )
+    OR EXISTS (
+      SELECT 1 FROM public.support_tickets st
+      WHERE st.id = ticket_id
+        AND (st.reporter_usuario_id = support_private.current_usuario_id() OR support_private.has_capability('support.view'))
+    )
+  );

--- a/supabase/migrations/20260611120000_add_safe_support_ticket_auto_assignment_rpc.sql
+++ b/supabase/migrations/20260611120000_add_safe_support_ticket_auto_assignment_rpc.sql
@@ -1,0 +1,44 @@
+-- Add best-effort auto-assignment RPC that cannot overwrite existing assignees.
+-- noqa: insert-into
+
+CREATE OR REPLACE FUNCTION public.auto_assign_support_ticket_if_unassigned(p_ticket_id uuid)
+RETURNS boolean
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path TO 'public', 'support_private'
+AS $$
+DECLARE
+  v_actor_usuario_id uuid;
+  v_updated_count integer := 0;
+BEGIN
+  v_actor_usuario_id := support_private.current_usuario_id();
+
+  IF v_actor_usuario_id IS NULL OR NOT support_private.has_capability('support.manage') THEN
+    RAISE EXCEPTION 'not authorized';
+  END IF;
+
+  UPDATE public.support_tickets
+  SET assignee_usuario_id = v_actor_usuario_id
+  WHERE id = p_ticket_id
+    AND assignee_usuario_id IS NULL;
+
+  GET DIAGNOSTICS v_updated_count = ROW_COUNT;
+
+  IF v_updated_count > 0 THEN
+    INSERT INTO public.support_ticket_events (ticket_id, actor_usuario_id, action, target_type, target_id, metadata)
+    VALUES (
+      p_ticket_id,
+      v_actor_usuario_id,
+      'support.ticket.assigned',
+      'support_ticket',
+      p_ticket_id,
+      jsonb_build_object('assigneeUsuarioId', v_actor_usuario_id, 'source', 'staff_reply_auto_assign')
+    );
+  END IF;
+
+  RETURN v_updated_count > 0;
+END;
+$$;
+
+REVOKE ALL ON FUNCTION public.auto_assign_support_ticket_if_unassigned(uuid) FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION public.auto_assign_support_ticket_if_unassigned(uuid) TO authenticated;

--- a/supabase/migrations/20260611183000_add_reporter_support_audit_events.sql
+++ b/supabase/migrations/20260611183000_add_reporter_support_audit_events.sql
@@ -1,0 +1,18 @@
+-- Allow authenticated reporters to append audit events for their own committed support actions.
+-- Production safety: additive grants/policies only; no data mutation or destructive changes.
+
+GRANT INSERT ON public.support_ticket_events TO authenticated;
+
+CREATE POLICY support_events_reporter_insert ON public.support_ticket_events
+  FOR INSERT TO authenticated
+  WITH CHECK (
+    actor_usuario_id = support_private.current_usuario_id()
+    AND action IN ('support.ticket.created', 'support.reporter_message.created')
+    AND target_type IN ('support_ticket', 'support_ticket_message')
+    AND EXISTS (
+      SELECT 1
+      FROM public.support_tickets st
+      WHERE st.id = ticket_id
+        AND st.reporter_usuario_id = support_private.current_usuario_id()
+    )
+  );


### PR DESCRIPTION
Closes #154

## Summary
- Tracker PR for the verified and archived SDD change `support-ticket-production-readiness`.
- Hardens support ticket production readiness across reporter UX, private R2 attachments, staff operations, capability administration, provider boundaries, and rollout verification.
- Includes additive Supabase/RLS migrations, generated type updates, staging smoke tooling, and OpenSpec archive artifacts.

## What Includes
- Reporter ticket form simplification, safe evidence/privacy defaults, public reporter audit events, and private R2 upload/download flow.
- Staff queue/detail lifecycle UI, support capability admin UI/actions/RPCs, and capability hierarchy across UI/server/RLS.
- ID-only Inngest boundary, external inbound bridge auth/idempotency/RPC persistence, Resend support notifications, and staging smoke script.
- OpenSpec canonical spec update and archived `support-ticket-production-readiness` change.

## Motivation / Why
The support ticket MVP needed production-readiness hardening before rollout. This closes gaps around private file handling, admin capability provisioning, provider boundaries, non-destructive Supabase staging validation, and release-gate evidence.

## Visual Evidence
| Before | After |
|-------|-------|
| Not captured | Not captured |

## Migrations / Database
- [ ] No aplica
- [x] Sí (orden exacto):
```text
20260610172000_add_support_capability_admin_rpcs.sql
20260610182000_add_support_external_inbound_rpc.sql
20260610190000_align_support_capability_hierarchy.sql
20260611183000_add_reporter_support_audit_events.sql
```
Notas:
- Additive/non-destructive migrations.
- Applied and validated against staging during PR5.3 evidence collection.

## Impact and Risks
- No intentional breaking change.
- Requires coordinated deployment of app code and Supabase migrations before enabling production support readiness.
- Requires provider env vars for R2, Resend, Inngest route auth, external bridge token/author, and Vercel protection bypass for protected preview smoke checks.
- Remaining warnings are documented in the SDD verify/archive reports: historical TDD RED ordering is partially unreconstructable, optional outbound escalation sender remains future wiring, and lint/React warnings remain non-blocking.

## Author Checklist
- [x] Código formateado (Prettier/ESLint)
- [x] Sin `console.log` / debugger
- [x] Validaciones con zod para entradas nuevas
- [x] Estados loading/error/empty cubiertos
- [x] Tipos TypeScript correctos
- [x] Migraciones probadas local/staging
- [x] Documentación actualizada (`docs/` o README)
- [x] Variables de entorno documentadas
- [x] Rebase con `main` limpio

## Reviewer Checklist
- [ ] Propósito claro
- [ ] Nombres descriptivos
- [ ] Sin lógica duplicada evidente
- [ ] Manejo adecuado de errores
- [ ] Cambios acotados al alcance
- [ ] Sin secretos / datos sensibles

## Manual Tests Performed
- [x] `pnpm exec tsc --noEmit`
- [x] `pnpm lint:migrations` — 0 errors, warnings only
- [x] `pnpm lint` — 0 errors, warnings only
- [x] `pnpm test -- --runInBand` — 19 suites / 149 tests passed
- [x] `pnpm test:rls` against staging — 12/12 passed
- [x] `pnpm support:smoke:staging` — Inngest, external bridge, R2, and Resend passed against non-production preview/staging
- [x] SDD verify — PASS WITH WARNINGS
- [x] SDD archive — completed

## Pending / Follow-up
- Consider moving privileged RPCs to a private schema in a future hardening pass.
- Consider sanitizing server-side R2 error messages further to avoid object-key leakage in server logs.
- Consider adding a transactional wrapper for ticket creation + audit if production policy requires atomic audit guarantees.

## Additional Notes
- This is intentionally a tracker PR (`*-tracker`) for the large SDD aggregate diff. The commits are split by work unit for review.
- Previous PR #155 was closed because the size guard did not recognize the aggregate tracker intent on the original branch name.
- No secrets are committed; `.gitignore` and `.vercelignore` explicitly exclude local env files.
