### PR TITLE
fix(support): harden support table grants

### DIFF
--- a/__tests__/supabase/support-ticket-system-migration.test.ts
+++ b/__tests__/supabase/support-ticket-system-migration.test.ts
@@ -28,6 +28,10 @@ function readSupportStaffDirectMutationMigration(): string {
   return readMigrationBySuffix('_restrict_support_staff_direct_mutations.sql')
 }
 
+function readSupportGrantHardeningMigration(): string {
+  return readMigrationBySuffix('_harden_support_table_grants.sql')
+}
+
 function readMigrationBySuffix(suffix: string): string {
   const migration = readdirSync(migrationsDir).find((file) => file.endsWith(suffix))
 
@@ -40,6 +44,14 @@ function readMigrationBySuffix(suffix: string): string {
 
 function compactSql(sql: string): string {
   return sql.replace(/\s+/g, ' ')
+}
+
+function sqlStatements(sql: string): string[] {
+  return sql
+    .split(';')
+    .map(compactSql)
+    .map((statement) => statement.trim())
+    .filter(Boolean)
 }
 
 function policySql(sql: string, policyName: string): string {
@@ -369,5 +381,53 @@ describe('support ticket system migration', () => {
     expect(insertPolicy).toContain('is_internal = false')
     expect(insertPolicy).toContain('st.reporter_usuario_id = support_private.current_usuario_id()')
     expect(insertPolicy).not.toContain("support_private.has_capability('support.reply')")
+  })
+
+  it('hardens support table grants to remove anon access and keep authenticated privileges minimal', () => {
+    const sql = readSupportGrantHardeningMigration()
+    const supportTables = [
+      'support_user_capabilities',
+      'support_tickets',
+      'support_ticket_messages',
+      'support_ticket_attachments',
+      'support_ticket_events',
+    ]
+
+    for (const table of supportTables) {
+      expect(sql).toContain(`REVOKE ALL PRIVILEGES ON TABLE public.${table} FROM anon`)
+      expect(sql).toContain(`REVOKE ALL PRIVILEGES ON TABLE public.${table} FROM authenticated`)
+      expect(sql).toContain(`GRANT ALL PRIVILEGES ON TABLE public.${table} TO service_role`)
+    }
+
+    const authenticatedSupportTableGrants = sqlStatements(sql).filter(
+      (statement) =>
+        /^GRANT\s/i.test(statement) &&
+        /\bON TABLE public\.support_/i.test(statement) &&
+        /\bTO authenticated$/i.test(statement),
+    )
+
+    expect(authenticatedSupportTableGrants.sort()).toEqual(
+      [
+        'GRANT SELECT ON TABLE public.support_user_capabilities TO authenticated',
+        'GRANT SELECT, INSERT ON TABLE public.support_tickets TO authenticated',
+        'GRANT SELECT, INSERT ON TABLE public.support_ticket_messages TO authenticated',
+        'GRANT SELECT, INSERT ON TABLE public.support_ticket_attachments TO authenticated',
+        'GRANT SELECT, INSERT ON TABLE public.support_ticket_events TO authenticated',
+      ].sort(),
+    )
+    expect(sql).not.toMatch(/GRANT\s+[^;]*\bON TABLE public\.support_\w+\s+TO anon\b/i)
+    expect(authenticatedSupportTableGrants.join('; ')).not.toMatch(/\b(UPDATE|DELETE|TRUNCATE|REFERENCES|TRIGGER|ALL PRIVILEGES)\b/i)
+  })
+
+  it('hardens the optional support ticket number identity sequence safely', () => {
+    const sql = readSupportGrantHardeningMigration()
+
+    expect(sql).toContain("to_regclass('public.support_tickets_ticket_number_seq')")
+    expect(sql).toContain("c.relkind = 'S'")
+    expect(sql).toContain('IF support_ticket_number_sequence IS NOT NULL THEN')
+    expect(sql).toContain('REVOKE ALL PRIVILEGES ON SEQUENCE %s FROM anon')
+    expect(sql).toContain('REVOKE ALL PRIVILEGES ON SEQUENCE %s FROM authenticated')
+    expect(sql).toContain('GRANT USAGE, SELECT ON SEQUENCE %s TO authenticated')
+    expect(sql).toContain('GRANT ALL PRIVILEGES ON SEQUENCE %s TO service_role')
   })
 })

--- a/supabase/migrations/20260612120500_harden_support_table_grants.sql
+++ b/supabase/migrations/20260612120500_harden_support_table_grants.sql
@@ -1,0 +1,45 @@
+-- Harden support table privileges after production verification found broad default grants.
+-- Production safety: privilege hardening only; no data mutation, no schema mutation, and no RLS policy changes.
+
+REVOKE ALL PRIVILEGES ON TABLE public.support_user_capabilities FROM anon;
+REVOKE ALL PRIVILEGES ON TABLE public.support_tickets FROM anon;
+REVOKE ALL PRIVILEGES ON TABLE public.support_ticket_messages FROM anon;
+REVOKE ALL PRIVILEGES ON TABLE public.support_ticket_attachments FROM anon;
+REVOKE ALL PRIVILEGES ON TABLE public.support_ticket_events FROM anon;
+
+REVOKE ALL PRIVILEGES ON TABLE public.support_user_capabilities FROM authenticated;
+REVOKE ALL PRIVILEGES ON TABLE public.support_tickets FROM authenticated;
+REVOKE ALL PRIVILEGES ON TABLE public.support_ticket_messages FROM authenticated;
+REVOKE ALL PRIVILEGES ON TABLE public.support_ticket_attachments FROM authenticated;
+REVOKE ALL PRIVILEGES ON TABLE public.support_ticket_events FROM authenticated;
+
+GRANT SELECT ON TABLE public.support_user_capabilities TO authenticated;
+GRANT SELECT, INSERT ON TABLE public.support_tickets TO authenticated;
+GRANT SELECT, INSERT ON TABLE public.support_ticket_messages TO authenticated;
+GRANT SELECT, INSERT ON TABLE public.support_ticket_attachments TO authenticated;
+GRANT SELECT, INSERT ON TABLE public.support_ticket_events TO authenticated;
+
+GRANT ALL PRIVILEGES ON TABLE public.support_user_capabilities TO service_role;
+GRANT ALL PRIVILEGES ON TABLE public.support_tickets TO service_role;
+GRANT ALL PRIVILEGES ON TABLE public.support_ticket_messages TO service_role;
+GRANT ALL PRIVILEGES ON TABLE public.support_ticket_attachments TO service_role;
+GRANT ALL PRIVILEGES ON TABLE public.support_ticket_events TO service_role;
+
+DO $$
+DECLARE
+  support_ticket_number_sequence text;
+BEGIN
+  SELECT format('%I.%I', n.nspname, c.relname)
+  INTO support_ticket_number_sequence
+  FROM pg_class c
+  JOIN pg_namespace n ON n.oid = c.relnamespace
+  WHERE c.oid = to_regclass('public.support_tickets_ticket_number_seq')
+    AND c.relkind = 'S';
+
+  IF support_ticket_number_sequence IS NOT NULL THEN
+    EXECUTE format('REVOKE ALL PRIVILEGES ON SEQUENCE %s FROM anon', support_ticket_number_sequence);
+    EXECUTE format('REVOKE ALL PRIVILEGES ON SEQUENCE %s FROM authenticated', support_ticket_number_sequence);
+    EXECUTE format('GRANT USAGE, SELECT ON SEQUENCE %s TO authenticated', support_ticket_number_sequence);
+    EXECUTE format('GRANT ALL PRIVILEGES ON SEQUENCE %s TO service_role', support_ticket_number_sequence);
+  END IF;
+END $$;


### PR DESCRIPTION
Closes #154

## Summary
- Adds a repo migration that mirrors the production support table grant hardening already applied through Supabase MCP.
- Adds migration guard assertions for anon/authenticated/service_role grant boundaries on support tables.

## Changes
| File | Change |
|------|--------|
| `supabase/migrations/20260612120500_harden_support_table_grants.sql` | Revokes broad support table grants from anon/authenticated and reapplies explicit least-privilege grants. |
| `__tests__/supabase/support-ticket-system-migration.test.ts` | Adds assertions for grant hardening and service_role preservation. |

## Test Plan
- [x] `pnpm jest __tests__/supabase/support-ticket-system-migration.test.ts --runInBand`
- [x] `pnpm lint:migrations`
- [x] Fresh-context diff review passed before commit.

## Author Checklist
- [x] Linked an approved issue
- [x] Conventional commit format
- [x] No secrets or sensitive values committed
- [x] Changes are scoped to support grant hardening
