### PR TITLE
fix(support): show staff details and attachment previews

### DIFF
--- a/__tests__/app/support-attachments-route.test.ts
+++ b/__tests__/app/support-attachments-route.test.ts
@@ -222,9 +222,29 @@ describe('support attachment route handlers', () => {
 
     expect(response.status).toBe(200)
     expect(response.headers.get('content-type')).toBe('image/png')
-    expect(response.headers.get('content-disposition')).toBe('attachment')
+    expect(response.headers.get('content-disposition')).toBe('inline')
+    expect(response.headers.get('accept-ranges')).toBe('bytes')
     expect(response.headers.get('location')).toBeNull()
     await expect(response.text()).resolves.toBe('file')
+  })
+
+  it('forwards range requests so authorized video previews can stream through the app route', async () => {
+    const actorQuery = createMaybeSingleQuery({ id: 'usuario-1' })
+    const attachmentQuery = createMaybeSingleQuery({ ...pendingAttachment, status: 'uploaded', content_type: 'video/mp4' })
+    const fetchMock = jest.fn().mockResolvedValue(createR2Response({ ok: true, status: 206, headers: { 'content-type': 'video/mp4', 'content-range': 'bytes 0-31/4096', 'content-length': '32', 'accept-ranges': 'bytes' }, body: new Uint8Array([1, 2, 3]) }))
+    createSupabaseServerClient
+      .mockResolvedValueOnce({ auth: { getUser: jest.fn().mockResolvedValue({ data: { user: { id: 'auth-1' } } }) } })
+      .mockResolvedValueOnce({ from: jest.fn().mockReturnValue(attachmentQuery) })
+    createSupabaseAdminClient.mockReturnValueOnce({ from: jest.fn().mockReturnValue(actorQuery) })
+    Object.defineProperty(globalThis, 'fetch', { value: fetchMock, writable: true })
+
+    const response = await supportAttachmentDownloadRoute({ headers: { get: (name: string) => name === 'range' ? 'bytes=0-31' : null } } as Request, 'attachment-1')
+
+    expect(response.status).toBe(206)
+    expect(fetchMock).toHaveBeenCalledWith(expect.stringContaining('attachment-1'), { headers: { range: 'bytes=0-31' } })
+    expect(response.headers.get('content-type')).toBe('video/mp4')
+    expect(response.headers.get('content-range')).toBe('bytes 0-31/4096')
+    expect(response.headers.get('content-length')).toBe('32')
   })
 
   it('returns 401 from the download route when the user is not authenticated', async () => {

--- a/__tests__/app/support-pages.test.tsx
+++ b/__tests__/app/support-pages.test.tsx
@@ -31,16 +31,19 @@ jest.mock('@/lib/actions/support.actions', () => ({
       category: 'bug',
       severity: 'normal',
       reporterUsuarioId: 'reporter-1',
-      assigneeUsuarioId: null,
+      assigneeUsuarioId: 'staff-1',
       reporter: { id: 'reporter-1', nombre: 'Ana', apellido: 'Pérez', photoUrl: null },
-      assignee: null,
+      assignee: { id: 'staff-1', nombre: 'Soporte', apellido: 'Central', photoUrl: 'https://cdn.example/staff.webp' },
       createdAt: '2026-06-09T00:00:00Z',
       updatedAt: '2026-06-09T00:00:00Z',
       evidence: { currentRoute: '/dashboard', browserName: 'Chrome', osName: 'macOS', viewport: '1440x900', appBuildVersion: null, sentryEventId: null, diagnosticsConsent: true },
-      attachments: [{ id: 'attachment-1', filename: 'map-error.webp', kind: 'screenshot', contentType: 'image/webp', byteSize: 2048, status: 'uploaded' }],
+      attachments: [
+        { id: 'attachment-1', filename: 'map-error.webp', kind: 'screenshot', contentType: 'image/webp', byteSize: 2048, status: 'uploaded' },
+        { id: 'attachment-2', filename: 'screen-recording.mp4', kind: 'video', contentType: 'video/mp4', byteSize: 4096, status: 'uploaded' },
+      ],
       messages: [
         { id: 'message-1', body: 'Public reply', authorUsuarioId: 'reporter-1', author: { id: 'reporter-1', nombre: 'Ana', apellido: 'Pérez', photoUrl: null }, createdAt: '2026-06-09T00:01:00Z' },
-        { id: 'message-2', body: 'Support reply', authorUsuarioId: 'staff-1', author: { id: 'staff-1', nombre: 'Soporte', apellido: 'Central', photoUrl: null }, createdAt: '2026-06-09T00:02:00Z' },
+        { id: 'message-2', body: 'Support reply', authorUsuarioId: 'staff-1', author: { id: 'staff-1', nombre: 'Soporte', apellido: 'Central', photoUrl: 'https://cdn.example/staff.webp' }, createdAt: '2026-06-09T00:02:00Z' },
       ],
       supportCapabilities: [],
     },
@@ -159,13 +162,18 @@ describe('reporter support pages', () => {
     expect(screen.getByRole('heading', { name: /Adjuntos/i })).toBeInTheDocument()
     expect(screen.getAllByText('Ana Pérez').length).toBeGreaterThan(0)
     expect(screen.getByText('map-error.webp')).toBeInTheDocument()
-    expect(screen.getByRole('link', { name: /Descargar map-error\.webp/i })).toHaveAttribute('href', '/api/support/attachments/attachment-1/download')
+    expect(screen.getAllByText('Responsable').length).toBeGreaterThan(0)
+    expect(screen.getAllByText('Soporte Central').length).toBeGreaterThan(0)
+    expect(screen.getByRole('img', { name: /Vista previa de map-error\.webp/i })).toHaveAttribute('src', '/api/support/attachments/attachment-1/download')
+    expect(screen.getByLabelText(/Vista previa de screen-recording\.mp4/i)).toHaveAttribute('src', '/api/support/attachments/attachment-2/download')
+    expect(screen.getByRole('link', { name: /Abrir map-error\.webp/i })).toHaveAttribute('href', '/api/support/attachments/attachment-1/download')
     expect(screen.queryByText(/support\/ticket-1\/attachment-1/i)).not.toBeInTheDocument()
     expect(screen.queryByText(/X-Amz-Signature/i)).not.toBeInTheDocument()
     expect(screen.getByText('Public reply')).toBeInTheDocument()
     expect(screen.getByText('Support reply')).toBeInTheDocument()
-    expect(screen.getByText('Soporte Central')).toBeInTheDocument()
-    expect(screen.getByText('Equipo de soporte')).toBeInTheDocument()
+    expect(screen.getAllByText('Soporte Central').length).toBeGreaterThan(0)
+    expect(screen.getByText('Soporte')).toBeInTheDocument()
+    expect(screen.queryByText('Equipo de soporte')).not.toBeInTheDocument()
     expect(screen.getByLabelText(/Respuesta/i)).toHaveAttribute('name', 'body')
     expect(screen.queryByLabelText(/Respuesta del equipo/i)).not.toBeInTheDocument()
     expect(screen.queryByLabelText(/Nuevo estado/i)).not.toBeInTheDocument()

--- a/__tests__/docs/support-operations.test.ts
+++ b/__tests__/docs/support-operations.test.ts
@@ -24,4 +24,10 @@ describe('support operations runbook', () => {
   it('documents the external inbound support event name', () => {
     expect(runbook).toContain('support/external.update.received')
   })
+
+  it('documents that /api/inngest is a custom webhook, not official Inngest SDK runs', () => {
+    expect(runbook).toContain('does **not** use the official Inngest SDK')
+    expect(runbook).toContain('/api/inngest')
+    expect(runbook).toContain('not an official Inngest SDK run')
+  })
 })

--- a/__tests__/lib/actions/support.actions.test.ts
+++ b/__tests__/lib/actions/support.actions.test.ts
@@ -12,9 +12,11 @@ import { sanitizeSupportEvidence } from '@/lib/support/support-evidence'
 import { dispatchSupportInngestEvent } from '@/lib/support/inngest'
 
 const createSupabaseServerClient = jest.fn()
+const createSupabaseAdminClient = jest.fn()
 const revalidatePath = jest.fn()
 
 jest.mock('@/lib/supabase/server', () => ({ createSupabaseServerClient: () => createSupabaseServerClient() }))
+jest.mock('@/lib/supabase/admin', () => ({ createSupabaseAdminClient: () => createSupabaseAdminClient() }))
 jest.mock('next/cache', () => ({ revalidatePath: (path: string) => revalidatePath(path) }))
 jest.mock('@/lib/support/inngest', () => ({
   createSupportTicketCreatedEvent: (payload: { eventId: string; ticketId: string; actorUserId?: string }) => ({
@@ -30,6 +32,7 @@ const dispatchSupportInngestEventMock = jest.mocked(dispatchSupportInngestEvent)
 describe('support reporter actions', () => {
   beforeEach(() => {
     createSupabaseServerClient.mockReset()
+    createSupabaseAdminClient.mockReset()
     dispatchSupportInngestEventMock.mockReset()
     revalidatePath.mockReset()
   })
@@ -204,6 +207,35 @@ describe('support reporter actions', () => {
     expect(attachmentsQuery.select).toHaveBeenCalledWith('id,original_filename,kind,content_type,byte_size,status')
     expect(attachmentsFilter.eq).toHaveBeenCalledWith('ticket_id', 'ticket-1')
     expect(attachmentsFilter.eq).toHaveBeenCalledWith('status', 'uploaded')
+  })
+
+  it('hydrates assigned staff and staff message profiles when reporter RLS omits embedded usuarios', async () => {
+    const ticketQuery = { select: jest.fn().mockReturnValue({ eq: jest.fn().mockReturnValue({ maybeSingle: jest.fn().mockResolvedValue({ data: { id: 'ticket-1', ticket_number: 42, title: 'Map bug', description: 'Steps', status: 'in_progress', category: 'bug', severity: 'normal', reporter_usuario_id: 'usuario-1', assignee_usuario_id: 'staff-1', reporter: { id: 'usuario-1', nombre: 'Ana', apellido: 'Pérez', foto_perfil_url: null }, assignee: null, current_route: '/dashboard', browser_name: 'Chrome', os_name: 'macOS', viewport: '1440x900', app_build_version: 'build-123', sentry_event_id: 'event-1', diagnostics_consent: true, created_at: '2026-06-09T00:00:00Z', updated_at: '2026-06-09T00:00:00Z' }, error: null }) }) }) }
+    const messagesFilter = { eq: jest.fn(), order: jest.fn().mockResolvedValue({ data: [{ id: 'message-1', body: 'Support reply', author_usuario_id: 'staff-1', author: null, is_internal: false, created_at: '2026-06-09T00:01:00Z' }], error: null }) }
+    messagesFilter.eq.mockReturnValue(messagesFilter)
+    const attachmentsFilter = { eq: jest.fn(), order: jest.fn().mockResolvedValue({ data: [], error: null }) }
+    attachmentsFilter.eq.mockReturnValue(attachmentsFilter)
+    const capabilitiesFilter = { eq: jest.fn(), is: jest.fn().mockResolvedValue({ data: [], error: null }) }
+    capabilitiesFilter.eq.mockReturnValue(capabilitiesFilter)
+    createSupabaseServerClient.mockResolvedValue({
+      auth: { getUser: jest.fn().mockResolvedValue({ data: { user: { id: 'auth-1' } } }) },
+      from: jest.fn((table) => {
+        if (table === 'usuarios') return { select: jest.fn().mockReturnValue({ eq: jest.fn().mockReturnValue({ maybeSingle: jest.fn().mockResolvedValue({ data: { id: 'usuario-1' }, error: null }) }) }) }
+        if (table === 'support_tickets') return ticketQuery
+        if (table === 'support_ticket_messages') return { select: jest.fn().mockReturnValue(messagesFilter) }
+        if (table === 'support_user_capabilities') return { select: jest.fn().mockReturnValue(capabilitiesFilter) }
+        return { select: jest.fn().mockReturnValue(attachmentsFilter) }
+      }),
+    })
+    const adminIn = jest.fn().mockResolvedValue({ data: [{ id: 'staff-1', nombre: 'Sofia', apellido: 'Soporte', foto_perfil_url: 'https://cdn.example/staff.webp' }], error: null })
+    createSupabaseAdminClient.mockReturnValue({ from: jest.fn().mockReturnValue({ select: jest.fn().mockReturnValue({ in: adminIn }) }) })
+
+    const result = await getSupportTicketDetail('ticket-1')
+
+    expect(result.success).toBe(true)
+    expect(result.ticket?.assignee).toEqual({ id: 'staff-1', nombre: 'Sofia', apellido: 'Soporte', photoUrl: 'https://cdn.example/staff.webp' })
+    expect(result.ticket?.messages[0].author).toEqual({ id: 'staff-1', nombre: 'Sofia', apellido: 'Soporte', photoUrl: 'https://cdn.example/staff.webp' })
+    expect(adminIn).toHaveBeenCalledWith('id', ['staff-1'])
   })
 
   it('maps Supabase list errors to a stable user-safe message', async () => {

--- a/app/(auth)/ayuda/tickets/[id]/page.tsx
+++ b/app/(auth)/ayuda/tickets/[id]/page.tsx
@@ -113,7 +113,7 @@ export default async function TicketDetailPage({ params }: { params: Promise<{ i
                     <div className="space-y-3">
                       {ticket.messages.map((message) => {
                         const isReporter = isReporterMessage(message.authorUsuarioId, ticket.reporterUsuarioId)
-                        const roleLabel = isReporter ? 'Solicitante' : 'Equipo de soporte'
+                        const roleLabel = isReporter ? 'Solicitante' : 'Soporte'
                         const participant = createParticipant(message.author, roleLabel)
 
                         return <MessageBubble key={message.id} message={message} participant={participant} roleLabel={roleLabel} isReporter={isReporter} />
@@ -146,14 +146,15 @@ export default async function TicketDetailPage({ params }: { params: Promise<{ i
                     <TextoSistema variante="sutil">No hay adjuntos finalizados.</TextoSistema>
                   ) : ticket.attachments.map((attachment) => (
                     <div key={attachment.id} className="rounded-2xl border border-border bg-muted/20 p-3">
+                      <AttachmentPreview attachment={attachment} />
                       <div className="min-w-0">
                         <p className="truncate text-sm font-semibold text-foreground">{attachment.filename}</p>
                         <TextoSistema variante="muted" tamaño="sm">{formatAttachmentKind(attachment.kind)} · {formatBytes(attachment.byteSize)}</TextoSistema>
                         <TextoSistema variante="muted" tamaño="sm">{attachment.contentType} · {formatAttachmentStatus(attachment.status)}</TextoSistema>
                       </div>
                       {attachment.status === 'uploaded' && (
-                        <a href={`/api/support/attachments/${attachment.id}/download`} aria-label={`Descargar ${attachment.filename}`} className="mt-3 inline-flex min-h-10 items-center rounded-xl border border-border px-3 text-sm font-medium text-[var(--brand-primary)] transition-colors hover:bg-card">
-                          Descargar archivo
+                        <a href={getAttachmentRoute(attachment.id)} aria-label={`Abrir ${attachment.filename}`} className="mt-3 inline-flex min-h-10 items-center rounded-xl border border-border px-3 text-sm font-medium text-[var(--brand-primary)] transition-colors hover:bg-card">
+                          Abrir archivo
                         </a>
                       )}
                     </div>
@@ -221,6 +222,34 @@ type TicketMessage = {
   createdAt: string
 }
 
+type TicketAttachment = {
+  id: string
+  filename: string
+  kind: string
+  contentType: string
+  byteSize: number
+  status: string
+}
+
+function AttachmentPreview({ attachment }: { attachment: TicketAttachment }) {
+  if (attachment.status !== 'uploaded') return null
+
+  const route = getAttachmentRoute(attachment.id)
+  if (isPreviewableImage(attachment.contentType)) {
+    return <img src={route} alt={`Vista previa de ${attachment.filename}`} className="mb-3 aspect-video w-full rounded-xl border border-border bg-card object-contain" loading="lazy" />
+  }
+
+  if (isPreviewableVideo(attachment.contentType)) {
+    return <video src={route} aria-label={`Vista previa de ${attachment.filename}`} className="mb-3 aspect-video w-full rounded-xl border border-border bg-black" controls preload="metadata" />
+  }
+
+  return null
+}
+
+function getAttachmentRoute(attachmentId: string) {
+  return `/api/support/attachments/${attachmentId}/download`
+}
+
 function MessageBubble({ message, participant, roleLabel, isReporter }: { message: TicketMessage; participant: Participant; roleLabel: string; isReporter: boolean }) {
   return (
     <article className={`flex gap-2.5 ${isReporter ? 'justify-start' : 'justify-end'}`}>
@@ -267,6 +296,14 @@ function formatAttachmentStatus(status: string) {
 
 function formatAttachmentKind(kind: string) {
   return kind === 'video' ? 'Video' : 'Captura'
+}
+
+function isPreviewableImage(contentType: string) {
+  return ['image/png', 'image/jpeg', 'image/webp'].includes(contentType)
+}
+
+function isPreviewableVideo(contentType: string) {
+  return ['video/mp4', 'video/webm', 'video/quicktime'].includes(contentType)
 }
 
 function formatBytes(byteSize: number) {

--- a/docs/support-operations.md
+++ b/docs/support-operations.md
@@ -62,14 +62,16 @@ Operational limits from code and spec:
 - Total active attachments per ticket: max 150 MB.
 - Object keys follow `support/{ticket_id}/{attachment_id}/{safe_filename}`; object keys are not authorization proof.
 
-### Inngest
+### Support event webhook (`/api/inngest`)
+
+The current app does **not** use the official Inngest SDK or real Inngest function registry. `package.json` has no `inngest` dependency. `/api/inngest` is a custom authenticated bearer webhook that accepts the support event shape below and then invokes local notification delivery helpers. Do not report provider dashboard run counts as application truth unless this is later replaced with a real Inngest SDK integration.
 
 | Setting | Required | Notes |
 |---------|----------|-------|
 | Event names | Yes | `support/ticket.created`, `support/ticket.message.created`, `support/ticket.status.changed`, `support/attachment.finalized`, `support/external.update.received`. |
 | Payload shape | Yes | IDs only: `eventId`, `ticketId`, optional `actorUserId`, and relevant message or attachment IDs. |
 | Idempotency | Yes | Email keys use `email:{eventId}:{recipient}`. Preserve this shape in any worker integration. |
-| Provider credentials | Future wiring | The current support module defines event contracts and email dispatch helpers; provider-specific live Inngest client wiring must be reviewed before enabling. |
+| Provider credentials | Custom webhook only | `SUPPORT_INNGEST_EVENT_URL` and `SUPPORT_INNGEST_WEBHOOK_SECRET` post to the app route. Official Inngest app/function credentials are not wired. |
 
 Workers must fetch ticket data server-side, avoid long user text in events, and never include evidence, attachment URLs, R2 keys, raw Sentry payloads, diagnostics, cookies, tokens, emails beyond the intended recipient, phone numbers, church/member details, or database internals in queued payloads.
 
@@ -118,7 +120,7 @@ Required environment keys, without values:
 |-------|---------------|-------------------|
 | Global guard | `RLS_ENV=staging` | Script refuses non-staging execution before provider calls. |
 | Protected Vercel preview routes | `VERCEL_AUTOMATION_BYPASS_SECRET` when `SUPPORT_SMOKE_BASE_URL` is behind Vercel Deployment Protection | The route smoke requests include `x-vercel-protection-bypass` so Vercel allows the request to reach app auth. Do not use this key for direct provider checks. |
-| Inngest route | `SUPPORT_SMOKE_BASE_URL`, `SUPPORT_INNGEST_WEBHOOK_SECRET` | `/api/inngest` rejects missing/invalid auth and accepts a signed ID-only support event with HTTP 202. |
+| Support event webhook | `SUPPORT_SMOKE_BASE_URL`, `SUPPORT_INNGEST_WEBHOOK_SECRET` | `/api/inngest` rejects missing/invalid auth and accepts a signed ID-only support event with HTTP 202; this is not an official Inngest SDK run. |
 | External bridge | `SUPPORT_SMOKE_BASE_URL`, `SUPPORT_EXTERNAL_BRIDGE_TOKEN`, `SUPPORT_EXTERNAL_BRIDGE_AUTHOR_USUARIO_ID`, `SUPPORT_SMOKE_TICKET_ID` | `/api/support/external/inbound` rejects invalid auth, accepts one sanitized staging update, and treats the duplicate idempotency key as duplicate. |
 | R2 direct provider | `R2_ACCOUNT_ID`, `R2_ACCESS_KEY_ID`, `R2_SECRET_ACCESS_KEY` | Private support bucket accepts one smoke PUT, returns matching bytes on GET, and deletes the smoke object in cleanup. |
 | Resend | `RESEND_API_KEY`, `SUPPORT_SMOKE_EMAIL_TO`, optional `RESEND_FROM_NAME`, `RESEND_FROM_EMAIL` | Resend accepts a staging-safe notification email with no evidence, attachments, diagnostics, secrets, object keys, or user PII. |

--- a/lib/actions/support.actions.ts
+++ b/lib/actions/support.actions.ts
@@ -5,6 +5,7 @@ import { z } from 'zod'
 
 import { diagnosticsConsentSchema, sanitizeSupportEvidence } from '@/lib/support/support-evidence'
 import { createSupportTicketCreatedEvent, dispatchSupportInngestEvent } from '@/lib/support/inngest'
+import { createSupabaseAdminClient } from '@/lib/supabase/admin'
 import { createSupabaseServerClient } from '@/lib/supabase/server'
 
 const SUPPORT_TICKET_STATUSES = ['received', 'in_review', 'in_progress', 'resolved', 'closed'] as const
@@ -256,7 +257,8 @@ export async function getSupportTicketDetail(ticketId: string) {
 
   if (attachmentsError) return { success: false, error: SUPPORT_TICKET_DETAIL_ERROR }
   const supportCapabilities = await listActorSupportCapabilities(supabase, actor.usuarioId)
-  return { success: true, ticket: toTicketDetail(ticket as SupportTicketRow, messages ?? [], attachments ?? [], supportCapabilities) }
+  const profiles = await fetchVisibleSupportProfiles(ticket as SupportTicketRow, messages ?? [])
+  return { success: true, ticket: toTicketDetail(ticket as SupportTicketRow, messages ?? [], attachments ?? [], supportCapabilities, profiles) }
 }
 
 export async function createSupportTicketMessage(ticketId: string, formData: FormData) {
@@ -381,18 +383,49 @@ function toTicketSummary(ticket: Omit<SupportTicketRow, 'description' | 'reporte
   return { id: ticket.id, ticketNumber: ticket.ticket_number, title: ticket.title, status: ticket.status, category: ticket.category, severity: ticket.severity, createdAt: ticket.created_at, updatedAt: ticket.updated_at }
 }
 
-function toTicketDetail(ticket: SupportTicketRow, messages: SupportMessageRow[], attachments: SupportAttachmentRow[], supportCapabilities: SupportCapability[]) {
+function toTicketDetail(ticket: SupportTicketRow, messages: SupportMessageRow[], attachments: SupportAttachmentRow[], supportCapabilities: SupportCapability[], profiles: Map<string, UsuarioProfileRow> = new Map()) {
   return {
     ...toTicketSummary(ticket),
     description: ticket.description,
     reporterUsuarioId: ticket.reporter_usuario_id,
     assigneeUsuarioId: ticket.assignee_usuario_id,
-    reporter: toSafeUsuarioProfile(ticket.reporter),
-    assignee: toSafeUsuarioProfile(ticket.assignee),
+    reporter: toSafeUsuarioProfile(ticket.reporter ?? profiles.get(ticket.reporter_usuario_id)),
+    assignee: toSafeUsuarioProfile(ticket.assignee ?? (ticket.assignee_usuario_id ? profiles.get(ticket.assignee_usuario_id) : null)),
     evidence: { currentRoute: ticket.current_route, browserName: ticket.browser_name, osName: ticket.os_name, viewport: ticket.viewport, appBuildVersion: ticket.app_build_version, sentryEventId: ticket.sentry_event_id, diagnosticsConsent: ticket.diagnostics_consent },
-    messages: messages.map((message) => ({ id: message.id, body: message.body, authorUsuarioId: message.author_usuario_id, author: toSafeUsuarioProfile(message.author), createdAt: message.created_at })),
+    messages: messages.map((message) => ({ id: message.id, body: message.body, authorUsuarioId: message.author_usuario_id, author: toSafeUsuarioProfile(message.author ?? profiles.get(message.author_usuario_id)), createdAt: message.created_at })),
     attachments: attachments.map((attachment) => ({ id: attachment.id, filename: attachment.original_filename, kind: attachment.kind, contentType: attachment.content_type, byteSize: attachment.byte_size, status: attachment.status })),
     supportCapabilities,
+  }
+}
+
+async function fetchVisibleSupportProfiles(ticket: SupportTicketRow, messages: SupportMessageRow[]) {
+  const profileIds = new Set<string>([ticket.reporter_usuario_id])
+  const profiles = new Map<string, UsuarioProfileRow>()
+  if (ticket.reporter) profiles.set(ticket.reporter.id, ticket.reporter)
+  if (ticket.assignee) profiles.set(ticket.assignee.id, ticket.assignee)
+
+  if (ticket.assignee_usuario_id) profileIds.add(ticket.assignee_usuario_id)
+  for (const message of messages) {
+    profileIds.add(message.author_usuario_id)
+    if (message.author) profiles.set(message.author.id, message.author)
+  }
+
+  const missingProfileIds = [...profileIds].filter((id) => !profiles.has(id))
+
+  if (missingProfileIds.length === 0) return profiles
+
+  try {
+    const admin = createSupabaseAdminClient()
+    const { data, error } = await admin
+      .from('usuarios')
+      .select('id,nombre,apellido,foto_perfil_url')
+      .in('id', missingProfileIds)
+
+    if (error) return profiles
+    for (const profile of data ?? []) profiles.set(profile.id, profile as UsuarioProfileRow)
+    return profiles
+  } catch {
+    return profiles
   }
 }
 

--- a/lib/support/r2-routes.ts
+++ b/lib/support/r2-routes.ts
@@ -100,20 +100,25 @@ export async function supportAttachmentFinalizeRoute(request: Request) {
   return NextResponse.json(result.body, { status: result.status })
 }
 
-export async function supportAttachmentDownloadRoute(_request: Request, attachmentId: string) {
+export async function supportAttachmentDownloadRoute(request: Request, attachmentId: string) {
   const { NextResponse } = await import('next/server')
   const result = await getAttachmentDownloadResult(attachmentId)
   if (result.status !== 200) return NextResponse.json(result.body, { status: result.status })
   const downloadUrl = typeof result.body.downloadUrl === 'string' ? result.body.downloadUrl : null
   if (!downloadUrl) return NextResponse.json({ error: 'Attachment not available' }, { status: 403 })
-  const response = await fetch(downloadUrl)
+  const range = request.headers?.get('range')
+  const response = await fetch(downloadUrl, range ? { headers: { range } } : undefined)
   if (!response.ok) return NextResponse.json({ error: 'Attachment download failed' }, { status: 502 })
   return new Response(response.body ?? await response.arrayBuffer(), {
-    status: 200,
+    status: response.status === 206 ? 206 : 200,
     headers: {
       'content-type': response.headers.get('content-type') ?? 'application/octet-stream',
-      'content-disposition': 'attachment',
+      'content-disposition': 'inline',
       'cache-control': 'no-store',
+      'x-content-type-options': 'nosniff',
+      'accept-ranges': response.headers.get('accept-ranges') ?? 'bytes',
+      ...(response.headers.get('content-range') ? { 'content-range': response.headers.get('content-range') ?? '' } : {}),
+      ...(response.headers.get('content-length') ? { 'content-length': response.headers.get('content-length') ?? '' } : {}),
     },
   })
 }


### PR DESCRIPTION
Closes #154

## Summary
- Shows assigned staff and support reply identity/photo in requester ticket detail views.
- Adds inline previews for image/video support attachments through the authorized app route.
- Documents that `/api/inngest` is a custom bearer-auth webhook, not official Inngest SDK telemetry.

## Changes
| File | Change |
|------|--------|
| `lib/actions/support.actions.ts` | Hydrates authorized assignee/staff profile details for requester-visible ticket context. |
| `app/(auth)/ayuda/tickets/[id]/page.tsx` | Renders staff identity/avatar and attachment previews. |
| `lib/support/r2-routes.ts` | Supports inline attachment responses, range forwarding for video, and `nosniff`. |
| `docs/support-operations.md` | Clarifies current Inngest-like route behavior. |
| tests | Cover staff identity, assignee hydration, attachment preview route behavior, and docs wording. |

## Test Plan
- [x] `pnpm test -- __tests__/app/support-pages.test.tsx __tests__/lib/actions/support.actions.test.ts __tests__/app/support-attachments-route.test.ts __tests__/docs/support-operations.test.ts --runInBand`
- [x] `git diff --check`
- [x] Fresh-context review passed with no blockers.

## Author Checklist
- [x] Linked an approved issue
- [x] Added exactly one type label
- [x] Conventional commit format
- [x] No secrets or sensitive values committed
- [x] Private R2 object keys/signed URLs are not exposed in UI
