### PR TITLE
feat(support): dispatch tickets to Hermes

### DIFF
--- a/__tests__/docs/support-operations.test.ts
+++ b/__tests__/docs/support-operations.test.ts
@@ -32,9 +32,16 @@ describe('support operations runbook', () => {
     expect(runbook).toContain('compatibility custom webhook')
   })
 
-  it('documents the staged Hermes foundation without live outbound dispatch', () => {
+  it('documents Hermes outbound dispatch controls and PR 2 scope boundaries', () => {
     expect(runbook).toContain('support/hermes.escalation.requested')
     expect(runbook).toContain('/api/support/external/inbound')
-    expect(runbook).toContain('Live outbound HTTP dispatch to Hermes is deferred to PR 2')
+    expect(runbook).toContain('SUPPORT_HERMES_DISPATCH_MODE')
+    expect(runbook).toContain('SUPPORT_HERMES_WEBHOOK_URL')
+    expect(runbook).toContain('SUPPORT_HERMES_WEBHOOK_SECRET')
+    expect(runbook).toContain('event_type')
+    expect(runbook).toContain('ID-first for PR 2')
+    expect(runbook).toContain('future staff-reviewed safe-summary field')
+    expect(runbook).toContain('Do not rely on `X-Hermes-Event`')
+    expect(runbook).toContain('Inbound callbacks/actions from Hermes are not part of this PR')
   })
 })

--- a/__tests__/lib/support/external-bridge.test.ts
+++ b/__tests__/lib/support/external-bridge.test.ts
@@ -4,9 +4,24 @@ import {
   sanitizeExternalBridgeMessage,
   verifyExternalBridgeAuthorization,
 } from '@/lib/support/external-bridge'
