### PR TITLE
fix(auth): use token hash password recovery

### DIFF
--- a/__tests__/app/auth-confirm-route.test.ts
+++ b/__tests__/app/auth-confirm-route.test.ts
@@ -1,0 +1,53 @@
+import { GET } from '@/app/auth/confirm/route'
+import { createSupabaseServerClient } from '@/lib/supabase/server'
+
+jest.mock('next/server', () => ({
+  NextResponse: {
+    redirect: (url: URL) => ({
+      headers: new Map([['location', url.toString()]]),
+    }),
+  },
+}))
+
+jest.mock('@/lib/supabase/server', () => ({
+  createSupabaseServerClient: jest.fn(),
+}))
+
+const mockCreateSupabaseServerClient = createSupabaseServerClient as jest.MockedFunction<
+  typeof createSupabaseServerClient
+>
+
+describe('auth confirm route', () => {
+  beforeEach(() => {
+    mockCreateSupabaseServerClient.mockReset()
+  })
+
+  it('verifies recovery token hashes and redirects to reset password', async () => {
+    const verifyOtp = jest.fn().mockResolvedValue({ error: null })
+    mockCreateSupabaseServerClient.mockResolvedValue({
+      auth: { verifyOtp },
+    } as never)
+
+    const response = await GET(
+      { url: 'https://global.test/auth/confirm?type=recovery&token_hash=token-1' } as Request
+    )
+
+    expect(verifyOtp).toHaveBeenCalledWith({ token_hash: 'token-1', type: 'recovery' })
+    expect(response.headers.get('location')).toBe('https://global.test/auth/reset-password')
+  })
+
+  it('redirects invalid or expired recovery links to reset-password-specific UX', async () => {
+    const verifyOtp = jest.fn().mockResolvedValue({ error: new Error('expired') })
+    mockCreateSupabaseServerClient.mockResolvedValue({
+      auth: { verifyOtp },
+    } as never)
+
+    const response = await GET(
+      { url: 'https://global.test/auth/confirm?type=recovery&token_hash=expired-token' } as Request
+    )
+
+    expect(response.headers.get('location')).toBe(
+      'https://global.test/reset-password?error=invalid_or_expired_recovery_link'
+    )
+  })
+})

--- a/__tests__/middleware.test.ts
+++ b/__tests__/middleware.test.ts
@@ -1,0 +1,14 @@
+jest.mock('next/server', () => ({
+  NextResponse: {
+    next: jest.fn(),
+    redirect: jest.fn(),
+  },
+}))
+
+import { isPublicPath } from '@/middleware'
+
+describe('middleware public paths', () => {
+  it('allows the Supabase token hash confirmation route without an existing session', () => {
+    expect(isPublicPath('/auth/confirm')).toBe(true)
+  })
+})

--- a/app/auth/confirm/route.ts
+++ b/app/auth/confirm/route.ts
@@ -1,0 +1,66 @@
+import { NextResponse } from 'next/server'
+import type { EmailOtpType } from '@supabase/supabase-js'
+import { createSupabaseServerClient } from '@/lib/supabase/server'
+
+const EMAIL_OTP_TYPES = new Set<EmailOtpType>([
+  'signup',
+  'invite',
+  'magiclink',
+  'recovery',
+  'email_change',
+  'email',
+])
+
+function getSafeRecoveryRedirect(requestUrl: URL) {
+  const next = requestUrl.searchParams.get('next')
+
+  if (!next) {
+    return '/auth/reset-password'
+  }
+
+  const nextUrl = new URL(next, requestUrl.origin)
+
+  if (nextUrl.origin !== requestUrl.origin || nextUrl.pathname !== '/auth/reset-password') {
+    return '/auth/reset-password'
+  }
+
+  return `${nextUrl.pathname}${nextUrl.search}${nextUrl.hash}`
+}
+
+function getSafeRedirect(requestUrl: URL) {
+  const next = requestUrl.searchParams.get('next') || '/dashboard'
+  const nextUrl = new URL(next, requestUrl.origin)
+
+  if (nextUrl.origin !== requestUrl.origin) {
+    return '/dashboard'
+  }
+
+  return `${nextUrl.pathname}${nextUrl.search}${nextUrl.hash}`
+}
+
+export async function GET(request: Request) {
+  const requestUrl = new URL(request.url)
+  const tokenHash = requestUrl.searchParams.get('token_hash')
+  const type = requestUrl.searchParams.get('type')
+
+  if (!tokenHash || !type || !EMAIL_OTP_TYPES.has(type as EmailOtpType)) {
+    return NextResponse.redirect(new URL('/reset-password?error=invalid_or_expired_recovery_link', requestUrl.origin))
+  }
+
+  const supabase = await createSupabaseServerClient()
+  const { error } = await supabase.auth.verifyOtp({
+    token_hash: tokenHash,
+    type: type as EmailOtpType,
+  })
+
+  if (error) {
+    console.error('Auth confirmation error:', error.message)
+    return NextResponse.redirect(new URL('/reset-password?error=invalid_or_expired_recovery_link', requestUrl.origin))
+  }
+
+  if (type === 'recovery') {
+    return NextResponse.redirect(new URL(getSafeRecoveryRedirect(requestUrl), requestUrl.origin))
+  }
+
+  return NextResponse.redirect(new URL(getSafeRedirect(requestUrl), requestUrl.origin))
+}

