### PR TITLE
docs(support): define Hermes response policy

### DIFF
--- a/__tests__/docs/support-operations.test.ts
+++ b/__tests__/docs/support-operations.test.ts
@@ -3,6 +3,7 @@ import { join } from 'node:path'
 
 describe('support operations runbook', () => {
   const runbook = readFileSync(join(process.cwd(), 'docs', 'support-operations.md'), 'utf8')
+  const hermesPolicy = readFileSync(join(process.cwd(), 'docs', 'hermes-response-policy.md'), 'utf8')
 
   it('documents production release gates and safe degraded behavior', () => {
     expect(runbook).toContain('## Production Readiness Gates')
@@ -52,5 +53,35 @@ describe('support operations runbook', () => {
     expect(runbook).toContain('ID-first for PR 2')
     expect(runbook).toContain('future staff-reviewed safe-summary field')
     expect(runbook).toContain('Do not rely on `X-Hermes-Event`')
+  })
+
+  it('documents PR 4 Hermes response policy with allowlist, denylist, and deferral rules', () => {
+    expect(runbook).toContain('Hermes response policy (PR 4)')
+    expect(runbook).toContain('Direct `public_reply` allowlist')
+    expect(runbook).toContain('Direct `public_reply` denylist')
+    expect(runbook).toContain('`internal_note` triggers')
+    expect(runbook).toContain('GitHub deferral rules')
+    expect(runbook).toContain('Scenario -> action examples')
+    expect(runbook).toContain('Safety rules for all Hermes responses')
+  })
+
+  it('locks safety constraints and response boundaries', () => {
+    expect(runbook).toContain('PII: names')
+    expect(runbook).toContain('Secrets or secrets-like values')
+    expect(runbook).toContain('Diagnostics: stack traces')
+    expect(runbook).toContain('Attachments and attachment metadata')
+    expect(runbook).toContain('Promises of engineering fixes')
+  })
+
+  it('verifies repo-visible Hermes policy reference document', () => {
+    expect(runbook).toContain('docs/hermes-response-policy.md')
+    expect(hermesPolicy).toContain('# Hermes Response Policy (PR 4)')
+    expect(hermesPolicy).toContain('Direct `public_reply` allowlist')
+    expect(hermesPolicy).toContain('GitHub deferral')
+    expect(hermesPolicy).toContain('Example mapping')
+    expect(hermesPolicy).toContain('Safety constraints')
+    expect(hermesPolicy).toContain('must use `internal_note` instead of `public_reply`')
+    expect(hermesPolicy).toContain('Never create GitHub issues from Hermes callback handling in this PR')
+    expect(hermesPolicy).toContain('Promises about engineering timelines or fixes')
   })
 })

--- a/docs/hermes-response-policy.md
+++ b/docs/hermes-response-policy.md
@@ -1,0 +1,80 @@
+# Hermes Response Policy (PR 4)
+
+This policy defines how Global Connect processes Hermes callbacks in PR 4.
+
+## Quick path
+
+1. Classify callback action as either `public_reply` or `internal_note`.
+2. Apply allowlist/denylist rules before writing any message.
+3. Redact all non-public or sensitive details.
+4. For `public_reply`, send only safe, actionable user guidance.
+5. For `internal_note`, include concise impact + triage direction only.
+
+## Decision policy
+
+| Callback action | When to use |
+|---|---|
+| `public_reply` | Safe user guidance with low risk and no sensitive context |
+| `internal_note` | Any case needing staff investigation, ambiguity, security context, diagnostics, or internal handling |
+
+## Direct `public_reply` allowlist
+
+- Password change and login/access reset flow guidance that does not require identity recovery.
+- App navigation and feature-location questions for existing user-visible screens.
+- Safe confirmation messages, such as “ticket created” or “support is reviewing”.
+- General self-service checks with no sensitive account, diagnostics, attachment, or internal context.
+- Non-technical status updates that do not promise delivery dates, root causes, or fixes.
+
+## Direct `public_reply` denylist
+
+If any item applies, Hermes must use `internal_note` instead of `public_reply`:
+
+- Security incidents, account compromise, or billing-impacting reports
+- Raw logs, stack traces, diagnostics, IDs, evidence, attachment contents, or object metadata
+- Sensitive user or staff details (PII/credentials/contacts)
+- Engineering commitments, release windows, or guaranteed fix timelines
+- Requests for actions that require manual investigation or internal policy decisions
+- Account recovery, identity verification, permission changes, or suspicious activity investigation
+- Any request involving data mutation, church/member private context, or cross-functional escalation
+
+## `internal_note` triggers
+
+- Missing clear allowlist fit
+- Request implies risk, escalation, or additional staff follow-up
+- Any ambiguity in scope or potential sensitive data handling
+- Repeated pattern reports that likely need trend analysis
+- Non-trivial failures requiring reproducibility and triage
+- `public_reply` would risk exposing PII, secrets, diagnostics, attachments, raw ticket data, or internal identifiers
+
+## GitHub deferral
+
+- PR 4 does not implement GitHub issue creation.
+- Never create GitHub issues from Hermes callback handling in this PR.
+- Use `internal_note` to record why escalation is needed and what was observed.
+- Include sanitized references only: summary, impact type, reproduction signal, and next owner.
+
+## Safety constraints
+
+Outbound Hermes responses must not include:
+
+- PII or credentials
+- Secrets or secret-like values
+- Diagnostics, stack traces, or raw Sentry payloads
+- Attachments, attachment metadata, object keys, or signed URLs
+- Raw ticket data and internal DB identifiers
+- Promises about engineering timelines or fixes
+
+## Example mapping
+
+| User scenario | Action |
+|---|---|
+| "How do I change my password?" | `public_reply` |
+| "Where is the support inbox?" | `public_reply` |
+| "My app crashes and I attached logs" | `internal_note` |
+| "Can you fix this and tell me by Friday?" | `internal_note` |
+| "I see repeated unauthorized activity" | `internal_note` |
+
+## Repository notes
+
+- Keep this policy authoritative for review of inbound Hermes behavior.
+- Runtime code changes remain in future PRs when integration requirements expand.

--- a/docs/support-operations.md
+++ b/docs/support-operations.md
@@ -102,6 +102,55 @@ Each callback is idempotent by `idempotencyKey`; duplicates return `duplicate: t
 
 For PR 3, `/api/support/external/inbound` persists the callback audit row and message only; it intentionally does **not** dispatch `support/external.update.received` or trigger staff notifications directly. Downstream support staff actions are deferred to a future durable outbox/replay design that preserves retry safety.
 
+### Hermes response policy (PR 4)
+
+All Hermes replies should follow this policy to keep responses safe, low-risk, and auditable. Repo policy source: `docs/hermes-response-policy.md`.
+
+#### Direct `public_reply` allowlist
+
+Use `public_reply` only for simple, safe guidance that users can execute immediately without staff assistance. The authoritative allowlist is in `docs/hermes-response-policy.md` and covers password-change/login navigation, existing app navigation, safe confirmation messages, general self-service checks with no sensitive context, and non-technical status updates that do not promise dates, root causes, or fixes.
+
+#### Direct `public_reply` denylist
+
+Use `internal_note` instead of `public_reply` when the case is not clearly safe or may require follow-up work. The authoritative denylist is in `docs/hermes-response-policy.md` and covers identity recovery, account compromise, credentials, logs, diagnostics, attachments, internal fields, DB IDs, storage keys, engineering timelines, root-cause commitments, data mutation, manual policy judgment, cross-functional escalation, and any ambiguous safety level.
+
+#### `internal_note` triggers
+
+- Escalation requires staff review, engineering handoff, or risk assessment.
+- User provides potentially identifying details.
+- User report needs manual repro, triage, or policy interpretation.
+- A safe answer is outside the allowlist or includes uncertainty.
+- `public_reply` would risk exposing PII/secrets/diagnostics/attachments/raw ticket data.
+
+See `docs/hermes-response-policy.md` for the complete trigger checklist and examples.
+
+#### GitHub deferral rules
+
+- Do not create GitHub issues from Hermes callbacks in PR 4.
+- If an issue is needed, capture a concise `internal_note` only and route for PR #5 integration.
+- Include impact + reproducibility signals without copying ticket raw text, attachments, diagnostics, or promises.
+- `public_reply` should never mention GitHub issue status or IDs.
+
+#### Scenario -> action examples
+
+- User asks for password reset steps → `public_reply`
+- User asks where a setting is located → `public_reply`
+- User reports duplicate charges or data corruption → `internal_note`
+- User shares logs/diagnostics/attachments for investigation → `internal_note`
+- User requests a guarantee on fix date or timeline → `internal_note`
+- User asks for account recovery or suspicious activity investigation → `internal_note`
+
+#### Safety rules for all Hermes responses
+
+All outbound content (both `public_reply` and `internal_note`) must omit:
+
+- PII: names, emails, phone numbers, free-form identifying details
+- Secrets or secrets-like values: tokens, keys, signed URLs, cookies, bearer values, headers
+- Diagnostics: stack traces, raw request/response payloads, Sentry bodies, memory/CPU details
+- Attachments and attachment metadata, including object keys and raw ticket evidence
+- Raw ticket payloads and internal DB identifiers
+- Promises of engineering fixes, delivery dates, or guaranteed outcomes
+
 ### Resend
 
 | Variable | Required | Notes |


### PR DESCRIPTION
Closes #171

## Summary
- Adds a repo-visible Hermes response policy for PR 4.
- Defines when Hermes may use public_reply and when it must use internal_note.
- Defers GitHub issue creation/integration to a later PR.
- Adds docs tests to lock policy guardrails.

## Scope
Docs/tests only. No runtime behavior, schema changes, or Production mutation.

## Test Plan
- [x] pnpm test -- __tests__/docs/support-operations.test.ts --runInBand
- [x] pnpm test -- __tests__/lib/support/external-bridge.test.ts __tests__/app/support-external-route.test.ts --runInBand
- [x] pnpm test:node

## Contributor Checklist
- [x] Linked an approved issue
- [x] Added exactly one type:* label
- [x] Docs updated if behavior changed
- [x] Conventional commit format
- [x] No Co-Authored-By trailers
