### PR TITLE
fix(support): repair staff replies and notifications

### DIFF
--- a/__tests__/lib/actions/support.actions.test.ts
+++ b/__tests__/lib/actions/support.actions.test.ts
@@ -403,7 +403,7 @@ describe('support reporter actions', () => {
     expect(rpc).not.toHaveBeenCalled()
   })
 
-  it('updates a support ticket status through the atomic audit RPC', async () => {
+  it('updates a support ticket status through the atomic audit RPC and auto-assigns if still unassigned', async () => {
     const rpc = jest.fn().mockResolvedValue({ error: null })
     createSupabaseServerClient.mockResolvedValue({
       auth: { getUser: jest.fn().mockResolvedValue({ data: { user: { id: 'auth-1' } } }) },
@@ -415,6 +415,7 @@ describe('support reporter actions', () => {
 
     expect(result).toEqual({ success: true })
     expect(rpc).toHaveBeenCalledWith('update_support_ticket_status', { p_ticket_id: 'ticket-1', p_status: 'resolved' })
+    expect(rpc).toHaveBeenCalledWith('auto_assign_support_ticket_if_unassigned', { p_ticket_id: 'ticket-1' })
   })
 
   it('maps denied staff status saves to a stable user-safe message', async () => {

--- a/__tests__/lib/support/inngest.test.ts
+++ b/__tests__/lib/support/inngest.test.ts
@@ -261,7 +261,7 @@ describe('support Inngest events', () => {
     })
   })
 
-  it('loads all active support staff recipients and sends one safe ticket-created notification to each recipient', async () => {
+  it('sends ticket-created receipts only to the ticket reporter', async () => {
     createdEmailMock.mockResolvedValue({ success: true, id: 'email-created' })
     const supabase = createSupportNotificationSupabaseMock()
 
@@ -270,28 +270,46 @@ describe('support Inngest events', () => {
       supabase
     )
 
-    expect(result).toEqual([{ success: true, id: 'email-created' }, { success: true, id: 'email-created' }])
-    expect(createdEmailMock).toHaveBeenCalledTimes(2)
-    expect(createdEmailMock).toHaveBeenNthCalledWith(1, expect.objectContaining({
-      recipientEmail: 'staff-view@example.com',
-      recipientName: 'View Staff',
+    expect(result).toEqual([{ success: true, id: 'email-created' }])
+    expect(createdEmailMock).toHaveBeenCalledTimes(1)
+    expect(createdEmailMock).toHaveBeenCalledWith(expect.objectContaining({
+      recipientEmail: 'reporter@example.com',
+      recipientName: 'Ticket Reporter',
       ticketId: 'ticket-1',
       ticketNumber: 42,
       title: 'Cannot open group map',
       status: 'received',
-      idempotencyKey: 'email:event-created:staff-view@example.com',
-    }))
-    expect(createdEmailMock).toHaveBeenNthCalledWith(2, expect.objectContaining({
-      recipientEmail: 'staff-reply@example.com',
-      recipientName: 'Reply Staff',
-      idempotencyKey: 'email:event-created:staff-reply@example.com',
+      idempotencyKey: 'email:event-created:reporter@example.com',
     }))
     expect(JSON.stringify(createdEmailMock.mock.calls)).not.toMatch(/rawSentry|evidence|attachment|object_key|support\/ticket-1/i)
+  })
+
+  it('keeps message notifications on the active support staff recipient path', async () => {
+    messageEmailMock.mockResolvedValue({ success: true, id: 'email-message' })
+    const supabase = createSupportNotificationSupabaseMock()
+
+    const result = await deliverSupportNotificationEvent(
+      createSupportTicketMessageCreatedEvent({ eventId: 'event-message', ticketId: 'ticket-1', messageId: 'message-1', actorUserId: 'reporter-1' }),
+      supabase
+    )
+
+    expect(result).toEqual([{ success: true, id: 'email-message' }, { success: true, id: 'email-message' }])
+    expect(messageEmailMock).toHaveBeenCalledTimes(2)
+    expect(messageEmailMock).toHaveBeenNthCalledWith(1, expect.objectContaining({
+      recipientEmail: 'staff-view@example.com',
+      recipientName: 'View Staff',
+      idempotencyKey: 'email:event-message:staff-view@example.com',
+    }))
+    expect(messageEmailMock).toHaveBeenNthCalledWith(2, expect.objectContaining({
+      recipientEmail: 'staff-reply@example.com',
+      recipientName: 'Reply Staff',
+      idempotencyKey: 'email:event-message:staff-reply@example.com',
+    }))
   })
 })
 
 function createSupportNotificationSupabaseMock() {
-  const ticketQuery = { select: jest.fn().mockReturnValue({ eq: jest.fn().mockReturnValue({ single: jest.fn().mockResolvedValue({ data: { id: 'ticket-1', ticket_number: 42, title: 'Cannot open group map', status: 'received' }, error: null }) }) }) }
+  const ticketQuery = { select: jest.fn().mockReturnValue({ eq: jest.fn().mockReturnValue({ single: jest.fn().mockResolvedValue({ data: { id: 'ticket-1', ticket_number: 42, title: 'Cannot open group map', status: 'received', reporter: { id: 'reporter-1', nombre: 'Ticket', apellido: 'Reporter', email: 'reporter@example.com' } }, error: null }) }) }) }
   const capabilityQuery = {
     select: jest.fn().mockReturnValue({
       is: jest.fn().mockResolvedValue({

--- a/app/(auth)/ayuda/tickets/[id]/page.tsx
+++ b/app/(auth)/ayuda/tickets/[id]/page.tsx
@@ -20,6 +20,8 @@ export default async function TicketDetailPage({ params }: { params: Promise<{ i
   const result = await getSupportTicketDetail(id)
   if (!result.success || !result.ticket) notFound()
   const ticket = result.ticket
+  const canManage = ticket.supportCapabilities.includes('support.manage')
+  const canStaffReply = canManage || ticket.supportCapabilities.includes('support.reply')
 
   async function replyAction(formData: FormData) {
     'use server'
@@ -36,8 +38,6 @@ export default async function TicketDetailPage({ params }: { params: Promise<{ i
     return updateSupportTicketStatus(ticket.id, String(formData.get('status') ?? ''))
   }
 
-  const canManage = ticket.supportCapabilities.includes('support.manage')
-  const canStaffReply = canManage || ticket.supportCapabilities.includes('support.reply')
   const reporter = createParticipant(ticket.reporter, 'Solicitante')
   const assignee = createParticipant(ticket.assignee, 'Sin asignar')
 

--- a/lib/actions/support.actions.ts
+++ b/lib/actions/support.actions.ts
@@ -217,6 +217,7 @@ export async function updateSupportTicketStatus(ticketId: string, status: string
 
   const { error } = await supabase.rpc('update_support_ticket_status' as never, { p_ticket_id: ticketId, p_status: parsed.data } as never)
   if (error) return { success: false, error: SUPPORT_STAFF_STATUS_ERROR }
+  await supabase.rpc('auto_assign_support_ticket_if_unassigned' as never, { p_ticket_id: ticketId } as never)
 
   revalidatePath(`/ayuda/tickets/${ticketId}`)
   revalidatePath('/ayuda/admin')

--- a/lib/support/inngest.ts
+++ b/lib/support/inngest.ts
@@ -57,15 +57,18 @@ interface SupportTicketNotificationRow {
   ticket_number: number
   title: string
   status: SupportEmailStatus
+  reporter?: SupportRecipientProfile | null
+}
+
+interface SupportRecipientProfile {
+  id: string
+  nombre: string | null
+  apellido: string | null
+  email: string | null
 }
 
 interface SupportCapabilityRecipientRow {
-  usuario?: {
-    id: string
-    nombre: string | null
-    apellido: string | null
-    email: string | null
-  } | null
+  usuario?: SupportRecipientProfile | null
 }
 
 interface SupportInngestDispatchOptions {
@@ -139,7 +142,7 @@ export async function deliverSupportNotificationEvent(
   const ticket = await loadSupportTicketNotificationData(supabase, event.data.ticketId)
   if (!ticket) return []
 
-  const recipients = await loadSupportStaffRecipients(supabase, ticket)
+  const recipients = await loadSupportNotificationRecipients(supabase, event, ticket)
   return sendSupportNotificationEmails(event, recipients)
 }
 
@@ -202,9 +205,21 @@ async function loadSupportTicketNotificationData(
   const query = supabase.from('support_tickets') as {
     select: (columns: string) => { eq: (column: string, value: string) => { single: () => Promise<{ data: SupportTicketNotificationRow | null; error: unknown }> } }
   }
-  const { data, error } = await query.select('id,ticket_number,title,status').eq('id', ticketId).single()
+  const { data, error } = await query.select('id,ticket_number,title,status,reporter:usuarios!support_tickets_reporter_usuario_id_fkey(id,nombre,apellido,email)').eq('id', ticketId).single()
   if (error || !data) return null
   return data
+}
+
+async function loadSupportNotificationRecipients(
+  supabase: { from: (table: string) => unknown },
+  event: SupportNotificationEvent,
+  ticket: SupportTicketNotificationRow
+): Promise<SupportNotificationEmailData[]> {
+  if (event.name === SUPPORT_INNGEST_EVENTS.ticketCreated) {
+    return toSupportNotificationRecipients([ticket.reporter], ticket)
+  }
+
+  return loadSupportStaffRecipients(supabase, ticket)
 }
 
 async function loadSupportStaffRecipients(
@@ -220,11 +235,17 @@ async function loadSupportStaffRecipients(
 
   if (error || !data) return []
 
+  return toSupportNotificationRecipients(data.map((row) => row.usuario), ticket)
+}
+
+function toSupportNotificationRecipients(
+  usuarios: Array<SupportRecipientProfile | null | undefined>,
+  ticket: SupportTicketNotificationRow
+) {
   const seen = new Set<string>()
   const recipients: SupportNotificationEmailData[] = []
 
-  for (const row of data) {
-    const usuario = row.usuario
+  for (const usuario of usuarios) {
     const email = usuario?.email?.trim()
     if (!usuario || !email) continue
 


### PR DESCRIPTION
Closes #154

## Summary
- Fixes the production staff reply crash caused by a Server Action closure ordering issue.
- Auto-assigns the current support manager when they move an unassigned ticket through a status update.
- Sends ticket-created receipt emails to the reporter instead of support staff/admin recipients.

## Changes
| File | Change |
|------|--------|
| `app/(auth)/ayuda/tickets/[id]/page.tsx` | Moves support capability booleans before Server Action closures. |
| `lib/actions/support.actions.ts` | Auto-assigns unassigned tickets after status updates through the safe RPC path. |
| `lib/support/inngest.ts` | Routes ticket-created receipt notifications to the reporter. |
| `__tests__/lib/actions/support.actions.test.ts` | Covers status-update auto-assignment behavior. |
| `__tests__/lib/support/inngest.test.ts` | Covers reporter recipient selection for ticket-created emails. |

## Test Plan
- [x] `pnpm jest __tests__/lib/actions/support.actions.test.ts __tests__/lib/support/inngest.test.ts --runInBand`
- [x] `pnpm jest __tests__/app/support-pages.test.tsx --runInBand`
- [x] Fresh-context diff review passed with no blockers.

## Author Checklist
- [x] Linked an approved issue
- [x] Added exactly one type label
- [x] Conventional commit format
- [x] No secrets or sensitive values committed
- [x] Changes are scoped to support production bug fixes