--- a/app/reset-password/page.tsx
+++ b/app/reset-password/page.tsx
@@ -28,7 +28,7 @@ export default function PaginaRestablecerContraseña() {
     try {
       const supabase = createClient()
       const { error } = await supabase.auth.resetPasswordForEmail(email, {
-        redirectTo: `${process.env.NEXT_PUBLIC_SITE_URL}/auth/callback?type=recovery`
+        redirectTo: `${process.env.NEXT_PUBLIC_SITE_URL}/auth/confirm?type=recovery`
       })
 
       if (error) {

--- a/docs/supabase-email-templates.html
+++ b/docs/supabase-email-templates.html
@@ -112,7 +112,7 @@
             <table cellpadding="0" cellspacing="0" width="100%">
               <tr>
                 <td align="center">
-                  <a href="{{ .ConfirmationURL }}" style="background-color:#D06D2D;color:#ffffff;padding:14px 28px;border-radius:10px;font-weight:600;font-size:15px;text-decoration:none;display:inline-block;">Restablecer contraseña</a>
+                  <a href="{{ .RedirectTo }}&token_hash={{ .TokenHash }}" style="background-color:#D06D2D;color:#ffffff;padding:14px 28px;border-radius:10px;font-weight:600;font-size:15px;text-decoration:none;display:inline-block;">Restablecer contraseña</a>
                 </td>
               </tr>
             </table>
@@ -120,7 +120,7 @@
               Si el botón no funciona, copia y pega este enlace en tu navegador:
             </p>
             <p style="color:#6b7280;font-size:12px;line-height:1.5;margin:4px 0 0;word-break:break-all;">
-              {{ .ConfirmationURL }}
+              {{ .RedirectTo }}&token_hash={{ .TokenHash }}
             </p>
           </td>
         </tr>

--- a/middleware.ts
+++ b/middleware.ts
@@ -4,7 +4,7 @@ import type { NextRequest } from 'next/server'
 
 /**
  * Rutas públicas que no requieren autenticación.
- * El code exchange se maneja exclusivamente en /auth/callback (Route Handler).
+ * El code exchange se maneja en /auth/callback y el token hash recovery en /auth/confirm.
  */
 const PUBLIC_PATHS = new Set([
   '/',               // login
@@ -12,8 +12,13 @@ const PUBLIC_PATHS = new Set([
   '/reset-password',
   '/verify-email',
   '/auth/callback',
+  '/auth/confirm',
   '/auth/reset-password',
 ])
+
+export function isPublicPath(path: string) {
+  return PUBLIC_PATHS.has(path)
+}
 
 export async function middleware(request: NextRequest) {
   const url = new URL(request.url)
@@ -57,7 +62,7 @@ export async function middleware(request: NextRequest) {
       }
     })
 
-    if (!PUBLIC_PATHS.has(path)) {
+    if (!isPublicPath(path)) {
       const redirectUrl = new URL('/', request.url)
       redirectUrl.searchParams.set('redirect', path)
       return NextResponse.redirect(redirectUrl)
@@ -65,7 +70,7 @@ export async function middleware(request: NextRequest) {
     return supabaseResponse
   }
 
-  const isPublic = PUBLIC_PATHS.has(path)
+  const isPublic = isPublicPath(path)
 
   // No autenticado + ruta privada → login
   if (!user && !isPublic) {


### PR DESCRIPTION
Closes #173

## PR Type
- [x] Bug fix

## Summary
- Adds a Supabase token-hash confirmation route for password recovery links.
- Sends reset emails to /auth/confirm?type=recovery and allows that route through middleware.
- Updates reset email template docs and adds focused auth recovery tests.

## Changes
| File | Change |
|------|--------|
| app/auth/confirm/route.ts | Adds verifyOtp token_hash confirmation route with safe recovery redirects. |
| app/reset-password/page.tsx | Points password reset emails at the token-hash confirm route. |
| middleware.ts | Allows /auth/confirm as a public auth route and exposes public-path helper for tests. |
| docs/supabase-email-templates.html | Updates reset-password template to use RedirectTo + TokenHash. |
| __tests__/app/auth-confirm-route.test.ts | Covers recovery token verification and expired-token handling. |
| __tests__/middleware.test.ts | Covers /auth/confirm public path access. |

## Test Plan
- [x] pnpm jest __tests__/app/auth-confirm-route.test.ts __tests__/middleware.test.ts --runInBand
- [x] pnpm exec tsc --noEmit --pretty false
- [x] pnpm eslint app/auth/confirm/route.ts app/reset-password/page.tsx middleware.ts __tests__/app/auth-confirm-route.test.ts __tests__/middleware.test.ts
- [x] Judgment Day final review approved

## Manual Deployment Step
Update Supabase Dashboard → Authentication → Email Templates → Reset password to use:

```html
{{ .RedirectTo }}&token_hash={{ .TokenHash }}
```

## Contributor Checklist
- [x] Linked an approved issue
- [x] Added exactly one type:* label
- [x] Ran shellcheck on modified scripts (not applicable; no shell scripts changed)
- [x] Docs updated if behavior changed
- [x] Conventional commit format
- [x] No Co-Authored-By trailers