-import { createHermesEscalationRequestedEvent, dispatchHermesEscalationRequest } from '@/lib/support/hermes'
+import { createSupportTicketCreatedEvent } from '@/lib/support/inngest'
+import {
+  createHermesEscalationRequestedEvent,
+  createHermesTicketCreatedPayload,
+  dispatchHermesEscalationRequest,
+  dispatchHermesTicketCreated,
+} from '@/lib/support/hermes'
 
 describe('support external bridge', () => {
+  beforeEach(() => {
+    delete process.env.SUPPORT_HERMES_DISPATCH_MODE
+    delete process.env.SUPPORT_HERMES_WEBHOOK_URL
+    delete process.env.SUPPORT_HERMES_WEBHOOK_SECRET
+    delete process.env.SUPPORT_HERMES_TIMEOUT_MS
+    delete process.env.NEXT_PUBLIC_SITE_URL
+    delete process.env.VERCEL_ENV
+  })
+
   it('creates sanitized outbound escalation payloads without diagnostics, attachments, signed URLs, object keys, or GitHub sync fields', () => {
     const payload = createExternalEscalationPayload({
       ticketId: 'ticket-1',
@@ -73,6 +88,134 @@ describe('support external bridge', () => {
       eventId: 'event-hermes-1',
       reason: 'Hermes live outbound dispatch is deferred',
     })
+  })
+
+  it('skips Hermes ticket-created HTTP dispatch in disabled and dry-run modes', async () => {
+    const fetchMock = jest.fn()
+    const event = createSupportTicketCreatedEvent({ eventId: 'event-created-1', ticketId: 'ticket-1' })
+
+    await expect(dispatchHermesTicketCreated(event, { mode: 'disabled', fetch: fetchMock })).resolves.toEqual({
+      success: true,
+      skipped: true,
+      reason: 'Hermes ticket dispatch disabled',
+    })
+
+    await expect(dispatchHermesTicketCreated(event, { fetch: fetchMock })).resolves.toEqual({
+      success: true,
+      skipped: true,
+      dryRun: true,
+      eventId: 'event-created-1',
+      deliveryId: 'global-connect:event-created-1',
+      reason: 'Hermes ticket dispatch dry-run',
+    })
+    expect(fetchMock).not.toHaveBeenCalled()
+  })
+
+  it('requires Hermes URL and secret before live ticket-created dispatch', async () => {
+    const fetchMock = jest.fn()
+    const event = createSupportTicketCreatedEvent({ eventId: 'event-created-1', ticketId: 'ticket-1' })
+
+    await expect(dispatchHermesTicketCreated(event, { mode: 'live', fetch: fetchMock })).rejects.toThrow(
+      'Hermes live dispatch is missing SUPPORT_HERMES_WEBHOOK_URL or SUPPORT_HERMES_WEBHOOK_SECRET'
+    )
+    expect(fetchMock).not.toHaveBeenCalled()
+  })
+
+  it('sends Hermes ticket-created event_type in the body without relying on X-Hermes-Event', async () => {
+    const fetchMock = jest.fn().mockResolvedValue({ ok: true, status: 202 })
+    const event = createSupportTicketCreatedEvent({ eventId: 'event-created-1', ticketId: 'ticket-1', actorUserId: 'user-1' })
+
+    await expect(dispatchHermesTicketCreated(event, {
+      mode: 'live',
+      webhookUrl: 'https://hermes.example.test/webhooks/support-ticket',
+      webhookSecret: 'test-webhook-secret',
+      fetch: fetchMock,
+    })).resolves.toEqual({ success: true, status: 202, deliveryId: 'global-connect:event-created-1' })
+
+    const [, request] = fetchMock.mock.calls[0]
+    const body = JSON.parse(request.body)
+    expect(body).toMatchObject({
+      event_type: 'ticket.created',
+      delivery_id: 'global-connect:event-created-1',
+      ticket: {
+        id: 'ticket-1',
+        internalUrl: '/ayuda/tickets/ticket-1',
+      },
+      source: { system: 'global-connect', environment: 'test' },
+    })
+    expect(body.ticket).not.toHaveProperty('number')
+    expect(body.ticket).not.toHaveProperty('title')
+    expect(body.ticket).not.toHaveProperty('category')
+    expect(body.ticket).not.toHaveProperty('priority')
+    expect(body.ticket).not.toHaveProperty('body')
+    expect(body).not.toHaveProperty('reporter')
+    expect(JSON.stringify(body)).not.toMatch(/Map fails|Open map|token|reporter@example|createdAt/i)
+    expect(request.headers).toEqual({ authorization: 'Bearer test-webhook-secret', 'content-type': 'application/json' })
+    expect(request.headers).not.toHaveProperty('X-Hermes-Event')
+  })
+
+  it('builds ID-first Hermes payloads without raw ticket fields or forbidden sensitive data', () => {
+    const event = createSupportTicketCreatedEvent({ eventId: 'event-created-1', ticketId: 'ticket-1', actorUserId: 'user-1' })
+    const payload = createHermesTicketCreatedPayload(event)
+    const serialized = JSON.stringify(payload)
+
+    expect(payload).toEqual({
+      event_type: 'ticket.created',
+      delivery_id: 'global-connect:event-created-1',
+      ticket: { id: 'ticket-1', internalUrl: '/ayuda/tickets/ticket-1' },
+      source: { system: 'global-connect', environment: 'test' },
+    })
+    expect(payload.ticket).not.toHaveProperty('title')
+    expect(payload.ticket).not.toHaveProperty('body')
+    expect(payload).not.toHaveProperty('reporter')
+    expect(serialized).not.toMatch(/reporter@example\.com|555 555|cookie=session|support\/ticket-1\/attachment|signature=secret|signedUrl|diagnostics|rawSentry|headers|cookies|token|Need support|Email reporter/i)
+  })
+
+  it('rejects invalid Hermes event IDs before dispatch', async () => {
+    const fetchMock = jest.fn()
+    const missingEventId = createSupportTicketCreatedEvent({ eventId: '', ticketId: 'ticket-1' })
+    const invalidTicketId = createSupportTicketCreatedEvent({ eventId: 'event-created-1', ticketId: 'ticket 1' })
+
+    expect(() => createHermesTicketCreatedPayload(missingEventId)).toThrow('Hermes ticket dispatch requires a valid eventId')
+    await expect(dispatchHermesTicketCreated(invalidTicketId, {
+      mode: 'live',
+      webhookUrl: 'https://hermes.example.test/webhooks/support-ticket',
+      webhookSecret: 'test-webhook-secret',
+      fetch: fetchMock,
+    })).rejects.toThrow('Hermes ticket dispatch requires a valid ticketId')
+    expect(fetchMock).not.toHaveBeenCalled()
+  })
+
+  it('throws on Hermes ticket-created fetch failures so Inngest can retry', async () => {
+    const fetchMock = jest.fn().mockResolvedValue({ ok: false, status: 503 })
+    const event = createSupportTicketCreatedEvent({ eventId: 'event-created-1', ticketId: 'ticket-1' })
+
+    await expect(dispatchHermesTicketCreated(event, {
+      mode: 'live',
+      webhookUrl: 'https://hermes.example.test/webhooks/support-ticket',
+      webhookSecret: 'test-webhook-secret',
+      fetch: fetchMock,
+    })).rejects.toThrow('Hermes ticket dispatch failed with status 503')
+  })
+
+  it('aborts live Hermes ticket-created dispatch after the configured timeout', async () => {
+    jest.useFakeTimers()
+    const event = createSupportTicketCreatedEvent({ eventId: 'event-created-1', ticketId: 'ticket-1' })
+    const fetchMock: typeof fetch = jest.fn((_url: RequestInfo | URL, init?: RequestInit) => new Promise<Response>((_resolve, reject) => {
+      init?.signal?.addEventListener('abort', () => reject(new Error('aborted')))
+    }))
+
+    const result = dispatchHermesTicketCreated(event, {
+      mode: 'live',
+      webhookUrl: 'https://hermes.example.test/webhooks/support-ticket',
+      webhookSecret: 'test-webhook-secret',
+      timeoutMs: 25,
+      fetch: fetchMock,
+    })
+    jest.advanceTimersByTime(25)
+
+    await expect(result).rejects.toThrow('aborted')
+    jest.useRealTimers()
   })
 
   it('authenticates inbound updates with a constant bearer token comparison', () => {

--- a/docs/support-operations.md
+++ b/docs/support-operations.md
@@ -76,11 +76,22 @@ The app retains `/api/inngest` as a custom authenticated bearer webhook for comp
 
 Workers must fetch ticket data server-side, avoid long user text in events, and never include evidence, attachment URLs, R2 keys, raw Sentry payloads, diagnostics, cookies, tokens, emails beyond the intended recipient, phone numbers, church/member details, or database internals in queued payloads.
 
-### Hermes escalation foundation
+### Hermes outbound dispatch
 
-Hermes support agent integration is a PR 1 contract only. The ID-first event is `support/hermes.escalation.requested`, and the current dispatch helper is dry-run/no-op by default. Live outbound HTTP dispatch to Hermes is deferred to PR 2.
+PR 2 adds outbound Global Connect to Hermes ticket-created dispatch through the official Inngest `support/ticket.created` worker. Inbound callbacks/actions from Hermes are not part of this PR, live Hermes remains disabled unless explicitly configured, and Global Connect must not create GitHub issues.
 
-The sanitized outbound shape contains ticket id, ticket number, title, staff-written summary, recipient, internal ticket URL, idempotency key, and callback URL. The callback remains the audited inbound path `/api/support/external/inbound`. Do not include diagnostics, attachment metadata, signed URLs, R2 object keys, raw Sentry payloads, tokens, cookies, GitHub sync fields, or secret values.
+| Variable | Required | Notes |
+|----------|----------|-------|
+| `SUPPORT_HERMES_DISPATCH_MODE` | Optional | `disabled`, `dry-run`, or `live`. Defaults to `dry-run`, so no network call is made by default. |
+| `SUPPORT_HERMES_WEBHOOK_URL` | Required only for `live` | Hermes route is `POST /webhooks/support-ticket`. |
+| `SUPPORT_HERMES_WEBHOOK_SECRET` | Required only for `live` | Server-only bearer secret. Never log or return this value. |
+| `SUPPORT_HERMES_TIMEOUT_MS` | Optional | Bounded HTTP timeout for live dispatch; defaults to a short safe value. |
+
+Hermes uses `event_type` in the JSON body for routing. Do not rely on `X-Hermes-Event`; Hermes ignored that header in smoke verification.
+
+The `ticket.created` payload is minimal and ID-first for PR 2: `event_type`, stable `delivery_id` shaped as `global-connect:{eventId}`, `ticket.id`, `ticket.internalUrl`, and source system/environment. It must not include raw support titles, descriptions, message bodies, reporter names, emails, phone numbers, church/member details, tokens, cookies, headers, raw Sentry data, diagnostics, signed URLs, R2 object keys, attachment data, GitHub sync fields, or secret values. Hermes can use the internal ticket URL now; callbacks or a future staff-reviewed safe-summary field can enrich later.
+
+The legacy `support/hermes.escalation.requested` foundation event remains a dry-run escalation contract for future reviewed work. The audited inbound path `/api/support/external/inbound` is documented for the existing bridge only; Hermes inbound callbacks/actions are out of scope for this PR.
 
 ### Resend
 
@@ -197,7 +208,7 @@ Operators and reviewers should confirm each item before enabling or reviewing th
 - [ ] Resend sender domain and `NEXT_PUBLIC_SITE_URL` produce authenticated support links for the target environment.
 - [ ] `/api/inngest` still preserves current custom webhook behavior, while `/api/inngest/official` remains the isolated official SDK foundation.
 - [ ] Inngest support events contain IDs only and preserve idempotency keys.
-- [ ] Hermes escalation remains dry-run/no-op until PR 2 live outbound review.
+- [ ] Hermes ticket-created outbound remains `dry-run` or `disabled` unless a reviewed environment explicitly sets `SUPPORT_HERMES_DISPATCH_MODE=live` with server-only URL and secret values.
 - [ ] Email templates exclude evidence, attachments, diagnostics, raw Sentry, R2 keys, GitHub data, and long user text.
 - [ ] Sentry support privacy defaults remain scrubbed and replay is not captured by default.
 - [ ] Rollback plan starts with hiding feature entry points and disabling side effects, not dropping production data.

--- a/lib/support/hermes.ts
+++ b/lib/support/hermes.ts
@@ -3,10 +3,17 @@ import {
   type ExternalEscalationInput,
   type ExternalEscalationPayload,
 } from '@/lib/support/external-bridge'
+import type { SupportInngestEvent } from '@/lib/support/inngest'
 
 export const SUPPORT_HERMES_EVENTS = {
   escalationRequested: 'support/hermes.escalation.requested',
 } as const
+
+export const SUPPORT_HERMES_TICKET_CREATED_EVENT_TYPE = 'ticket.created'
+
+const DEFAULT_HERMES_TIMEOUT_MS = 5000
+const MAX_HERMES_TIMEOUT_MS = 30000
+const SUPPORT_EVENT_ID_PATTERN = /^[A-Za-z0-9._-]+$/
 
 export type SupportHermesEscalationRequestedEvent = {
   name: typeof SUPPORT_HERMES_EVENTS.escalationRequested
@@ -18,7 +25,20 @@ export type SupportHermesEscalationRequestedEvent = {
   }
 }
 
-export type HermesDispatchMode = 'dry-run' | 'disabled'
+export type HermesDispatchMode = 'dry-run' | 'disabled' | 'live'
+
+export type HermesTicketCreatedPayload = {
+  event_type: typeof SUPPORT_HERMES_TICKET_CREATED_EVENT_TYPE
+  delivery_id: string
+  ticket: {
+    id: string
+    internalUrl: string
+  }
+  source: {
+    system: 'global-connect'
+    environment: 'preview' | 'production' | 'development' | 'test'
+  }
+}
 
 type CreateHermesEscalationRequestedEventInput = ExternalEscalationInput & {
   eventId: string
@@ -26,6 +46,14 @@ type CreateHermesEscalationRequestedEventInput = ExternalEscalationInput & {
 
 type DispatchHermesEscalationOptions = {
   mode?: HermesDispatchMode
+}
+
+type DispatchHermesTicketCreatedOptions = {
+  mode?: HermesDispatchMode
+  webhookUrl?: string
+  webhookSecret?: string
+  timeoutMs?: number
+  fetch?: typeof fetch
 }
 
 export function createHermesEscalationRequestedEvent(input: CreateHermesEscalationRequestedEventInput): SupportHermesEscalationRequestedEvent {
@@ -59,6 +87,110 @@ export async function dispatchHermesEscalationRequest(
   }
 }
 
+export async function dispatchHermesTicketCreated(
+  event: SupportInngestEvent<'support/ticket.created', { eventId: string; ticketId: string; actorUserId?: string }>,
+  options: DispatchHermesTicketCreatedOptions = {}
+) {
+  const mode = options.mode ?? readHermesDispatchMode()
+
+  if (mode === 'disabled') {
+    return { success: true as const, skipped: true as const, reason: 'Hermes ticket dispatch disabled' }
+  }
+
+  const payload = createHermesTicketCreatedPayload(event)
+
+  if (mode === 'dry-run') {
+    return {
+      success: true as const,
+      skipped: true as const,
+      dryRun: true as const,
+      eventId: event.data.eventId,
+      deliveryId: payload.delivery_id,
+      reason: 'Hermes ticket dispatch dry-run',
+    }
+  }
+
+  const webhookUrl = options.webhookUrl ?? process.env.SUPPORT_HERMES_WEBHOOK_URL
+  const webhookSecret = options.webhookSecret ?? process.env.SUPPORT_HERMES_WEBHOOK_SECRET
+
+  if (!webhookUrl || !webhookSecret) {
+    throw new Error('Hermes live dispatch is missing SUPPORT_HERMES_WEBHOOK_URL or SUPPORT_HERMES_WEBHOOK_SECRET')
+  }
+
+  const controller = new AbortController()
+  const timeout = setTimeout(() => controller.abort(), resolveHermesTimeoutMs(options.timeoutMs))
+
+  try {
+    const response = await (options.fetch ?? fetch)(webhookUrl, {
+      method: 'POST',
+      headers: {
+        authorization: `Bearer ${webhookSecret}`,
+        'content-type': 'application/json',
+      },
+      body: JSON.stringify(payload),
+      signal: controller.signal,
+    })
+
+    if (!response.ok) {
+      throw new Error(`Hermes ticket dispatch failed with status ${response.status}`)
+    }
+
+    return { success: true as const, status: response.status, deliveryId: payload.delivery_id }
+  } finally {
+    clearTimeout(timeout)
+  }
+}
+
+export function createHermesTicketCreatedPayload(
+  event: SupportInngestEvent<'support/ticket.created', { eventId: string; ticketId: string; actorUserId?: string }>
+): HermesTicketCreatedPayload {
+  const eventId = assertSupportEventId(event.data.eventId, 'eventId')
+  const ticketId = assertSupportEventId(event.data.ticketId, 'ticketId')
+
+  return {
+    event_type: SUPPORT_HERMES_TICKET_CREATED_EVENT_TYPE,
+    delivery_id: `global-connect:${eventId}`,
+    ticket: {
+      id: ticketId,
+      internalUrl: createInternalTicketUrl(ticketId),
+    },
+    source: {
+      system: 'global-connect',
+      environment: resolveHermesSourceEnvironment(),
+    },
+  }
+}
+
 function readHermesDispatchMode(): HermesDispatchMode {
-  return process.env.SUPPORT_HERMES_DISPATCH_MODE === 'disabled' ? 'disabled' : 'dry-run'
+  if (process.env.SUPPORT_HERMES_DISPATCH_MODE === 'disabled') return 'disabled'
+  if (process.env.SUPPORT_HERMES_DISPATCH_MODE === 'live') return 'live'
+  return 'dry-run'
+}
+
+function assertSupportEventId(value: string, fieldName: 'eventId' | 'ticketId') {
+  const trimmed = value.trim()
+  if (!trimmed || !SUPPORT_EVENT_ID_PATTERN.test(trimmed)) {
+    throw new Error(`Hermes ticket dispatch requires a valid ${fieldName}`)
+  }
+  return trimmed
+}
+
+function createInternalTicketUrl(ticketId: string) {
+  const path = `/ayuda/tickets/${encodeURIComponent(ticketId)}`
+  const baseUrl = process.env.NEXT_PUBLIC_SITE_URL
+  if (!baseUrl) return path
+  return new URL(path, baseUrl).toString()
+}
+
+function resolveHermesSourceEnvironment(): HermesTicketCreatedPayload['source']['environment'] {
+  if (process.env.NODE_ENV === 'test') return 'test'
+  if (process.env.VERCEL_ENV === 'production' || process.env.NODE_ENV === 'production') return 'production'
+  if (process.env.VERCEL_ENV === 'preview') return 'preview'
+  return 'development'
+}
+
+function resolveHermesTimeoutMs(timeoutMs: number | undefined) {
+  const rawTimeout = timeoutMs ?? (Number(process.env.SUPPORT_HERMES_TIMEOUT_MS) || DEFAULT_HERMES_TIMEOUT_MS)
+  if (!Number.isFinite(rawTimeout) || rawTimeout <= 0) return DEFAULT_HERMES_TIMEOUT_MS
+  return Math.min(rawTimeout, MAX_HERMES_TIMEOUT_MS)
 }

--- a/lib/support/inngest-functions.ts
+++ b/lib/support/inngest-functions.ts
@@ -1,15 +1,21 @@
-import { SUPPORT_HERMES_EVENTS } from '@/lib/support/hermes'
+import { SUPPORT_HERMES_EVENTS, dispatchHermesTicketCreated } from '@/lib/support/hermes'
 import { inngest } from '@/lib/support/inngest-client'
 import { SUPPORT_INNGEST_EVENTS } from '@/lib/support/inngest'
+
+const SUPPORT_EVENT_ID_PATTERN = /^[A-Za-z0-9._-]+$/
 
 const supportTicketCreatedFoundation = inngest.createFunction(
   { id: 'support-ticket-created-foundation', triggers: { event: SUPPORT_INNGEST_EVENTS.ticketCreated } },
   async ({ event, step }) => {
-    return step.run('record safe dual-mode ticket event', () => ({
+    const ticketEvent = normalizeTicketCreatedEvent(event.data)
+    const hermes = await step.run('dispatch hermes ticket created', () => dispatchHermesTicketCreated(ticketEvent))
+
+    return {
       accepted: true,
-      eventId: event.data.eventId,
-      ticketId: event.data.ticketId,
-    }))
+      eventId: ticketEvent.data.eventId,
+      ticketId: ticketEvent.data.ticketId,
+      hermes,
+    }
   }
 )
 
@@ -29,3 +35,32 @@ export const supportInngestFunctions = [
   supportTicketCreatedFoundation,
   supportHermesEscalationRequestedFoundation,
 ]
+
+function normalizeTicketCreatedEvent(data: Record<string, unknown>) {
+  const eventId = normalizeSupportEventId(data.eventId, 'eventId')
+  const ticketId = normalizeSupportEventId(data.ticketId, 'ticketId')
+  const actorUserId = typeof data.actorUserId === 'string' ? data.actorUserId : undefined
+
+  return {
+    name: SUPPORT_INNGEST_EVENTS.ticketCreated,
+    id: `support:${eventId}`,
+    data: {
+      eventId,
+      ticketId,
+      ...(actorUserId ? { actorUserId } : {}),
+    },
+  }
+}
+
+function normalizeSupportEventId(value: unknown, fieldName: 'eventId' | 'ticketId') {
+  if (typeof value !== 'string') {
+    throw new Error(`Support ticket.created event requires a valid ${fieldName}`)
+  }
+
+  const trimmed = value.trim()
+  if (!trimmed || !SUPPORT_EVENT_ID_PATTERN.test(trimmed)) {
+    throw new Error(`Support ticket.created event requires a valid ${fieldName}`)
+  }
+
+  return trimmed
+}


### PR DESCRIPTION
# Título del PR
feat(support): dispatch tickets to Hermes

Closes #163

## Resumen
Adds safe outbound dispatch from official Inngest support ticket events to the dedicated Hermes support webhook.

## Qué Incluye
- Live-capable Hermes webhook dispatch with safe default `dry-run`.
- ID-first `ticket.created` payloads using `event_type` in the request body.
- Stable `delivery_id` values for idempotency.
- Fail-fast validation for missing `eventId` or `ticketId`.
- Documentation and tests for env vars, mode behavior, privacy boundaries, and out-of-scope callbacks.

## Motivación / Por Qué
Hermes should handle support ticket analysis externally without overloading Global Connect. This PR only sends minimal metadata to Hermes; it does not send raw user content, create GitHub issues, or apply callbacks/actions.

## Evidencia Visual (si aplica)
| Antes | Después |
|-------|---------|
| No aplica | No aplica |

## Migraciones / Base de Datos
- [x] No aplica
- [ ] Sí (orden exacto):
```
N/A
```
Notas: no schema changes.

## Impacto y Riesgos
- Default mode is not live, so no outbound dispatch happens unless explicitly configured.
- Live mode requires `SUPPORT_HERMES_WEBHOOK_URL` and `SUPPORT_HERMES_WEBHOOK_SECRET`.
- Payload is ID-first only: no title, description, body, reporter PII, attachments, diagnostics, signed URLs, or R2 keys.
- Inbound Hermes callbacks/actions and GitHub issue creation remain out of scope.

## Checklist Autor
- [x] Código formateado (Prettier/ESLint)
- [x] Sin `console.log` / debugger
- [x] Validaciones con zod para entradas nuevas
- [x] Estados loading/error/empty cubiertos
- [x] Tipos TypeScript correctos
- [x] Migraciones probadas local
- [x] Documentación actualizada (`docs/` o README)
- [x] Variables de entorno documentadas
- [x] Rebase con `main` limpio

## Checklist Revisor
- [ ] Propósito claro
- [ ] Nombres descriptivos
- [ ] Sin lógica duplicada evidente
- [ ] Manejo adecuado de errores
- [ ] Cambios acotados al alcance
- [ ] Sin secretos / datos sensibles

## Pruebas Manuales Realizadas
- `pnpm test -- __tests__/lib/support/external-bridge.test.ts __tests__/docs/support-operations.test.ts --runInBand`
- `pnpm exec eslint lib/support/hermes.ts lib/support/inngest-functions.ts __tests__/lib/support/external-bridge.test.ts __tests__/docs/support-operations.test.ts`
- `pnpm test -- __tests__/lib/support/inngest.test.ts __tests__/app/support-inngest-official-route.test.ts --runInBand`
- `pnpm tsc --noEmit`
- Safe live smoke against Hermes webhook using synthetic ID-first payload and `source.environment=test`; Hermes returned `status: 200` with delivery id `global-connect:hermes-smoke-1781321340933`.

## Pendientes / Follow-up (opcional)
- PR 3: implement audited Hermes callback/action handling for replies, status updates, human escalation, and GitHub issue references.
- Add a future safe-summary path if Hermes needs more context than ticket IDs.

## Notas Adicionales
`artifacts/` remains untracked and is not part of this PR. This PR intentionally keeps Global Connect as the system of record while Hermes handles external analysis.