### PR TITLE
feat(support): add durable outbox drain

### DIFF
--- a/__tests__/app/support-inngest-route.test.ts
+++ b/__tests__/app/support-inngest-route.test.ts
@@ -1,5 +1,24 @@
 import { POST } from '@/app/api/inngest/route'
 
+jest.mock('@/lib/support/inngest', () => {
+  const actual = jest.requireActual('@/lib/support/inngest')
+
+  return {
+    ...actual,
+    deliverSupportNotificationEvent: jest.fn(),
+  }
+})
+
+jest.mock('@/lib/supabase/admin', () => ({
+  createSupabaseAdminClient: jest.fn(),
+}))
+
+import { deliverSupportNotificationEvent } from '@/lib/support/inngest'
+
+const mockDeliverSupportNotificationEvent = deliverSupportNotificationEvent as jest.MockedFunction<
+  typeof deliverSupportNotificationEvent
+>
+
 class TestResponseClass {
   status: number
 
@@ -30,6 +49,9 @@ describe('support Inngest route', () => {
 
   beforeEach(() => {
     delete process.env.SUPPORT_INNGEST_WEBHOOK_SECRET
+    process.env.SUPABASE_URL = 'https://example.supabase.co'
+    process.env.SUPABASE_SERVICE_ROLE_KEY = 'service-role-secret'
+    mockDeliverSupportNotificationEvent.mockClear()
   })
 
   it('rejects unsigned provider requests when a webhook secret is configured', async () => {
@@ -73,5 +95,26 @@ describe('support Inngest route', () => {
 
     expect(response.status).toBe(400)
     await expect(response.json()).resolves.toEqual({ error: 'Malformed support event provider payload' })
+  })
+
+  it('accepts external update events without dispatching notification processing', async () => {
+    process.env.SUPPORT_INNGEST_WEBHOOK_SECRET = 'secret-1'
+
+    const response = await POST({
+      headers: new Headers([['authorization', 'Bearer secret-1']]),
+      json: async () => ({
+        name: 'support/external.update.received',
+        id: 'support:event-3',
+        data: { eventId: 'event-3', ticketId: 'ticket-3' },
+      }),
+    } as Request)
+
+    expect(response.status).toBe(202)
+    await expect(response.json()).resolves.toEqual({
+      accepted: true,
+      eventId: 'event-3',
+      name: 'support/external.update.received',
+    })
+    expect(mockDeliverSupportNotificationEvent).not.toHaveBeenCalled()
   })
 })

--- a/__tests__/app/support-outbox-drain-route.test.ts
+++ b/__tests__/app/support-outbox-drain-route.test.ts
@@ -1,0 +1,94 @@
+import { GET, POST } from '@/app/api/support/outbox/drain/route'
+import { drainSupportEventOutbox } from '@/lib/support/outbox'
+
+jest.mock('@/lib/supabase/admin', () => ({
+  createSupabaseAdminClient: jest.fn(() => ({ admin: true })),
+}))
+
+jest.mock('@/lib/support/outbox', () => ({
+  drainSupportEventOutbox: jest.fn(),
+}))
+
+const mockDrainSupportEventOutbox = drainSupportEventOutbox as jest.MockedFunction<typeof drainSupportEventOutbox>
+
+class TestResponseClass {
+  status: number
+
+  private readonly body: unknown
+
+  constructor(body: unknown, init?: ResponseInit) {
+    this.body = body
+    this.status = init?.status ?? 200
+  }
+
+  static json(body: unknown, init?: ResponseInit) {
+    return new TestResponseClass(body, init)
+  }
+
+  async json() {
+    return this.body
+  }
+}
+
+const TestResponse = TestResponseClass as unknown as typeof Response
+
+describe('support outbox drain route', () => {
+  beforeAll(() => {
+    if (typeof Response === 'undefined') {
+      Object.defineProperty(globalThis, 'Response', { value: TestResponse, configurable: true })
+    }
+  })
+
+  beforeEach(() => {
+    delete process.env.SUPPORT_OUTBOX_DRAIN_SECRET
+    mockDrainSupportEventOutbox.mockReset()
+  })
+
+  it('rejects drain requests when the route secret is not configured', async () => {
+    const response = await POST({ headers: new Headers() } as Request)
+
+    expect(response.status).toBe(503)
+    await expect(response.json()).resolves.toEqual({ error: 'Support outbox drain is not configured' })
+    expect(mockDrainSupportEventOutbox).not.toHaveBeenCalled()
+  })
+
+  it('rejects unauthenticated drain requests without leaking payloads', async () => {
+    process.env.SUPPORT_OUTBOX_DRAIN_SECRET = 'secret-1'
+
+    const response = await POST({ headers: new Headers() } as Request)
+
+    expect(response.status).toBe(401)
+    await expect(response.json()).resolves.toEqual({ error: 'Unauthorized support outbox drain request' })
+    expect(mockDrainSupportEventOutbox).not.toHaveBeenCalled()
+  })
+
+  it('accepts authenticated drain requests and returns only counts', async () => {
+    process.env.SUPPORT_OUTBOX_DRAIN_SECRET = 'secret-1'
+    mockDrainSupportEventOutbox.mockResolvedValue({ success: true, claimed: 2, dispatched: 1, failed: 1 })
+
+    const response = await POST({ headers: new Headers([['authorization', 'Bearer secret-1']]) } as Request)
+
+    expect(response.status).toBe(202)
+    await expect(response.json()).resolves.toEqual({ claimed: 2, dispatched: 1, failed: 1 })
+  })
+
+  it('accepts Vercel cron GET requests with the configured bearer secret', async () => {
+    process.env.SUPPORT_OUTBOX_DRAIN_SECRET = 'secret-1'
+    mockDrainSupportEventOutbox.mockResolvedValue({ success: true, claimed: 1, dispatched: 1, failed: 0 })
+
+    const response = await GET({ headers: new Headers([['authorization', 'Bearer secret-1']]) } as Request)
+
+    expect(response.status).toBe(202)
+    await expect(response.json()).resolves.toEqual({ claimed: 1, dispatched: 1, failed: 0 })
+  })
+
+  it('rejects unauthenticated Vercel cron GET requests', async () => {
+    process.env.SUPPORT_OUTBOX_DRAIN_SECRET = 'secret-1'
+
+    const response = await GET({ headers: new Headers() } as Request)
+
+    expect(response.status).toBe(401)
+    await expect(response.json()).resolves.toEqual({ error: 'Unauthorized support outbox drain request' })
+    expect(mockDrainSupportEventOutbox).not.toHaveBeenCalled()
+  })
+})

--- a/__tests__/app/support-pages.test.tsx
+++ b/__tests__/app/support-pages.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from '@testing-library/react'
+import { act, render, screen } from '@testing-library/react'
 
 import AyudaPage from '@/app/(auth)/ayuda/page'
 import SupportAdminPage from '@/app/(auth)/ayuda/admin/page'
@@ -45,6 +45,9 @@ jest.mock('@/lib/actions/support.actions', () => ({
         { id: 'message-1', body: 'Public reply', authorUsuarioId: 'reporter-1', author: { id: 'reporter-1', nombre: 'Ana', apellido: 'Pérez', photoUrl: null }, createdAt: '2026-06-09T00:01:00Z' },
         { id: 'message-2', body: 'Support reply', authorUsuarioId: 'staff-1', author: { id: 'staff-1', nombre: 'Soporte', apellido: 'Central', photoUrl: 'https://cdn.example/staff.webp' }, createdAt: '2026-06-09T00:02:00Z' },
       ],
+      events: [
+        { type: 'support.ticket.status_changed', actorUsuarioId: 'staff-1', createdAt: '2026-06-09T00:03:00Z', metadata: { status: 'in_progress', source: 'staff' } },
+      ],
       supportCapabilities: [],
     },
   }),
@@ -71,14 +74,18 @@ describe('reporter support pages', () => {
   })
 
   it('renders the /ayuda home with report and history links', async () => {
-    render(await AyudaPage())
+    await act(async () => {
+      render(await AyudaPage())
+    })
 
     expect(screen.getByRole('link', { name: /Reportar un problema/i })).toHaveAttribute('href', '/ayuda/reportar')
     expect(screen.getByRole('link', { name: /Ver mis tickets/i })).toHaveAttribute('href', '/ayuda/tickets')
   })
 
   it('renders the report form with only reporter-facing fields', async () => {
-    render(await ReportarPage())
+    await act(async () => {
+      render(await ReportarPage())
+    })
 
     expect(screen.getByLabelText(/Asunto/i)).toHaveAttribute('name', 'subject')
     expect(screen.getByLabelText(/Descripcion/i)).toHaveAttribute('name', 'description')
@@ -129,7 +136,9 @@ describe('reporter support pages', () => {
   })
 
   it('renders the reporter ticket history', async () => {
-    render(await TicketsPage())
+    await act(async () => {
+      render(await TicketsPage())
+    })
 
     expect(screen.getByRole('table')).toBeInTheDocument()
     expect(screen.getByText('Historial de tickets de soporte enviados por ti.')).toBeInTheDocument()
@@ -146,7 +155,9 @@ describe('reporter support pages', () => {
     const { listSupportTickets } = jest.requireMock('@/lib/actions/support.actions') as { listSupportTickets: jest.Mock }
     listSupportTickets.mockResolvedValueOnce({ success: true, tickets: [] })
 
-    render(await TicketsPage())
+    await act(async () => {
+      render(await TicketsPage())
+    })
 
     expect(screen.getByRole('table')).toBeInTheDocument()
     expect(screen.getAllByText('Todavia no has enviado tickets de soporte.')[0]).toBeInTheDocument()
@@ -154,7 +165,9 @@ describe('reporter support pages', () => {
   })
 
   it('renders reporter-visible ticket details and reply form', async () => {
-    render(await TicketDetailPage({ params: Promise.resolve({ id: 'ticket-1' }) }))
+    await act(async () => {
+      render(await TicketDetailPage({ params: Promise.resolve({ id: 'ticket-1' }) }))
+    })
 
     expect(screen.getByText('The group map does not load.')).toBeInTheDocument()
     expect(screen.getByRole('heading', { name: /Solicitante/i })).toBeInTheDocument()
@@ -177,6 +190,88 @@ describe('reporter support pages', () => {
     expect(screen.getByLabelText(/Respuesta/i)).toHaveAttribute('name', 'body')
     expect(screen.queryByLabelText(/Respuesta del equipo/i)).not.toBeInTheDocument()
     expect(screen.queryByLabelText(/Nuevo estado/i)).not.toBeInTheDocument()
+    expect(screen.queryByRole('heading', { name: /^Actividad$/i })).not.toBeInTheDocument()
+    expect(screen.queryByText(/Estado actualizado/i)).not.toBeInTheDocument()
+  })
+
+  it('renders internal note badge only for users with support.view-equivalent capability', async () => {
+    const { getSupportTicketDetail } = jest.requireMock('@/lib/actions/support.actions') as { getSupportTicketDetail: jest.Mock }
+    getSupportTicketDetail.mockResolvedValueOnce({
+      success: true,
+      ticket: {
+        id: 'ticket-5',
+        ticketNumber: 46,
+        title: 'Need internal context',
+        description: 'Support needs private context before answering.',
+        status: 'received',
+        category: 'bug',
+        severity: 'normal',
+        reporterUsuarioId: 'reporter-5',
+        assigneeUsuarioId: 'staff-2',
+        reporter: { id: 'reporter-5', nombre: 'Lucía', apellido: 'García', photoUrl: null },
+        assignee: { id: 'staff-2', nombre: 'Soporte', apellido: 'Senior', photoUrl: 'https://cdn.example/staff-2.webp' },
+        createdAt: '2026-06-10T03:00:00Z',
+        updatedAt: '2026-06-10T03:05:00Z',
+        evidence: { currentRoute: '/dashboard', browserName: 'Chrome', osName: 'macOS', viewport: '1440x900', appBuildVersion: null, sentryEventId: null, diagnosticsConsent: true },
+        attachments: [],
+        messages: [
+          { id: 'message-1', body: 'Internal update for staff', authorUsuarioId: 'staff-2', isInternal: true, author: { id: 'staff-2', nombre: 'Soporte', apellido: 'Senior', photoUrl: 'https://cdn.example/staff-2.webp' }, createdAt: '2026-06-10T03:01:00Z' },
+          { id: 'message-2', body: 'Public follow-up', authorUsuarioId: 'staff-2', isInternal: false, author: { id: 'staff-2', nombre: 'Soporte', apellido: 'Senior', photoUrl: 'https://cdn.example/staff-2.webp' }, createdAt: '2026-06-10T03:02:00Z' },
+        ],
+        events: [
+          { type: 'support.ticket.status_changed', actorUsuarioId: 'staff-2', createdAt: '2026-06-10T03:03:00Z', metadata: { status: 'in_review', source: 'staff', category: 'bug' } },
+        ],
+        supportCapabilities: ['support.view'],
+      },
+    })
+
+    await act(async () => {
+      render(await TicketDetailPage({ params: Promise.resolve({ id: 'ticket-5' }) }))
+    })
+
+    expect(screen.getByText('Need internal context')).toBeInTheDocument()
+    expect(screen.getByText('Nota interna')).toBeInTheDocument()
+    expect(screen.getByText('Internal update for staff')).toBeInTheDocument()
+    expect(screen.getByText('Public follow-up')).toBeInTheDocument()
+    expect(screen.getByRole('heading', { name: /^Actividad$/i })).toBeInTheDocument()
+    expect(screen.getByText('Estado actualizado')).toBeInTheDocument()
+    expect(screen.getByText(/Origen staff/i)).toBeInTheDocument()
+    expect(screen.queryByText(/Private body/i)).not.toBeInTheDocument()
+  })
+
+  it('does not render internal-note badge when message is public-only', async () => {
+    const { getSupportTicketDetail } = jest.requireMock('@/lib/actions/support.actions') as { getSupportTicketDetail: jest.Mock }
+    getSupportTicketDetail.mockResolvedValueOnce({
+      success: true,
+      ticket: {
+        id: 'ticket-6',
+        ticketNumber: 47,
+        title: 'Reporter only context',
+        description: 'No internal notes here.',
+        status: 'received',
+        category: 'other',
+        severity: 'low',
+        reporterUsuarioId: 'reporter-6',
+        assigneeUsuarioId: null,
+        reporter: { id: 'reporter-6', nombre: 'Mauro', apellido: 'López', photoUrl: null },
+        assignee: null,
+        createdAt: '2026-06-10T04:00:00Z',
+        updatedAt: '2026-06-10T04:05:00Z',
+        evidence: { currentRoute: '/dashboard', browserName: 'Chrome', osName: 'macOS', viewport: '1440x900', appBuildVersion: null, sentryEventId: null, diagnosticsConsent: true },
+        attachments: [],
+        messages: [
+          { id: 'message-3', body: 'Public reply only', authorUsuarioId: 'staff-2', isInternal: false, author: { id: 'staff-2', nombre: 'Soporte', apellido: 'Senior', photoUrl: 'https://cdn.example/staff-2.webp' }, createdAt: '2026-06-10T04:01:00Z' },
+        ],
+        supportCapabilities: [],
+      },
+    })
+
+    await act(async () => {
+      render(await TicketDetailPage({ params: Promise.resolve({ id: 'ticket-6' }) }))
+    })
+
+    expect(screen.getByText('Public reply only')).toBeInTheDocument()
+    expect(screen.queryByText('Nota interna')).not.toBeInTheDocument()
   })
 
   it('renders staff reply and lifecycle controls only when staff capabilities are present', async () => {
@@ -204,7 +299,9 @@ describe('reporter support pages', () => {
       },
     })
 
-    render(await TicketDetailPage({ params: Promise.resolve({ id: 'ticket-2' }) }))
+    await act(async () => {
+      render(await TicketDetailPage({ params: Promise.resolve({ id: 'ticket-2' }) }))
+    })
 
     expect(screen.getByLabelText(/Respuesta de soporte/i)).toHaveAttribute('name', 'body')
     expect(screen.getByRole('button', { name: /Enviar respuesta al solicitante/i })).toBeInTheDocument()
@@ -238,7 +335,9 @@ describe('reporter support pages', () => {
       },
     })
 
-    render(await TicketDetailPage({ params: Promise.resolve({ id: 'ticket-3' }) }))
+    await act(async () => {
+      render(await TicketDetailPage({ params: Promise.resolve({ id: 'ticket-3' }) }))
+    })
 
     expect(screen.getByLabelText(/Respuesta de soporte/i)).toHaveAttribute('name', 'body')
     expect(screen.getByRole('button', { name: /Enviar respuesta al solicitante/i })).toBeInTheDocument()
@@ -272,7 +371,9 @@ describe('reporter support pages', () => {
       },
     })
 
-    render(await TicketDetailPage({ params: Promise.resolve({ id: 'ticket-4' }) }))
+    await act(async () => {
+      render(await TicketDetailPage({ params: Promise.resolve({ id: 'ticket-4' }) }))
+    })
 
     expect(screen.queryByLabelText(/Respuesta de soporte/i)).not.toBeInTheDocument()
     expect(screen.queryByRole('button', { name: /Enviar respuesta al solicitante/i })).not.toBeInTheDocument()
@@ -281,7 +382,9 @@ describe('reporter support pages', () => {
   })
 
   it('renders the staff queue with search and filter controls', async () => {
-    render(await SupportAdminPage({ searchParams: Promise.resolve({ search: 'attendance', status: 'in_progress', category: 'bug' }) }))
+    await act(async () => {
+      render(await SupportAdminPage({ searchParams: Promise.resolve({ search: 'attendance', status: 'in_progress', category: 'bug' }) }))
+    })
 
     expect(listStaffSupportTickets).toHaveBeenCalledWith({ search: 'attendance', status: 'in_progress', category: 'bug', campusId: undefined, assigneeId: undefined })
     expect(screen.getByRole('searchbox', { name: /Buscar tickets/i })).toHaveValue('attendance')
@@ -296,7 +399,9 @@ describe('reporter support pages', () => {
   })
 
   it('hides staff queue assignment and status transition controls for view-only staff', async () => {
-    render(await SupportAdminPage({ searchParams: Promise.resolve({}) }))
+    await act(async () => {
+      render(await SupportAdminPage({ searchParams: Promise.resolve({}) }))
+    })
 
     expect(screen.queryByLabelText(/Nuevo estado para #43/i)).not.toBeInTheDocument()
     expect(screen.queryByRole('button', { name: /Actualizar #43/i })).not.toBeInTheDocument()
@@ -308,7 +413,9 @@ describe('reporter support pages', () => {
   it('renders staff queue assignment and status transition controls for support managers', async () => {
     listStaffSupportTickets.mockResolvedValueOnce({ ...staffQueueResult, supportCapabilities: ['support.view', 'support.manage'] })
 
-    render(await SupportAdminPage({ searchParams: Promise.resolve({}) }))
+    await act(async () => {
+      render(await SupportAdminPage({ searchParams: Promise.resolve({}) }))
+    })
 
     expect(screen.getAllByLabelText(/Nuevo estado para #43/i)[0]).toHaveValue('in_progress')
     expect(screen.getAllByRole('button', { name: /Actualizar #43/i })[0]).toBeInTheDocument()
@@ -322,7 +429,9 @@ describe('reporter support pages', () => {
     createSupabaseServerClient.mockResolvedValue(supabase)
     getUserWithRoles.mockResolvedValue({ user: { id: 'auth-1' }, roles: ['miembro'] })
 
-    render(await SupportCapabilitiesPage())
+    await act(async () => {
+      render(await SupportCapabilitiesPage())
+    })
 
     expect(screen.getByRole('heading', { name: /Acceso requerido/i })).toBeInTheDocument()
     expect(screen.getByText(/requiere un rol de administracion alto y la capacidad support.manage/i)).toBeInTheDocument()
@@ -334,7 +443,9 @@ describe('reporter support pages', () => {
     createSupabaseServerClient.mockResolvedValue(supabase)
     getUserWithRoles.mockResolvedValue({ user: { id: 'auth-1' }, roles: ['director-general'] })
 
-    render(await SupportCapabilitiesPage())
+    await act(async () => {
+      render(await SupportCapabilitiesPage())
+    })
 
     expect(screen.getByRole('heading', { name: /Capacidades permitidas/i })).toBeInTheDocument()
     expect(screen.getByRole('button', { name: /Otorgar capacidad/i })).toBeInTheDocument()

--- a/__tests__/docs/support-operations.test.ts
+++ b/__tests__/docs/support-operations.test.ts
@@ -59,7 +59,7 @@ describe('support operations runbook', () => {
     expect(vercelConfig.crons).toEqual([
       {
         path: '/api/support/outbox/drain',
-        schedule: '*/5 * * * *',
+        schedule: '0 8 * * *',
       },
     ])
   })

--- a/__tests__/docs/support-operations.test.ts
+++ b/__tests__/docs/support-operations.test.ts
@@ -4,6 +4,9 @@ import { join } from 'node:path'
 describe('support operations runbook', () => {
   const runbook = readFileSync(join(process.cwd(), 'docs', 'support-operations.md'), 'utf8')
   const hermesPolicy = readFileSync(join(process.cwd(), 'docs', 'hermes-response-policy.md'), 'utf8')
+  const vercelConfig = JSON.parse(readFileSync(join(process.cwd(), 'vercel.json'), 'utf8')) as {
+    crons?: Array<{ path?: string; schedule?: string }>
+  }
 
   it('documents production release gates and safe degraded behavior', () => {
     expect(runbook).toContain('## Production Readiness Gates')
@@ -39,6 +42,26 @@ describe('support operations runbook', () => {
     expect(runbook).toContain('/api/inngest')
     expect(runbook).toContain('/api/inngest/official')
     expect(runbook).toContain('compatibility custom webhook')
+  })
+
+  it('documents drain-only support event dispatch and scheduler wiring without secret values', () => {
+    expect(runbook).toContain('drain-only')
+    expect(runbook).toContain('POST /api/support/outbox/drain')
+    expect(runbook).toContain('GET /api/support/outbox/drain')
+    expect(runbook).toContain('CRON_SECRET')
+    expect(runbook).toContain('SUPPORT_OUTBOX_DRAIN_SECRET')
+    expect(runbook).toContain('Authorization: Bearer <configured scheduler secret>')
+    expect(runbook).toContain('vercel.json')
+    expect(runbook).toContain('must not directly dispatch provider events')
+    expect(runbook).toContain('returns counts only')
+    expect(runbook).toContain('Transient dispatch failures')
+    expect(runbook).toContain('Unsupported event types are marked `failed`')
+    expect(vercelConfig.crons).toEqual([
+      {
+        path: '/api/support/outbox/drain',
+        schedule: '*/5 * * * *',
+      },
+    ])
   })
 
   it('documents Hermes outbound dispatch controls and PR 2 scope boundaries', () => {

--- a/__tests__/lib/actions/support.actions.test.ts
+++ b/__tests__/lib/actions/support.actions.test.ts
@@ -24,6 +24,16 @@ jest.mock('@/lib/support/inngest', () => ({
     id: `support:${payload.eventId}`,
     data: payload,
   }),
+  createSupportTicketMessageCreatedEvent: (payload: { eventId: string; ticketId: string; messageId: string; actorUserId?: string }) => ({
+    name: 'support/ticket.message.created',
+    id: `support:${payload.eventId}`,
+    data: payload,
+  }),
+  createSupportTicketStatusChangedEvent: (payload: { eventId: string; ticketId: string; actorUserId?: string }) => ({
+    name: 'support/ticket.status.changed',
+    id: `support:${payload.eventId}`,
+    data: payload,
+  }),
   dispatchSupportInngestEvent: jest.fn(),
 }))
 
@@ -33,6 +43,7 @@ describe('support reporter actions', () => {
   beforeEach(() => {
     createSupabaseServerClient.mockReset()
     createSupabaseAdminClient.mockReset()
+    createSupabaseAdminClient.mockReturnValue({ from: jest.fn() })
     dispatchSupportInngestEventMock.mockReset()
     revalidatePath.mockReset()
   })
@@ -113,51 +124,54 @@ describe('support reporter actions', () => {
   })
 
   it('creates a received ticket for the authenticated reporter', async () => {
-    const insert = jest.fn().mockReturnValue({ select: jest.fn().mockReturnValue({ single: jest.fn().mockResolvedValue({ data: { id: 'ticket-1', ticket_number: 42 }, error: null }) }) })
+    const rpc = jest.fn().mockResolvedValue({ data: { ticketId: 'ticket-1', ticketNumber: 42, eventId: 'event-1', actorUserId: 'usuario-1' }, error: null })
     createSupabaseServerClient.mockResolvedValue({
       auth: { getUser: jest.fn().mockResolvedValue({ data: { user: { id: 'auth-1' } } }) },
-      from: createFromMock({ usuarioId: 'usuario-1', insert }),
+      from: createFromMock({ usuarioId: 'usuario-1', insert: jest.fn() }),
+      rpc,
     })
 
     const result = await createSupportTicket(createTicketFormData())
 
     expect(result).toEqual({ success: true, ticketId: 'ticket-1', ticketNumber: 42 })
-    expect(insert).toHaveBeenCalledWith(expect.objectContaining({
-      reporter_usuario_id: 'usuario-1',
-      status: 'received',
-      title: 'Cannot open group map',
-      severity: 'normal',
-      diagnostics_consent: true,
+    expect(rpc).toHaveBeenCalledWith('create_support_ticket_with_outbox', expect.objectContaining({
+      p_subject: 'Cannot open group map',
+      p_description: 'The map stays blank after I open the dashboard.',
+      p_category: 'bug',
+      p_diagnostics_consent: true,
     }))
-    expect(insert.mock.calls[0][0]).not.toHaveProperty('cookies')
+    expect(rpc.mock.calls[0][1]).not.toHaveProperty('cookies')
     expect(revalidatePath).toHaveBeenCalledWith('/ayuda/tickets')
   })
 
-  it('audits reporter ticket creation and dispatches an ID-only ticket-created event after commit', async () => {
-    dispatchSupportInngestEventMock.mockResolvedValue({ success: true, skipped: true, reason: 'Provider not configured' })
-    const ticketInsert = jest.fn().mockReturnValue({ select: jest.fn().mockReturnValue({ single: jest.fn().mockResolvedValue({ data: { id: 'ticket-1', ticket_number: 42 }, error: null }) }) })
-    const eventInsert = jest.fn().mockReturnValue({ select: jest.fn().mockReturnValue({ single: jest.fn().mockResolvedValue({ data: { id: 'event-1' }, error: null }) }) })
+  it('creates reporter tickets through the atomic outbox RPC without immediate provider dispatch', async () => {
+    const rpc = jest.fn().mockResolvedValue({ data: { ticketId: 'ticket-1', ticketNumber: 42, eventId: 'event-1', actorUserId: 'usuario-1' }, error: null })
     createSupabaseServerClient.mockResolvedValue({
       auth: { getUser: jest.fn().mockResolvedValue({ data: { user: { id: 'auth-1' } } }) },
-      from: createReporterMutationFromMock({ usuarioId: 'usuario-1', ticketInsert, eventInsert }),
+      from: createFromMock({ usuarioId: 'usuario-1', insert: jest.fn() }),
+      rpc,
     })
 
     const result = await createSupportTicket(createTicketFormData())
 
     expect(result).toEqual({ success: true, ticketId: 'ticket-1', ticketNumber: 42 })
-    expect(eventInsert).toHaveBeenCalledWith({
-      ticket_id: 'ticket-1',
-      actor_usuario_id: 'usuario-1',
-      action: 'support.ticket.created',
-      target_type: 'support_ticket',
-      target_id: 'ticket-1',
-      metadata: { source: 'reporter' },
+    expect(rpc).toHaveBeenCalledWith('create_support_ticket_with_outbox', expect.any(Object))
+    expect(dispatchSupportInngestEventMock).not.toHaveBeenCalled()
+  })
+
+  it('does not dispatch when the atomic ticket creation RPC fails', async () => {
+    const rpc = jest.fn().mockResolvedValue({ data: null, error: { message: 'outbox insert failed' } })
+    createSupabaseServerClient.mockResolvedValue({
+      auth: { getUser: jest.fn().mockResolvedValue({ data: { user: { id: 'auth-1' } } }) },
+      from: createFromMock({ usuarioId: 'usuario-1', insert: jest.fn() }),
+      rpc,
     })
-    expect(dispatchSupportInngestEventMock).toHaveBeenCalledWith({
-      name: 'support/ticket.created',
-      id: 'support:event-1',
-      data: { eventId: 'event-1', ticketId: 'ticket-1', actorUserId: 'usuario-1' },
-    })
+
+    const result = await createSupportTicket(createTicketFormData())
+
+    expect(result).toEqual({ success: false, error: 'No se pudo crear el ticket de soporte' })
+    expect(dispatchSupportInngestEventMock).not.toHaveBeenCalled()
+    expect(revalidatePath).not.toHaveBeenCalled()
   })
 
   it('lists only public reporter fields from RLS-filtered tickets', async () => {
@@ -187,6 +201,7 @@ describe('support reporter actions', () => {
         if (table === 'support_tickets') return ticketQuery
         if (table === 'support_ticket_messages') return messagesQuery
         if (table === 'support_user_capabilities') return capabilitiesQuery
+        if (table === 'support_ticket_events') throw new Error('Reporter detail must not fetch support events')
         return attachmentsQuery
       }),
     })
@@ -194,7 +209,7 @@ describe('support reporter actions', () => {
     const result = await getSupportTicketDetail('ticket-1')
 
     expect(result.success).toBe(true)
-    expect(result.ticket?.messages).toEqual([{ id: 'message-1', body: 'Public reply', authorUsuarioId: 'usuario-1', author: { id: 'usuario-1', nombre: 'Ana', apellido: 'Pérez', photoUrl: null }, createdAt: '2026-06-09T00:01:00Z' }])
+    expect(result.ticket?.messages).toEqual([{ id: 'message-1', body: 'Public reply', isInternal: false, authorUsuarioId: 'usuario-1', author: { id: 'usuario-1', nombre: 'Ana', apellido: 'Pérez', photoUrl: null }, createdAt: '2026-06-09T00:01:00Z' }])
     expect(result.ticket?.attachments).toEqual([{ id: 'attachment-1', filename: 'map-error.webp', kind: 'screenshot', contentType: 'image/webp', byteSize: 2048, status: 'uploaded' }])
     expect(result.ticket?.reporter).toEqual({ id: 'usuario-1', nombre: 'Ana', apellido: 'Pérez', photoUrl: null })
     expect(result.ticket?.assigneeUsuarioId).toBeNull()
@@ -202,6 +217,7 @@ describe('support reporter actions', () => {
     expect(result.ticket?.attachments[0]).not.toHaveProperty('objectKey')
     expect(result.ticket?.attachments[0]).not.toHaveProperty('downloadUrl')
     expect(result.ticket).not.toHaveProperty('rawSentryPayload')
+    expect(result.ticket?.events).toEqual([])
     expect(messagesFilter.eq).toHaveBeenCalledWith('ticket_id', 'ticket-1')
     expect(messagesFilter.eq).toHaveBeenCalledWith('is_internal', false)
     expect(attachmentsQuery.select).toHaveBeenCalledWith('id,original_filename,kind,content_type,byte_size,status')
@@ -238,6 +254,84 @@ describe('support reporter actions', () => {
     expect(adminIn).toHaveBeenCalledWith('id', ['staff-1'])
   })
 
+  it('filters internal messages for reporters without support.view-equivalent capability', async () => {
+    const ticketQuery = { select: jest.fn().mockReturnValue({ eq: jest.fn().mockReturnValue({ maybeSingle: jest.fn().mockResolvedValue({ data: { id: 'ticket-2', ticket_number: 43, title: 'Billing issue', description: 'No invoice', status: 'received', category: 'billing', severity: 'normal', reporter_usuario_id: 'usuario-1', assignee_usuario_id: 'staff-1', reporter: { id: 'usuario-1', nombre: 'Ana', apellido: 'Pérez', foto_perfil_url: null }, assignee: { id: 'staff-1', nombre: 'Soporte', apellido: 'Central', foto_perfil_url: 'https://cdn.example/staff.webp' }, current_route: '/billing', browser_name: 'Chrome', os_name: 'macOS', viewport: '1440x900', app_build_version: null, sentry_event_id: null, diagnostics_consent: true, created_at: '2026-06-10T00:00:00Z', updated_at: '2026-06-10T00:05:00Z' }, error: null }) }) }) }
+    const messagesFilter = { eq: jest.fn(), order: jest.fn().mockResolvedValue({ data: [{ id: 'message-1', body: 'Public reply', author_usuario_id: 'usuario-1', author: { id: 'usuario-1', nombre: 'Ana', apellido: 'Pérez', foto_perfil_url: null }, is_internal: false, created_at: '2026-06-10T00:01:00Z' }], error: null }) }
+    messagesFilter.eq.mockReturnValue(messagesFilter)
+    const messagesQuery = { select: jest.fn().mockReturnValue(messagesFilter) }
+    const attachmentsFilter = { eq: jest.fn(), order: jest.fn().mockResolvedValue({ data: [], error: null }) }
+    attachmentsFilter.eq.mockReturnValue(attachmentsFilter)
+    const attachmentsQuery = { select: jest.fn().mockReturnValue(attachmentsFilter) }
+    const capabilitiesFilter = { eq: jest.fn(), is: jest.fn().mockResolvedValue({ data: [], error: null }) }
+    capabilitiesFilter.eq.mockReturnValue(capabilitiesFilter)
+
+    createSupabaseServerClient.mockResolvedValue({
+      auth: { getUser: jest.fn().mockResolvedValue({ data: { user: { id: 'reporter-1' } } }) },
+      from: jest.fn((table) => {
+        if (table === 'usuarios') return { select: jest.fn().mockReturnValue({ eq: jest.fn().mockReturnValue({ maybeSingle: jest.fn().mockResolvedValue({ data: { id: 'usuario-1' }, error: null }) }) }) }
+        if (table === 'support_tickets') return ticketQuery
+        if (table === 'support_ticket_messages') return messagesQuery
+        if (table === 'support_user_capabilities') return { select: jest.fn().mockReturnValue(capabilitiesFilter) }
+        return attachmentsQuery
+      }),
+    })
+
+    const result = await getSupportTicketDetail('ticket-2')
+
+    expect(result.success).toBe(true)
+    expect(result.ticket?.messages).toEqual([{ id: 'message-1', body: 'Public reply', isInternal: false, authorUsuarioId: 'usuario-1', author: { id: 'usuario-1', nombre: 'Ana', apellido: 'Pérez', photoUrl: null }, createdAt: '2026-06-10T00:01:00Z' }])
+    expect(messagesFilter.eq).toHaveBeenCalledWith('ticket_id', 'ticket-2')
+    expect(messagesFilter.eq).toHaveBeenCalledWith('is_internal', false)
+  })
+
+  it('returns internal messages for staff with support.view-equivalent capability', async () => {
+    const ticketQuery = { select: jest.fn().mockReturnValue({ eq: jest.fn().mockReturnValue({ maybeSingle: jest.fn().mockResolvedValue({ data: { id: 'ticket-3', ticket_number: 44, title: 'Access issue', description: 'Need internal context', status: 'received', category: 'access', severity: 'high', reporter_usuario_id: 'usuario-1', assignee_usuario_id: 'staff-1', reporter: { id: 'usuario-1', nombre: 'Ana', apellido: 'Pérez', foto_perfil_url: null }, assignee: { id: 'staff-1', nombre: 'Soporte', apellido: 'Central', foto_perfil_url: 'https://cdn.example/staff.webp' }, current_route: '/access', browser_name: 'Chrome', os_name: 'macOS', viewport: '1440x900', app_build_version: null, sentry_event_id: null, diagnostics_consent: true, created_at: '2026-06-10T00:00:00Z', updated_at: '2026-06-10T00:05:00Z' }, error: null }) }) }) }
+    const messagesFilter = { eq: jest.fn(), order: jest.fn().mockResolvedValue({ data: [
+      { id: 'message-1', body: 'Public reply', author_usuario_id: 'usuario-1', author: { id: 'usuario-1', nombre: 'Ana', apellido: 'Pérez', foto_perfil_url: null }, is_internal: false, created_at: '2026-06-10T00:01:00Z' },
+      { id: 'message-2', body: 'Internal note', author_usuario_id: 'staff-1', author: { id: 'staff-1', nombre: 'Soporte', apellido: 'Central', foto_perfil_url: 'https://cdn.example/staff.webp' }, is_internal: true, created_at: '2026-06-10T00:02:00Z' },
+    ], error: null }) }
+    messagesFilter.eq.mockReturnValue(messagesFilter)
+    const messagesQuery = { select: jest.fn().mockReturnValue(messagesFilter) }
+    const attachmentsFilter = { eq: jest.fn(), order: jest.fn().mockResolvedValue({ data: [], error: null }) }
+    attachmentsFilter.eq.mockReturnValue(attachmentsFilter)
+    const attachmentsQuery = { select: jest.fn().mockReturnValue(attachmentsFilter) }
+    const eventsFilter = { eq: jest.fn(), order: jest.fn().mockResolvedValue({ data: [
+      { action: 'support.ticket.status_changed', actor_usuario_id: 'staff-1', created_at: '2026-06-10T00:03:00Z', metadata: { status: 'in_progress', source: 'staff', diagnostics: { cookies: 'secret' }, body: 'Private body', r2Key: 'support/ticket-3/private' } },
+    ], error: null }) }
+    eventsFilter.eq.mockReturnValue(eventsFilter)
+    const eventsQuery = { select: jest.fn().mockReturnValue(eventsFilter) }
+    const capabilitiesFilter = { eq: jest.fn(), is: jest.fn().mockResolvedValue({ data: [{ capability: 'support.view' }], error: null }) }
+    capabilitiesFilter.eq.mockReturnValue(capabilitiesFilter)
+
+    createSupabaseServerClient.mockResolvedValue({
+      auth: { getUser: jest.fn().mockResolvedValue({ data: { user: { id: 'staff-1' } } }) },
+      from: jest.fn((table) => {
+        if (table === 'usuarios') return { select: jest.fn().mockReturnValue({ eq: jest.fn().mockReturnValue({ maybeSingle: jest.fn().mockResolvedValue({ data: { id: 'staff-1' }, error: null }) }) }) }
+        if (table === 'support_tickets') return ticketQuery
+        if (table === 'support_ticket_messages') return messagesQuery
+        if (table === 'support_user_capabilities') return { select: jest.fn().mockReturnValue(capabilitiesFilter) }
+        if (table === 'support_ticket_events') return eventsQuery
+        return attachmentsQuery
+      }),
+    })
+
+    const result = await getSupportTicketDetail('ticket-3')
+
+    expect(result.success).toBe(true)
+    expect(result.ticket?.messages).toEqual([
+      { id: 'message-1', body: 'Public reply', isInternal: false, authorUsuarioId: 'usuario-1', author: { id: 'usuario-1', nombre: 'Ana', apellido: 'Pérez', photoUrl: null }, createdAt: '2026-06-10T00:01:00Z' },
+      { id: 'message-2', body: 'Internal note', isInternal: true, authorUsuarioId: 'staff-1', author: { id: 'staff-1', nombre: 'Soporte', apellido: 'Central', photoUrl: 'https://cdn.example/staff.webp' }, createdAt: '2026-06-10T00:02:00Z' },
+    ])
+    expect(result.ticket?.events).toEqual([{ type: 'support.ticket.status_changed', actorUsuarioId: 'staff-1', createdAt: '2026-06-10T00:03:00Z', metadata: { source: 'staff', status: 'in_progress' } }])
+    expect(result.ticket?.events[0].metadata).not.toHaveProperty('diagnostics')
+    expect(result.ticket?.events[0].metadata).not.toHaveProperty('body')
+    expect(result.ticket?.events[0].metadata).not.toHaveProperty('r2Key')
+    expect(eventsQuery.select).toHaveBeenCalledWith('action,actor_usuario_id,created_at,metadata')
+    expect(eventsFilter.eq).toHaveBeenCalledWith('ticket_id', 'ticket-3')
+    expect(messagesFilter.eq).toHaveBeenCalledWith('ticket_id', 'ticket-3')
+    expect(messagesFilter.eq).not.toHaveBeenCalledWith('is_internal', false)
+  })
+
   it('maps Supabase list errors to a stable user-safe message', async () => {
     createSupabaseServerClient.mockResolvedValue({
       auth: { getUser: jest.fn().mockResolvedValue({ data: { user: { id: 'auth-1' } } }) },
@@ -248,38 +342,48 @@ describe('support reporter actions', () => {
   })
 
   it('adds reporter public replies only', async () => {
-    const insert = jest.fn().mockResolvedValue({ error: null })
+    const rpc = jest.fn().mockResolvedValue({ data: { messageId: 'message-1', eventId: 'event-1', actorUserId: 'usuario-1' }, error: null })
     createSupabaseServerClient.mockResolvedValue({
       auth: { getUser: jest.fn().mockResolvedValue({ data: { user: { id: 'auth-1' } } }) },
-      from: createFromMock({ usuarioId: 'usuario-1', insert }),
+      from: createFromMock({ usuarioId: 'usuario-1', insert: jest.fn() }),
+      rpc,
     })
 
     const result = await createSupportTicketMessage('ticket-1', createMessageFormData())
 
     expect(result).toEqual({ success: true })
-    expect(insert).toHaveBeenCalledWith({ ticket_id: 'ticket-1', author_usuario_id: 'usuario-1', body: 'I can reproduce it on mobile.', is_internal: false })
+    expect(rpc).toHaveBeenCalledWith('create_support_ticket_message_with_outbox', { p_ticket_id: 'ticket-1', p_body: 'I can reproduce it on mobile.' })
     expect(revalidatePath).toHaveBeenCalledWith('/ayuda/tickets/ticket-1')
   })
 
-  it('audits reporter public replies after the message commit', async () => {
-    const messageInsert = jest.fn().mockReturnValue({ select: jest.fn().mockReturnValue({ single: jest.fn().mockResolvedValue({ data: { id: 'message-1' }, error: null }) }) })
-    const eventInsert = jest.fn().mockResolvedValue({ error: null })
+  it('creates reporter public replies through the atomic outbox RPC without immediate provider dispatch', async () => {
+    const rpc = jest.fn().mockResolvedValue({ data: { messageId: 'message-1', eventId: 'event-1', actorUserId: 'usuario-1' }, error: null })
     createSupabaseServerClient.mockResolvedValue({
       auth: { getUser: jest.fn().mockResolvedValue({ data: { user: { id: 'auth-1' } } }) },
-      from: createReporterMutationFromMock({ usuarioId: 'usuario-1', messageInsert, eventInsert }),
+      from: createFromMock({ usuarioId: 'usuario-1', insert: jest.fn() }),
+      rpc,
     })
 
     const result = await createSupportTicketMessage('ticket-1', createMessageFormData())
 
     expect(result).toEqual({ success: true })
-    expect(eventInsert).toHaveBeenCalledWith({
-      ticket_id: 'ticket-1',
-      actor_usuario_id: 'usuario-1',
-      action: 'support.reporter_message.created',
-      target_type: 'support_ticket_message',
-      target_id: 'message-1',
-      metadata: { source: 'reporter' },
+    expect(rpc).toHaveBeenCalledWith('create_support_ticket_message_with_outbox', { p_ticket_id: 'ticket-1', p_body: 'I can reproduce it on mobile.' })
+    expect(dispatchSupportInngestEventMock).not.toHaveBeenCalled()
+  })
+
+  it('creates staff replies through the atomic outbox RPC without immediate provider dispatch', async () => {
+    const rpc = jest.fn().mockResolvedValue({ data: { messageId: 'reply-message-1', eventId: 'event-1', actorUserId: 'usuario-1' }, error: null })
+    createSupabaseServerClient.mockResolvedValue({
+      auth: { getUser: jest.fn().mockResolvedValue({ data: { user: { id: 'auth-1' } } }) },
+      from: createStaffActionFromMock({ usuarioId: 'usuario-1', hasCapability: true, capability: 'support.reply' }),
+      rpc,
     })
+
+    const result = await createStaffSupportTicketReply('ticket-1', createMessageFormData())
+
+    expect(result).toEqual({ success: true })
+    expect(rpc).toHaveBeenCalledWith('create_staff_support_ticket_reply_with_outbox', { p_ticket_id: 'ticket-1', p_body: 'I can reproduce it on mobile.' })
+    expect(dispatchSupportInngestEventMock).not.toHaveBeenCalled()
   })
 
   it('denies staff queue access without support.view-equivalent capability', async () => {
@@ -365,7 +469,7 @@ describe('support reporter actions', () => {
   })
 
   it('adds a staff reply through the atomic audit RPC', async () => {
-    const rpc = jest.fn().mockResolvedValue({ error: null })
+    const rpc = jest.fn().mockResolvedValue({ data: { messageId: 'reply-message-1', eventId: 'event-1', actorUserId: 'usuario-1' }, error: null })
     createSupabaseServerClient.mockResolvedValue({
       auth: { getUser: jest.fn().mockResolvedValue({ data: { user: { id: 'auth-1' } } }) },
       from: createStaffActionFromMock({ usuarioId: 'usuario-1', hasCapability: true, capability: 'support.reply' }),
@@ -375,13 +479,13 @@ describe('support reporter actions', () => {
     const result = await createStaffSupportTicketReply('ticket-1', createMessageFormData())
 
     expect(result).toEqual({ success: true })
-    expect(rpc).toHaveBeenCalledWith('create_staff_support_ticket_reply', { p_ticket_id: 'ticket-1', p_body: 'I can reproduce it on mobile.' })
+    expect(rpc).toHaveBeenCalledWith('create_staff_support_ticket_reply_with_outbox', { p_ticket_id: 'ticket-1', p_body: 'I can reproduce it on mobile.' })
     expect(revalidatePath).toHaveBeenCalledWith('/ayuda/tickets/ticket-1')
     expect(revalidatePath).toHaveBeenCalledWith('/ayuda/admin')
   })
 
   it('assigns an unassigned ticket to the managing staff responder after replying', async () => {
-    const rpc = jest.fn().mockResolvedValue({ error: null })
+    const rpc = jest.fn().mockResolvedValue({ data: { messageId: 'reply-message-1', eventId: 'event-1', actorUserId: 'usuario-1' }, error: null })
     createSupabaseServerClient.mockResolvedValue({
       auth: { getUser: jest.fn().mockResolvedValue({ data: { user: { id: 'auth-1' } } }) },
       from: createStaffActionFromMock({ usuarioId: 'usuario-1', hasCapability: true, capability: 'support.manage' }),
@@ -391,12 +495,14 @@ describe('support reporter actions', () => {
     const result = await createStaffSupportTicketReply('ticket-1', createMessageFormData(), { autoAssignIfUnassigned: true })
 
     expect(result).toEqual({ success: true })
-    expect(rpc).toHaveBeenCalledWith('create_staff_support_ticket_reply', { p_ticket_id: 'ticket-1', p_body: 'I can reproduce it on mobile.' })
+    expect(rpc).toHaveBeenCalledWith('create_staff_support_ticket_reply_with_outbox', { p_ticket_id: 'ticket-1', p_body: 'I can reproduce it on mobile.' })
     expect(rpc).toHaveBeenCalledWith('auto_assign_support_ticket_if_unassigned', { p_ticket_id: 'ticket-1' })
   })
 
   it('keeps staff replies successful when best-effort auto-assignment fails', async () => {
-    const rpc = jest.fn((functionName: string) => Promise.resolve({ error: functionName === 'auto_assign_support_ticket_if_unassigned' ? { message: 'assignment failed' } : null }))
+    const rpc = jest.fn((functionName: string) => Promise.resolve(functionName === 'auto_assign_support_ticket_if_unassigned'
+      ? { error: { message: 'assignment failed' } }
+      : { data: { messageId: 'reply-message-1', eventId: 'event-1', actorUserId: 'usuario-1' }, error: null }))
     createSupabaseServerClient.mockResolvedValue({
       auth: { getUser: jest.fn().mockResolvedValue({ data: { user: { id: 'auth-1' } } }) },
       from: createStaffActionFromMock({ usuarioId: 'usuario-1', hasCapability: true, capability: 'support.manage' }),
@@ -408,7 +514,7 @@ describe('support reporter actions', () => {
   })
 
   it('assigns a support ticket through the atomic audit RPC', async () => {
-    const rpc = jest.fn().mockResolvedValue({ error: null })
+    const rpc = jest.fn().mockResolvedValue({ data: { eventId: 'event-1', actorUserId: 'usuario-1' }, error: null })
     createSupabaseServerClient.mockResolvedValue({
       auth: { getUser: jest.fn().mockResolvedValue({ data: { user: { id: 'auth-1' } } }) },
       from: createStaffActionFromMock({ usuarioId: 'usuario-1', hasCapability: true, capability: 'support.manage' }),
@@ -435,8 +541,8 @@ describe('support reporter actions', () => {
     expect(rpc).not.toHaveBeenCalled()
   })
 
-  it('updates a support ticket status through the atomic audit RPC and auto-assigns if still unassigned', async () => {
-    const rpc = jest.fn().mockResolvedValue({ error: null })
+  it('updates a support ticket status through the atomic outbox RPC without immediate provider dispatch', async () => {
+    const rpc = jest.fn().mockResolvedValue({ data: { eventId: 'event-1', actorUserId: 'usuario-1' }, error: null })
     createSupabaseServerClient.mockResolvedValue({
       auth: { getUser: jest.fn().mockResolvedValue({ data: { user: { id: 'auth-1' } } }) },
       from: createStaffActionFromMock({ usuarioId: 'usuario-1', hasCapability: true, capability: 'support.manage' }),
@@ -446,8 +552,31 @@ describe('support reporter actions', () => {
     const result = await updateSupportTicketStatus('ticket-1', 'resolved')
 
     expect(result).toEqual({ success: true })
-    expect(rpc).toHaveBeenCalledWith('update_support_ticket_status', { p_ticket_id: 'ticket-1', p_status: 'resolved' })
+    expect(rpc).toHaveBeenCalledWith('update_support_ticket_status_with_outbox', { p_ticket_id: 'ticket-1', p_status: 'resolved' })
     expect(rpc).toHaveBeenCalledWith('auto_assign_support_ticket_if_unassigned', { p_ticket_id: 'ticket-1' })
+    expect(dispatchSupportInngestEventMock).not.toHaveBeenCalled()
+  })
+
+  it('keeps repeated same-status saves drain-only even with distinct returned audit event ids', async () => {
+    let statusMutationCount = 0
+    const rpc = jest.fn((functionName: string) => {
+      if (functionName === 'update_support_ticket_status_with_outbox') {
+        statusMutationCount += 1
+        return Promise.resolve({ data: { eventId: `event-${statusMutationCount}`, actorUserId: 'usuario-1' }, error: null })
+      }
+      return Promise.resolve({ error: null })
+    })
+    createSupabaseServerClient.mockResolvedValue({
+      auth: { getUser: jest.fn().mockResolvedValue({ data: { user: { id: 'auth-1' } } }) },
+      from: createStaffActionFromMock({ usuarioId: 'usuario-1', hasCapability: true, capability: 'support.manage' }),
+      rpc,
+    })
+
+    await updateSupportTicketStatus('ticket-1', 'resolved')
+    await updateSupportTicketStatus('ticket-1', 'resolved')
+
+    expect(rpc).toHaveBeenCalledWith('update_support_ticket_status_with_outbox', { p_ticket_id: 'ticket-1', p_status: 'resolved' })
+    expect(dispatchSupportInngestEventMock).not.toHaveBeenCalled()
   })
 
   it('maps denied staff status saves to a stable user-safe message', async () => {

--- a/__tests__/lib/support/outbox.test.ts
+++ b/__tests__/lib/support/outbox.test.ts
@@ -1,0 +1,133 @@
+import { drainSupportEventOutbox, enqueueSupportEventOutbox } from '@/lib/support/outbox'
+
+describe('support event outbox', () => {
+  it('enqueues support events with event_key idempotency', async () => {
+    const upsert = jest.fn().mockResolvedValue({ error: null })
+    const supabase = { rpc: jest.fn(), from: jest.fn().mockReturnValue({ upsert }) }
+
+    await expect(enqueueSupportEventOutbox(supabase, {
+      ticketId: 'ticket-1',
+      eventType: 'support/ticket.created',
+      eventKey: 'support:event-1',
+      payload: { eventId: 'event-1', ticketId: 'ticket-1' },
+    })).resolves.toEqual({ success: true })
+
+    expect(supabase.from).toHaveBeenCalledWith('support_event_outbox')
+    expect(upsert).toHaveBeenCalledWith(
+      {
+        ticket_id: 'ticket-1',
+        event_type: 'support/ticket.created',
+        event_key: 'support:event-1',
+        payload: { eventId: 'event-1', ticketId: 'ticket-1' },
+      },
+      { onConflict: 'event_key', ignoreDuplicates: true },
+    )
+  })
+
+  it('treats duplicate event_key errors as idempotent success', async () => {
+    const supabase = {
+      rpc: jest.fn(),
+      from: jest.fn().mockReturnValue({ upsert: jest.fn().mockResolvedValue({ error: { code: '23505', message: 'duplicate key value violates unique constraint' } }) }),
+    }
+
+    await expect(enqueueSupportEventOutbox(supabase, {
+      ticketId: 'ticket-1',
+      eventType: 'support/ticket.created',
+      eventKey: 'support:event-1',
+      payload: {},
+    })).resolves.toEqual({ success: true })
+  })
+
+  it('drains claimed allowed events and marks successful dispatches', async () => {
+    const update = jest.fn(() => ({ eq: jest.fn().mockResolvedValue({ error: null }) }))
+    const supabase = {
+      rpc: jest.fn().mockResolvedValue({
+        data: [claimedRow({ event_type: 'support/ticket.created' })],
+        error: null,
+      }),
+      from: jest.fn().mockReturnValue({ update }),
+    }
+    const dispatch = jest.fn().mockResolvedValue({ success: true })
+
+    await expect(drainSupportEventOutbox(supabase, { dispatch })).resolves.toEqual({
+      success: true,
+      claimed: 1,
+      dispatched: 1,
+      failed: 0,
+    })
+
+    expect(supabase.rpc).toHaveBeenCalledWith('claim_support_event_outbox_batch', { p_limit: 10 })
+    expect(dispatch).toHaveBeenCalledWith(expect.objectContaining({
+      id: 'support:event-1',
+      name: 'support/ticket.created',
+      data: expect.objectContaining({ eventId: 'event-1', ticketId: 'ticket-1' }),
+    }))
+    expect(update).toHaveBeenCalledWith(expect.objectContaining({ status: 'dispatched', last_error: null, locked_at: null }))
+  })
+
+  it('increments attempts and schedules retry when dispatch fails', async () => {
+    const eq = jest.fn().mockResolvedValue({ error: null })
+    const update = jest.fn(() => ({ eq }))
+    const supabase = {
+      rpc: jest.fn().mockResolvedValue({ data: [claimedRow({ attempts: 2 })], error: null }),
+      from: jest.fn().mockReturnValue({ update }),
+    }
+    const now = new Date('2026-06-15T09:00:00.000Z')
+    const dispatch = jest.fn().mockResolvedValue({ success: false, status: 503 })
+
+    await expect(drainSupportEventOutbox(supabase, { now, dispatch })).resolves.toEqual({
+      success: true,
+      claimed: 1,
+      dispatched: 0,
+      failed: 1,
+    })
+
+    expect(update).toHaveBeenCalledWith(expect.objectContaining({
+      status: 'pending',
+      attempts: 3,
+      last_error: 'Support event dispatch failed with status 503',
+      available_at: '2026-06-15T09:00:08.000Z',
+      locked_at: null,
+    }))
+    expect(eq).toHaveBeenCalledWith('id', 'outbox-1')
+  })
+
+  it('marks unsupported event types failed with a safe last_error', async () => {
+    const update = jest.fn(() => ({ eq: jest.fn().mockResolvedValue({ error: null }) }))
+    const supabase = {
+      rpc: jest.fn().mockResolvedValue({ data: [claimedRow({ event_type: 'support/attachment.finalized' })], error: null }),
+      from: jest.fn().mockReturnValue({ update }),
+    }
+    const dispatch = jest.fn()
+
+    await expect(drainSupportEventOutbox(supabase, { now: new Date('2026-06-15T09:00:00.000Z'), dispatch })).resolves.toEqual({
+      success: true,
+      claimed: 1,
+      dispatched: 0,
+      failed: 1,
+    })
+
+    expect(dispatch).not.toHaveBeenCalled()
+    expect(update).toHaveBeenCalledWith(expect.objectContaining({
+      status: 'failed',
+      attempts: 1,
+      last_error: 'Unsupported support outbox event type: support/attachment.finalized',
+      locked_at: null,
+    }))
+    expect(update).toHaveBeenCalledWith(expect.not.objectContaining({
+      available_at: expect.any(String),
+    }))
+  })
+})
+
+function claimedRow(overrides: Record<string, unknown> = {}) {
+  return {
+    id: 'outbox-1',
+    ticket_id: 'ticket-1',
+    event_type: 'support/ticket.created',
+    event_key: 'support:event-1',
+    payload: { eventId: 'event-1', ticketId: 'ticket-1', actorUserId: 'user-1' },
+    attempts: 0,
+    ...overrides,
+  }
+}

--- a/__tests__/supabase/support-ticket-system-migration.test.ts
+++ b/__tests__/supabase/support-ticket-system-migration.test.ts
@@ -19,6 +19,15 @@ function readSupportTicketSql(): string {
     readMigrationBySuffix('_restrict_support_external_inbound_rpc_visibility_privileges.sql'),
     readMigrationBySuffix('_align_support_capability_hierarchy.sql'),
     readMigrationBySuffix('_add_safe_support_ticket_auto_assignment_rpc.sql'),
+    readAtomicSupportOutboxRpcMigration(),
+  ].join('\n')
+}
+
+function readCurrentSupportTicketSql(): string {
+  return [
+    readSupportTicketSql(),
+    readCloseSupportOutboxBypassesMigration(),
+    readRestrictSupportTicketEventsSelectMigration(),
   ].join('\n')
 }
 
@@ -32,6 +41,30 @@ function readSupportStaffDirectMutationMigration(): string {
 
 function readSupportGrantHardeningMigration(): string {
   return readMigrationBySuffix('_harden_support_table_grants.sql')
+}
+
+function readSupportEventOutboxMigration(): string {
+  return readMigrationBySuffix('_add_support_event_outbox.sql')
+}
+
+function readAtomicSupportOutboxRpcMigration(): string {
+  return readMigrationBySuffix('_add_atomic_support_outbox_rpcs.sql')
+}
+
+function readCloseSupportOutboxBypassesMigration(): string {
+  return readMigrationBySuffix('_close_support_outbox_bypasses.sql')
+}
+
+function readRestrictSupportTicketEventsSelectMigration(): string {
+  return readMigrationBySuffix('_restrict_support_ticket_events_select.sql')
+}
+
+function readSupportOutboxClaimingMigration(): string {
+  return readMigrationBySuffix('_add_support_outbox_claiming.sql')
+}
+
+function readTightenSupportOutboxGrantsMigration(): string {
+  return readMigrationBySuffix('_tighten_support_outbox_grants.sql')
 }
 
 function readMigrationBySuffix(suffix: string): string {
@@ -313,7 +346,7 @@ describe('support ticket system migration', () => {
     expect(revokeRpc).not.toMatch(/\bEXECUTE\b/i)
   })
 
-  it('keeps nullable support capability audit events readable only to higher-role support managers', () => {
+  it('keeps nullable support capability audit events staff-only before final event read hardening', () => {
     const sql = readSupportTicketSql()
     const selectPolicy = latestPolicySqlByName(sql, 'support_events_select')
 
@@ -323,6 +356,21 @@ describe('support ticket system migration', () => {
     expect(selectPolicy).toContain('support_private.has_support_configuration_access()')
     expect(selectPolicy).toContain('st.id = ticket_id')
     expect(selectPolicy).toContain("support_private.has_capability('support.view')")
+  })
+
+  it('hardens direct support event reads to staff-only capability checks', () => {
+    const sql = readCurrentSupportTicketSql()
+    const hardeningSql = readRestrictSupportTicketEventsSelectMigration()
+    const selectPolicy = latestPolicySqlByName(sql, 'support_events_select')
+
+    expect(hardeningSql).toContain('REVOKE SELECT ON TABLE public.support_ticket_events FROM anon')
+    expect(hardeningSql).toContain('DROP POLICY IF EXISTS support_events_select ON public.support_ticket_events')
+    expect(selectPolicy).toContain("support_private.has_capability('support.view')")
+    expect(selectPolicy).not.toContain('reporter_usuario_id')
+    expect(selectPolicy).not.toContain('support_private.current_usuario_id()')
+    expect(selectPolicy).not.toContain('st.id = ticket_id')
+    expect(hardeningSql).not.toMatch(/REVOKE\s+SELECT[^;]*ON TABLE public\.support_ticket_events FROM authenticated/i)
+    expect(hardeningSql).not.toMatch(/REVOKE\s+[^;]*ON TABLE public\.support_ticket_events FROM service_role/i)
   })
 
   it('keeps support capability admin RPC execution limited to authenticated callers', () => {
@@ -458,5 +506,132 @@ describe('support ticket system migration', () => {
     expect(sql).toContain('REVOKE ALL PRIVILEGES ON SEQUENCE %s FROM authenticated')
     expect(sql).toContain('GRANT USAGE, SELECT ON SEQUENCE %s TO authenticated')
     expect(sql).toContain('GRANT ALL PRIVILEGES ON SEQUENCE %s TO service_role')
+  })
+
+  it('adds a service-role-only support event outbox for durable pending dispatch', () => {
+    const sql = readSupportEventOutboxMigration()
+
+    expect(sql).toContain('CREATE TABLE IF NOT EXISTS public.support_event_outbox')
+    expect(sql).toContain('id uuid PRIMARY KEY DEFAULT gen_random_uuid()')
+    expect(sql).toContain('ticket_id uuid NOT NULL REFERENCES public.support_tickets(id) ON DELETE CASCADE')
+    expect(sql).toContain('event_type text NOT NULL')
+    expect(sql).toContain('event_key text NOT NULL UNIQUE')
+    expect(sql).toContain("payload jsonb NOT NULL DEFAULT '{}'::jsonb")
+    expect(sql).toContain("status text NOT NULL DEFAULT 'pending' CHECK (status IN ('pending', 'dispatched', 'failed'))")
+    expect(sql).toContain('attempts integer NOT NULL DEFAULT 0 CHECK (attempts >= 0)')
+    expect(sql).toContain("available_at timestamptz NOT NULL DEFAULT timezone('utc', now())")
+    expect(sql).toContain('CREATE INDEX IF NOT EXISTS support_event_outbox_pending_idx')
+    expect(sql).toContain("WHERE status = 'pending'")
+    expect(sql).toContain('CREATE INDEX IF NOT EXISTS support_event_outbox_ticket_idx')
+    expect(sql).toContain('ALTER TABLE public.support_event_outbox ENABLE ROW LEVEL SECURITY')
+    expect(sql).toContain('REVOKE ALL PRIVILEGES ON TABLE public.support_event_outbox FROM anon')
+    expect(sql).toContain('REVOKE ALL PRIVILEGES ON TABLE public.support_event_outbox FROM authenticated')
+    expect(sql).toContain('GRANT SELECT, INSERT, UPDATE, DELETE ON TABLE public.support_event_outbox TO service_role')
+    expect(sql).not.toMatch(/GRANT\s+ALL(?:\s+PRIVILEGES)?\s+ON TABLE public\.support_event_outbox\s+TO service_role/i)
+    expect(sql).not.toMatch(/GRANT\s+[^;]*ON TABLE public\.support_event_outbox\s+TO (anon|authenticated)\b/i)
+  })
+
+  it('adds atomic support mutation RPCs that insert audit and outbox rows before returning', () => {
+    const sql = readAtomicSupportOutboxRpcMigration()
+
+    expect(sql).toContain('CREATE OR REPLACE FUNCTION public.create_support_ticket_with_outbox')
+    expect(sql).toContain('CREATE OR REPLACE FUNCTION public.create_support_ticket_message_with_outbox')
+    expect(sql).toContain('CREATE OR REPLACE FUNCTION public.create_staff_support_ticket_reply_with_outbox')
+    expect(sql).toContain('CREATE OR REPLACE FUNCTION public.update_support_ticket_status_with_outbox')
+    expect(sql).toContain('INSERT INTO public.support_ticket_events')
+    expect(sql).toContain('RETURNING id INTO v_event_id')
+    expect(sql).toContain('INSERT INTO public.support_event_outbox (ticket_id, event_type, event_key, payload)')
+    expect(sql).not.toMatch(/EXCEPTION\s+WHEN/i)
+    expect(sql).not.toContain('ON CONFLICT')
+  })
+
+  it('uses the returned audit event id for status outbox keys so repeated statuses are not deduped', () => {
+    const sql = readAtomicSupportOutboxRpcMigration()
+    const statusFunction = sql.match(/CREATE OR REPLACE FUNCTION public\.update_support_ticket_status_with_outbox[\s\S]*?GRANT EXECUTE ON FUNCTION public\.update_support_ticket_status_with_outbox/)?.[0]
+
+    expect(statusFunction).toContain("'support:' || v_event_id::text")
+    expect(statusFunction).toContain("'eventId', v_event_id::text")
+    expect(statusFunction).not.toContain('p_ticket_id::text || p_status')
+    expect(statusFunction).not.toContain('p_ticket_id::text || \':\' || p_status')
+  })
+
+  it('adds service-role-only support outbox claiming with retry locks', () => {
+    const sql = readSupportOutboxClaimingMigration()
+
+    expect(sql).toContain('ADD COLUMN IF NOT EXISTS locked_at timestamptz')
+    expect(sql).toContain("CHECK (status IN ('pending', 'processing', 'dispatched', 'failed'))")
+    expect(sql).toContain('CREATE OR REPLACE FUNCTION public.claim_support_event_outbox_batch')
+    expect(sql).toContain("SET search_path TO 'public', 'pg_temp'")
+    expect(sql).toContain('FOR UPDATE SKIP LOCKED')
+    expect(sql).toContain("status = 'processing'")
+    expect(sql).toContain('GRANT EXECUTE ON FUNCTION public.claim_support_event_outbox_batch(integer, interval) TO service_role')
+    expect(sql).toContain('REVOKE ALL ON FUNCTION public.claim_support_event_outbox_batch(integer, interval) FROM authenticated')
+    expect(sql).not.toContain('GRANT EXECUTE ON FUNCTION public.claim_support_event_outbox_batch(integer, interval) TO authenticated')
+  })
+
+  it('tightens support outbox grants and drops stale reporter event insert policy', () => {
+    const sql = readTightenSupportOutboxGrantsMigration()
+
+    expect(sql).toContain('REVOKE TRUNCATE, REFERENCES, TRIGGER ON TABLE public.support_event_outbox FROM service_role')
+    expect(sql).toContain('GRANT SELECT, INSERT, UPDATE, DELETE ON TABLE public.support_event_outbox TO service_role')
+    expect(sql).toContain('DROP POLICY IF EXISTS support_events_reporter_insert ON public.support_ticket_events')
+
+    for (const table of ['support_ticket_events', 'support_event_outbox']) {
+      expect(sql).toContain(`REVOKE INSERT, UPDATE, DELETE ON TABLE public.${table} FROM anon`)
+      expect(sql).toContain(`REVOKE INSERT, UPDATE, DELETE ON TABLE public.${table} FROM authenticated`)
+      expect(sql).not.toMatch(new RegExp(`GRANT\\s+[^;]*\\b(INSERT|UPDATE|DELETE)\\b[^;]*ON TABLE public\\.${table}\\s+TO (anon|authenticated)`, 'i'))
+    }
+
+    expect(sql).not.toMatch(/GRANT\s+ALL(?:\s+PRIVILEGES)?\s+ON TABLE public\.support_event_outbox\s+TO service_role/i)
+    expect(sql).not.toMatch(/GRANT\s+[^;]*\b(TRUNCATE|REFERENCES|TRIGGER)\b[^;]*ON TABLE public\.support_event_outbox\s+TO service_role/i)
+  })
+
+  it('closes direct support ticket, message, and event mutation grants after outbox RPCs exist', () => {
+    const sql = readCloseSupportOutboxBypassesMigration()
+
+    for (const table of ['support_tickets', 'support_ticket_messages', 'support_ticket_events']) {
+      expect(sql).toContain(`REVOKE INSERT, UPDATE, DELETE ON TABLE public.${table} FROM anon`)
+      expect(sql).toContain(`REVOKE INSERT, UPDATE, DELETE ON TABLE public.${table} FROM authenticated`)
+      expect(sql).not.toMatch(new RegExp(`GRANT\\s+[^;]*\\b(INSERT|UPDATE|DELETE)\\b[^;]*ON TABLE public\\.${table}\\s+TO (anon|authenticated)`, 'i'))
+    }
+
+    expect(sql).toContain('DROP POLICY IF EXISTS support_tickets_insert ON public.support_tickets')
+    expect(sql).toContain('DROP POLICY IF EXISTS support_tickets_update ON public.support_tickets')
+    expect(sql).toContain('DROP POLICY IF EXISTS support_messages_insert ON public.support_ticket_messages')
+  })
+
+  it('preserves authenticated attachment inserts for the R2 intent path but blocks direct finalization updates', () => {
+    const sql = readCloseSupportOutboxBypassesMigration()
+
+    expect(sql).toContain('REVOKE UPDATE, DELETE ON TABLE public.support_ticket_attachments FROM anon')
+    expect(sql).toContain('REVOKE UPDATE, DELETE ON TABLE public.support_ticket_attachments FROM authenticated')
+    expect(sql).toContain('Keep authenticated INSERT on support_ticket_attachments')
+    expect(sql).not.toMatch(/REVOKE\s+INSERT[^;]*ON TABLE public\.support_ticket_attachments FROM authenticated/i)
+  })
+
+  it('revokes legacy support mutation RPC execution without touching new outbox RPC grants', () => {
+    const bypassSql = readCloseSupportOutboxBypassesMigration()
+    const atomicRpcSql = readAtomicSupportOutboxRpcMigration()
+
+    for (const signature of [
+      'public.create_staff_support_ticket_reply(uuid, text)',
+      'public.update_support_ticket_status(uuid, text)',
+    ]) {
+      expect(bypassSql).toContain(`REVOKE ALL ON FUNCTION ${signature} FROM PUBLIC`)
+      expect(bypassSql).toContain(`REVOKE ALL ON FUNCTION ${signature} FROM anon`)
+      expect(bypassSql).toContain(`REVOKE ALL ON FUNCTION ${signature} FROM authenticated`)
+      expect(bypassSql).toContain(`REVOKE ALL ON FUNCTION ${signature} FROM service_role`)
+      expect(bypassSql).not.toContain(`GRANT EXECUTE ON FUNCTION ${signature} TO authenticated`)
+    }
+
+    for (const signature of [
+      'public.create_support_ticket_with_outbox(text, text, text, text, text, text, text, text, text, boolean)',
+      'public.create_support_ticket_message_with_outbox(uuid, text)',
+      'public.create_staff_support_ticket_reply_with_outbox(uuid, text)',
+      'public.update_support_ticket_status_with_outbox(uuid, text)',
+    ]) {
+      expect(atomicRpcSql).toContain(`REVOKE ALL ON FUNCTION ${signature} FROM PUBLIC`)
+      expect(atomicRpcSql).toContain(`GRANT EXECUTE ON FUNCTION ${signature} TO authenticated`)
+    }
   })
 })

--- a/app/(auth)/ayuda/tickets/[id]/page.tsx
+++ b/app/(auth)/ayuda/tickets/[id]/page.tsx
@@ -22,6 +22,8 @@ export default async function TicketDetailPage({ params }: { params: Promise<{ i
   const ticket = result.ticket
   const canManage = ticket.supportCapabilities.includes('support.manage')
   const canStaffReply = canManage || ticket.supportCapabilities.includes('support.reply')
+  const canViewInternalMessages = canManage || ticket.supportCapabilities.includes('support.view') || ticket.supportCapabilities.includes('support.reply')
+  const safeEvents = ticket.events ?? []
 
   async function replyAction(formData: FormData) {
     'use server'
@@ -101,7 +103,10 @@ export default async function TicketDetailPage({ params }: { params: Promise<{ i
               <TarjetaSistema className="space-y-4 lg:flex lg:h-full lg:min-h-0 lg:flex-col lg:overflow-hidden">
                 <div className="flex flex-col gap-2 sm:flex-row sm:items-end sm:justify-between lg:flex-none">
                   <SectionHeader eyebrow="Actividad" title="Conversación" />
-                  <TextoSistema variante="muted" tamaño="sm">{ticket.messages.length} {ticket.messages.length === 1 ? 'respuesta pública' : 'respuestas públicas'}</TextoSistema>
+                  <TextoSistema variante="muted" tamaño="sm">
+                    {ticket.messages.length} {ticket.messages.length === 1 ? 'interacción' : 'interacciones'}
+                    {canViewInternalMessages ? '' : ' públicas'}
+                  </TextoSistema>
                 </div>
 
                 <div className="lg:min-h-0 lg:flex-1 lg:overflow-y-auto lg:pr-1">
@@ -116,7 +121,7 @@ export default async function TicketDetailPage({ params }: { params: Promise<{ i
                         const roleLabel = isReporter ? 'Solicitante' : 'Soporte'
                         const participant = createParticipant(message.author, roleLabel)
 
-                        return <MessageBubble key={message.id} message={message} participant={participant} roleLabel={roleLabel} isReporter={isReporter} />
+                        return <MessageBubble key={message.id} message={message} participant={participant} roleLabel={roleLabel} isReporter={isReporter} isInternal={message.isInternal ?? false} />
                       })}
                     </div>
                   )}
@@ -161,6 +166,21 @@ export default async function TicketDetailPage({ params }: { params: Promise<{ i
                   ))}
                 </div>
               </TarjetaSistema>
+
+              {canViewInternalMessages && safeEvents.length > 0 && (
+                <TarjetaSistema className="space-y-4 lg:flex-none">
+                  <SectionHeader eyebrow="Staff" title="Actividad" />
+                  <ol className="space-y-3">
+                    {safeEvents.map((event, index) => (
+                      <li key={`${event.type}-${event.createdAt}-${index}`} className="rounded-2xl border border-border bg-muted/20 p-3">
+                        <p className="text-sm font-semibold text-foreground">{formatEventType(event.type)}</p>
+                        <TextoSistema variante="muted" tamaño="sm">{formatMessageTimestamp(event.createdAt)}</TextoSistema>
+                        <SupportEventMetadata event={event} />
+                      </li>
+                    ))}
+                  </ol>
+                </TarjetaSistema>
+              )}
             </aside>
           </div>
         </div>
@@ -220,6 +240,13 @@ type TicketMessage = {
   body: string
   authorUsuarioId?: string
   createdAt: string
+  isInternal?: boolean
+  author: {
+    id: string
+    nombre: string | null
+    apellido: string | null
+    photoUrl: string | null
+  } | null
 }
 
 type TicketAttachment = {
@@ -229,6 +256,31 @@ type TicketAttachment = {
   contentType: string
   byteSize: number
   status: string
+}
+
+type SupportTicketEvent = {
+  type: string
+  createdAt: string
+  actorUsuarioId: string | null
+  metadata: {
+    source?: string
+    status?: string
+    category?: string
+    actor?: string
+  }
+}
+
+function SupportEventMetadata({ event }: { event: SupportTicketEvent }) {
+  const items = [
+    event.actorUsuarioId ? `Actor ${event.actorUsuarioId}` : null,
+    event.metadata.source ? `Origen ${event.metadata.source}` : null,
+    event.metadata.status ? `Estado ${formatSupportStatus(event.metadata.status)}` : null,
+    event.metadata.category ? `Categoría ${formatCategory(event.metadata.category)}` : null,
+    event.metadata.actor ? `Actor ${event.metadata.actor}` : null,
+  ].filter(Boolean)
+
+  if (items.length === 0) return null
+  return <TextoSistema variante="sutil" tamaño="sm">{items.join(' · ')}</TextoSistema>
 }
 
 function AttachmentPreview({ attachment }: { attachment: TicketAttachment }) {
@@ -250,14 +302,15 @@ function getAttachmentRoute(attachmentId: string) {
   return `/api/support/attachments/${attachmentId}/download`
 }
 
-function MessageBubble({ message, participant, roleLabel, isReporter }: { message: TicketMessage; participant: Participant; roleLabel: string; isReporter: boolean }) {
+function MessageBubble({ message, participant, roleLabel, isReporter, isInternal = false }: { message: TicketMessage; participant: Participant; roleLabel: string; isReporter: boolean; isInternal?: boolean }) {
   return (
     <article className={`flex gap-2.5 ${isReporter ? 'justify-start' : 'justify-end'}`}>
       {isReporter && <UserAvatar photoUrl={participant.photoUrl} nombre={participant.nombre} apellido={participant.apellido} size="sm" className="mt-1 ring-2 ring-background" />}
-      <div className={`max-w-[min(92%,42rem)] rounded-2xl border px-3 py-2.5 shadow-sm ${isReporter ? 'rounded-tl-md border-border bg-card/85' : 'rounded-tr-md border-border border-l-4 border-l-[var(--brand-primary)] bg-muted/40'}`}>
+      <div className={`max-w-[min(92%,42rem)] rounded-2xl border px-3 py-2.5 shadow-sm ${isReporter ? 'rounded-tl-md border-border bg-card/85' : 'rounded-tr-md border-border bg-muted/40'} ${isInternal ? 'border-l-4 border-l-amber-500/90 bg-amber-50/35 dark:bg-amber-900/20' : 'border-l-4 border-l-[var(--brand-primary)]'}`}>
         <div className="mb-1 flex flex-wrap items-center gap-x-2 gap-y-0.5">
           <p className="text-sm font-semibold text-foreground">{participant.fullName}</p>
           <span className="text-xs font-medium text-muted-foreground">{roleLabel}</span>
+          {isInternal ? <span className="rounded-full border border-amber-300 bg-amber-100 px-2 py-0.5 text-[10px] font-semibold uppercase tracking-wide text-amber-800 dark:border-amber-500/60 dark:bg-amber-500/15 dark:text-amber-100">Nota interna</span> : null}
           <time className="text-xs text-muted-foreground" dateTime={message.createdAt}>{formatMessageTimestamp(message.createdAt)}</time>
         </div>
         <TextoSistema tamaño="sm" className="whitespace-pre-wrap leading-relaxed">{message.body}</TextoSistema>
@@ -296,6 +349,18 @@ function formatAttachmentStatus(status: string) {
 
 function formatAttachmentKind(kind: string) {
   return kind === 'video' ? 'Video' : 'Captura'
+}
+
+function formatEventType(type: string) {
+  const labels: Record<string, string> = {
+    'support.ticket.created': 'Ticket creado',
+    'support.reporter_message.created': 'Respuesta del solicitante',
+    'support.staff_reply.created': 'Respuesta de soporte',
+    'support.ticket.status_changed': 'Estado actualizado',
+    'support.ticket.assigned': 'Ticket asignado',
+    'support.ticket.auto_assigned': 'Ticket autoasignado',
+  }
+  return labels[type] ?? type
 }
 
 function isPreviewableImage(contentType: string) {

--- a/app/api/support/outbox/drain/route.ts
+++ b/app/api/support/outbox/drain/route.ts
@@ -1,0 +1,37 @@
+import { timingSafeEqual } from 'crypto'
+
+import { createSupabaseAdminClient } from '@/lib/supabase/admin'
+import { drainSupportEventOutbox } from '@/lib/support/outbox'
+
+export const runtime = 'nodejs'
+
+export async function POST(request: Request): Promise<Response> {
+  return drainOutbox(request)
+}
+
+export async function GET(request: Request): Promise<Response> {
+  return drainOutbox(request)
+}
+
+async function drainOutbox(request: Request): Promise<Response> {
+  const secret = process.env.SUPPORT_OUTBOX_DRAIN_SECRET
+  if (!secret) return Response.json({ error: 'Support outbox drain is not configured' }, { status: 503 })
+
+  if (!verifyBearerToken(request.headers.get('authorization'), secret)) {
+    return Response.json({ error: 'Unauthorized support outbox drain request' }, { status: 401 })
+  }
+
+  const result = await drainSupportEventOutbox(createSupabaseAdminClient() as never)
+  if (!result.success) return Response.json({ error: 'Support outbox drain failed' }, { status: 500 })
+
+  return Response.json({ claimed: result.claimed, dispatched: result.dispatched, failed: result.failed }, { status: 202 })
+}
+
+function verifyBearerToken(authorizationHeader: string | null, expectedToken: string) {
+  if (!authorizationHeader || !expectedToken) return false
+
+  const expected = Buffer.from(`Bearer ${expectedToken}`)
+  const received = Buffer.from(authorizationHeader)
+  if (received.length !== expected.length) return false
+  return timingSafeEqual(received, expected)
+}

--- a/docs/support-operations.md
+++ b/docs/support-operations.md
@@ -5,7 +5,7 @@ This runbook covers the operational path for the support ticket system. It is in
 ## Quick Path
 
 1. Confirm the support feature slice being released and review the migration diff before any hosted apply.
-2. Configure server-only provider environment variables for R2, Inngest, Resend, and Sentry/privacy controls in the target environment.
+2. Configure server-only provider environment variables for R2, Inngest, Resend, the support outbox drain scheduler, and Sentry/privacy controls in the target environment.
 3. Apply support migrations only after explicit review approval; do not apply production migrations from an unreviewed local branch.
 4. Verify `/ayuda` reporter flow, staff queue access, private attachment signing, and safe notification payloads with test accounts.
 5. If a rollout issue appears, hide support entry points and disable side effects first; preserve production data unless a reviewed retention/export plan exists.
@@ -16,7 +16,7 @@ This runbook covers the operational path for the support ticket system. It is in
 |------|------|
 | Production Supabase | Migration application is manual, explicit, reviewed, and separate from this documentation change. |
 | R2 | Buckets stay private; signed URLs are issued only after app authorization. |
-| Inngest | Safe dual mode is intentional: `/api/inngest` remains the compatibility custom webhook, while `/api/inngest/official` exposes the official SDK foundation. Events carry IDs only; workers must fetch data after authorization and must be idempotent. |
+| Inngest | Support actions are drain-only: mutations enqueue durable outbox rows, and the protected drain route dispatches provider events. Safe dual mode is intentional: `/api/inngest` remains the compatibility custom webhook, while `/api/inngest/official` exposes the official SDK foundation. Events carry IDs only; workers must fetch data after authorization and must be idempotent. |
 | Resend | Emails contain safe authenticated links only; no evidence, attachments, or raw diagnostics. |
 | Sentry | Support stores Sentry references only; raw payloads, replay media, cookies, headers, and diagnostics are scrubbed. |
 | GitHub | No MVP sync. Future GitHub issues are downstream engineering artifacts only. |
@@ -62,9 +62,11 @@ Operational limits from code and spec:
 - Total active attachments per ticket: max 150 MB.
 - Object keys follow `support/{ticket_id}/{attachment_id}/{safe_filename}`; object keys are not authorization proof.
 
-### Support event processing: safe dual mode
+### Support event processing: drain-only safe dual mode
 
-The app retains `/api/inngest` as a custom authenticated bearer webhook for compatibility with the existing notification path. PR 1 also introduces the official Inngest SDK foundation at `/api/inngest/official` with app id `global-connect`; it must not replace the custom webhook until a later reviewed migration proves equivalent behavior.
+Global Connect owns canonical support state and the durable support event boundary. Ticket creation, reporter public replies, staff public replies, and status changes enqueue `support_event_outbox` rows inside the same database mutation path; actions must not directly dispatch provider events after mutation success. The protected drain route is the only support-event dispatch path.
+
+The app retains `/api/inngest` as a custom authenticated bearer webhook for compatibility with the existing notification path. PR 1 also introduces the official Inngest SDK foundation at `/api/inngest/official` with app id `global-connect`; it must not replace the custom webhook until a later reviewed migration proves equivalent behavior. This remains Safe dual mode, but support mutation dispatch is drain-only.
 
 | Setting | Required | Notes |
 |---------|----------|-------|
@@ -73,6 +75,29 @@ The app retains `/api/inngest` as a custom authenticated bearer webhook for comp
 | Idempotency | Yes | Email keys use `email:{eventId}:{recipient}`. Preserve this shape in any worker integration. |
 | Custom webhook credentials | Existing compatibility path | `SUPPORT_INNGEST_EVENT_URL` and `SUPPORT_INNGEST_WEBHOOK_SECRET` post to `/api/inngest`. Preserve this behavior until replacement is explicitly reviewed. |
 | Official Inngest credentials | Optional foundation path | `SUPPORT_OFFICIAL_INNGEST_ENABLED` and `INNGEST_EVENT_KEY` allow ID-only events to be sent through the official SDK. The official route is `/api/inngest/official`. |
+
+#### Support outbox drain scheduler
+
+The scheduler must call the app route, not Inngest directly:
+
+- Method and path: `POST /api/support/outbox/drain`.
+- Scheduled method and path: `GET /api/support/outbox/drain` via Vercel Cron.
+- Auth: `Authorization: Bearer <configured scheduler secret>`.
+- Required server-only variable: `SUPPORT_OUTBOX_DRAIN_SECRET`.
+- Vercel Cron sends `Authorization: Bearer <CRON_SECRET>` automatically. Configure Vercel `CRON_SECRET` to the same secret value as `SUPPORT_OUTBOX_DRAIN_SECRET`; the route still validates only against `SUPPORT_OUTBOX_DRAIN_SECRET`.
+- Repo scheduler config: `vercel.json` runs `/api/support/outbox/drain` on `*/5 * * * *` UTC. Confirm the Vercel plan supports this cadence before deploy; Hobby plans require a daily cadence.
+- Do not print, paste, store, or commit the actual secret in runbooks, issue comments, smoke logs, screenshots, or examples.
+
+Expected behavior:
+
+- The route returns `503` when `SUPPORT_OUTBOX_DRAIN_SECRET` is missing and `401` for missing/invalid bearer auth.
+- A successful authenticated drain returns counts only: `claimed`, `dispatched`, and `failed`.
+- Allowed durable event types are `support/ticket.created`, `support/ticket.message.created`, and `support/ticket.status.changed`.
+- Successful provider dispatch marks the outbox row `dispatched`.
+- Transient dispatch failures return the row to `pending`, increment `attempts`, record a scrubbed `last_error`, and schedule retry with bounded backoff.
+- Unsupported event types are marked `failed` and are not sent to providers.
+
+Scheduler cadence, hosted environment variables, and secret rotation are deferred operational setup steps. Configure them only in the target runtime after review approval; this repository documentation must never include a real secret value.
 
 Workers must fetch ticket data server-side, avoid long user text in events, and never include evidence, attachment URLs, R2 keys, raw Sentry payloads, diagnostics, cookies, tokens, emails beyond the intended recipient, phone numbers, church/member details, or database internals in queued payloads.
 

--- a/docs/support-operations.md
+++ b/docs/support-operations.md
@@ -85,7 +85,7 @@ The scheduler must call the app route, not Inngest directly:
 - Auth: `Authorization: Bearer <configured scheduler secret>`.
 - Required server-only variable: `SUPPORT_OUTBOX_DRAIN_SECRET`.
 - Vercel Cron sends `Authorization: Bearer <CRON_SECRET>` automatically. Configure Vercel `CRON_SECRET` to the same secret value as `SUPPORT_OUTBOX_DRAIN_SECRET`; the route still validates only against `SUPPORT_OUTBOX_DRAIN_SECRET`.
-- Repo scheduler config: `vercel.json` runs `/api/support/outbox/drain` on `*/5 * * * *` UTC. Confirm the Vercel plan supports this cadence before deploy; Hobby plans require a daily cadence.
+- Repo scheduler config: `vercel.json` runs `/api/support/outbox/drain` daily at `0 8 * * *` UTC so the baseline scheduler is compatible with Vercel Hobby limits. Increase cadence only after confirming the target Vercel plan supports it.
 - Do not print, paste, store, or commit the actual secret in runbooks, issue comments, smoke logs, screenshots, or examples.
 
 Expected behavior:

--- a/lib/actions/support.actions.ts
+++ b/lib/actions/support.actions.ts
@@ -4,7 +4,6 @@ import { revalidatePath } from 'next/cache'
 import { z } from 'zod'
 
 import { diagnosticsConsentSchema, sanitizeSupportEvidence } from '@/lib/support/support-evidence'
-import { createSupportTicketCreatedEvent, dispatchSupportInngestEvent } from '@/lib/support/inngest'
 import { createSupabaseAdminClient } from '@/lib/supabase/admin'
 import { createSupabaseServerClient } from '@/lib/supabase/server'
 
@@ -44,7 +43,6 @@ const SUPPORT_STAFF_QUEUE_ERROR = 'No se pudo cargar la cola de soporte'
 const SUPPORT_STAFF_REPLY_ERROR = 'No se pudo enviar la respuesta de soporte del equipo'
 const SUPPORT_STAFF_ASSIGNMENT_ERROR = 'No se pudo asignar el ticket de soporte'
 const SUPPORT_STAFF_STATUS_ERROR = 'No se pudo actualizar el estado del ticket de soporte'
-const DEFAULT_REPORTER_SEVERITY = 'normal'
 type SupportCapability = 'support.view' | 'support.reply' | 'support.manage'
 type SupportActionResult<T extends Record<string, unknown> = Record<string, never>> = ({ success: true } & T) | { success: false; error: string }
 
@@ -72,8 +70,10 @@ type SupportTicketRow = {
 }
 
 type UsuarioProfileRow = { id: string; nombre: string | null; apellido: string | null; foto_perfil_url: string | null }
-type SupportMessageRow = { id: string; body: string; author_usuario_id: string; created_at: string; author?: UsuarioProfileRow | null }
+type SupportMessageRow = { id: string; body: string; is_internal: boolean; author_usuario_id: string; created_at: string; author?: UsuarioProfileRow | null }
 type SupportAttachmentRow = { id: string; original_filename: string; kind: string; content_type: string; byte_size: number; status: string }
+type SupportTicketEventRow = { action: string; actor_usuario_id: string | null; created_at: string; metadata: unknown }
+type SupportOutboxMutationResult = { ticketId?: string; ticketNumber?: number; messageId?: string; eventId: string; actorUserId: string }
 
 type StaffSupportTicketRow = Pick<SupportTicketRow, 'id' | 'ticket_number' | 'title' | 'status' | 'category' | 'severity' | 'created_at' | 'updated_at'> & {
   assignee_usuario_id: string | null
@@ -90,31 +90,25 @@ export async function createSupportTicket(formData: FormData): Promise<SupportAc
   const actor = await getActorUsuarioId(supabase)
   if (!actor.success) return actor
 
-  const { data, error } = await supabase.from('support_tickets').insert({
-    reporter_usuario_id: actor.usuarioId,
-    status: 'received',
-    title: parsed.data.subject,
-    description: parsed.data.description,
-    category: parsed.data.category,
-    severity: DEFAULT_REPORTER_SEVERITY,
-    ...sanitizeSupportEvidence(parsed.data),
-  }).select('id,ticket_number').single()
+  const evidence = sanitizeSupportEvidence(parsed.data)
+  const { data, error } = await supabase.rpc('create_support_ticket_with_outbox' as never, {
+    p_subject: parsed.data.subject,
+    p_description: parsed.data.description,
+    p_category: parsed.data.category,
+    p_current_route: evidence.current_route,
+    p_browser_name: evidence.browser_name,
+    p_os_name: evidence.os_name,
+    p_viewport: evidence.viewport,
+    p_app_build_version: evidence.app_build_version,
+    p_sentry_event_id: evidence.sentry_event_id,
+    p_diagnostics_consent: evidence.diagnostics_consent,
+  } as never)
 
-  if (error || !data) return { success: false, error: SUPPORT_TICKET_CREATE_ERROR }
+  const mutation = readSupportOutboxMutationResult(data)
+  if (error || !mutation?.ticketId || typeof mutation.ticketNumber !== 'number') return { success: false, error: SUPPORT_TICKET_CREATE_ERROR }
 
-  const audit = await appendSupportTicketEvent(supabase, {
-    ticketId: data.id,
-    actorUsuarioId: actor.usuarioId,
-    action: 'support.ticket.created',
-    targetType: 'support_ticket',
-    targetId: data.id,
-    metadata: { source: 'reporter' },
-  })
-  if (!audit.success) return { success: false, error: SUPPORT_TICKET_CREATE_ERROR }
-
-  await dispatchSupportInngestEvent(createSupportTicketCreatedEvent({ eventId: audit.eventId, ticketId: data.id, actorUserId: actor.usuarioId }))
   revalidatePath('/ayuda/tickets')
-  return { success: true, ticketId: data.id, ticketNumber: data.ticket_number }
+  return { success: true, ticketId: mutation.ticketId, ticketNumber: mutation.ticketNumber }
 }
 
 export async function createSupportTicketFromForm(_previousState: SupportActionResult<{ ticketId: string; ticketNumber: number }> | null, formData: FormData): Promise<SupportActionResult<{ ticketId: string; ticketNumber: number }>> {
@@ -173,8 +167,9 @@ export async function createStaffSupportTicketReply(ticketId: string, formData: 
   const capability = await requireSupportCapability(supabase, actor.usuarioId, 'support.reply')
   if (!capability.success) return capability
 
-  const { error } = await supabase.rpc('create_staff_support_ticket_reply' as never, { p_ticket_id: ticketId, p_body: parsed.data.body } as never)
-  if (error) return { success: false, error: SUPPORT_STAFF_REPLY_ERROR }
+  const { data, error } = await supabase.rpc('create_staff_support_ticket_reply_with_outbox' as never, { p_ticket_id: ticketId, p_body: parsed.data.body } as never)
+  const mutation = readSupportOutboxMutationResult(data)
+  if (error || !mutation?.messageId) return { success: false, error: SUPPORT_STAFF_REPLY_ERROR }
 
   if (options.autoAssignIfUnassigned) {
     const manageCapability = await requireSupportCapability(supabase, actor.usuarioId, 'support.manage')
@@ -216,8 +211,9 @@ export async function updateSupportTicketStatus(ticketId: string, status: string
   const capability = await requireSupportCapability(supabase, actor.usuarioId, 'support.manage')
   if (!capability.success) return capability
 
-  const { error } = await supabase.rpc('update_support_ticket_status' as never, { p_ticket_id: ticketId, p_status: parsed.data } as never)
-  if (error) return { success: false, error: SUPPORT_STAFF_STATUS_ERROR }
+  const { data, error } = await supabase.rpc('update_support_ticket_status_with_outbox' as never, { p_ticket_id: ticketId, p_status: parsed.data } as never)
+  const mutation = readSupportOutboxMutationResult(data)
+  if (error || !mutation) return { success: false, error: SUPPORT_STAFF_STATUS_ERROR }
   await supabase.rpc('auto_assign_support_ticket_if_unassigned' as never, { p_ticket_id: ticketId } as never)
 
   revalidatePath(`/ayuda/tickets/${ticketId}`)
@@ -238,13 +234,19 @@ export async function getSupportTicketDetail(ticketId: string) {
 
   if (error) return { success: false, error: SUPPORT_TICKET_DETAIL_ERROR }
   if (!ticket) return { success: false, error: 'Ticket no encontrado' }
+  const supportCapabilities = await listActorSupportCapabilities(supabase, actor.usuarioId)
 
-  const { data: messages, error: messagesError } = await supabase
+  const hasInternalCapability = hasSupportCapability(supportCapabilities, 'support.view')
+  const messageQuery = supabase
     .from('support_ticket_messages')
-    .select('id,body,author_usuario_id,created_at,author:usuarios!support_ticket_messages_author_usuario_id_fkey(id,nombre,apellido,foto_perfil_url)')
+    .select('id,body,author_usuario_id,created_at,is_internal,author:usuarios!support_ticket_messages_author_usuario_id_fkey(id,nombre,apellido,foto_perfil_url)')
     .eq('ticket_id', ticketId)
-    .eq('is_internal', false)
-    .order('created_at', { ascending: true })
+
+  if (!hasInternalCapability) {
+    messageQuery.eq('is_internal', false)
+  }
+
+  const { data: messages, error: messagesError } = await messageQuery.order('created_at', { ascending: true })
 
   if (messagesError) return { success: false, error: SUPPORT_TICKET_DETAIL_ERROR }
 
@@ -256,9 +258,10 @@ export async function getSupportTicketDetail(ticketId: string) {
     .order('created_at', { ascending: true })
 
   if (attachmentsError) return { success: false, error: SUPPORT_TICKET_DETAIL_ERROR }
-  const supportCapabilities = await listActorSupportCapabilities(supabase, actor.usuarioId)
+  const events = hasInternalCapability ? await fetchSafeSupportTicketEvents(supabase, ticketId) : []
+  if (events === null) return { success: false, error: SUPPORT_TICKET_DETAIL_ERROR }
   const profiles = await fetchVisibleSupportProfiles(ticket as SupportTicketRow, messages ?? [])
-  return { success: true, ticket: toTicketDetail(ticket as SupportTicketRow, messages ?? [], attachments ?? [], supportCapabilities, profiles) }
+  return { success: true, ticket: toTicketDetail(ticket as SupportTicketRow, messages ?? [], attachments ?? [], supportCapabilities, profiles, events) }
 }
 
 export async function createSupportTicketMessage(ticketId: string, formData: FormData) {
@@ -269,79 +272,37 @@ export async function createSupportTicketMessage(ticketId: string, formData: For
   const actor = await getActorUsuarioId(supabase)
   if (!actor.success) return actor
 
-  const messageInsertResult = supabase.from('support_ticket_messages').insert({
-    ticket_id: ticketId,
-    author_usuario_id: actor.usuarioId,
-    body: parsed.data.body,
-    is_internal: false,
-  })
-  const message = await resolveInsertWithOptionalSingle(messageInsertResult)
-
-  if (message.error) return { success: false, error: SUPPORT_TICKET_MESSAGE_ERROR }
-
-  const audit = await appendSupportTicketEvent(supabase, {
-    ticketId,
-    actorUsuarioId: actor.usuarioId,
-    action: 'support.reporter_message.created',
-    targetType: 'support_ticket_message',
-    targetId: message.id ?? null,
-    metadata: { source: 'reporter' },
-  })
-  if (!audit.success) return { success: false, error: SUPPORT_TICKET_MESSAGE_ERROR }
+  const { data, error } = await supabase.rpc('create_support_ticket_message_with_outbox' as never, { p_ticket_id: ticketId, p_body: parsed.data.body } as never)
+  const mutation = readSupportOutboxMutationResult(data)
+  if (error || !mutation?.messageId) return { success: false, error: SUPPORT_TICKET_MESSAGE_ERROR }
 
   revalidatePath(`/ayuda/tickets/${ticketId}`)
   return { success: true }
 }
 
-async function appendSupportTicketEvent(
-  supabase: Awaited<ReturnType<typeof createSupabaseServerClient>>,
-  input: {
-    ticketId: string
-    actorUsuarioId: string
-    action: string
-    targetType: string
-    targetId: string | null
-    metadata: Record<string, string>
+function readSupportOutboxMutationResult(value: unknown): SupportOutboxMutationResult | null {
+  if (typeof value !== 'object' || value === null) return null
+  const row = value as Record<string, unknown>
+  const eventId = readString(row.eventId)
+  const actorUserId = readString(row.actorUserId)
+  if (!eventId || !actorUserId) return null
+  return {
+    eventId,
+    actorUserId,
+    ticketId: readString(row.ticketId),
+    ticketNumber: readNumber(row.ticketNumber),
+    messageId: readString(row.messageId),
   }
-) {
-  const insertResult = supabase.from('support_ticket_events').insert({
-    ticket_id: input.ticketId,
-    actor_usuario_id: input.actorUsuarioId,
-    action: input.action,
-    target_type: input.targetType,
-    target_id: input.targetId,
-    metadata: input.metadata,
-  })
-  const event = await resolveInsertWithOptionalSingle(insertResult)
-
-  if (event.error) return { success: false as const }
-  return { success: true as const, eventId: event.id ?? `${input.action}:${input.ticketId}` }
 }
 
-async function resolveInsertWithOptionalSingle(insertResult: unknown): Promise<{ id: string | null; error: unknown }> {
-  if (hasSelect(insertResult)) {
-    const selected = insertResult.select('id')
-    if (hasSingle(selected)) {
-      const { data, error } = await selected.single()
-      return { id: readInsertedId(data), error }
-    }
-  }
-
-  const result = await insertResult as { error?: unknown }
-  return { id: null, error: result?.error ?? null }
+function readString(value: unknown) {
+  return typeof value === 'string' && value.length > 0 ? value : undefined
 }
 
-function hasSelect(value: unknown): value is { select: (columns: string) => unknown } {
-  return typeof value === 'object' && value !== null && 'select' in value && typeof value.select === 'function'
-}
-
-function hasSingle(value: unknown): value is { single: () => Promise<{ data: unknown; error: unknown }> } {
-  return typeof value === 'object' && value !== null && 'single' in value && typeof value.single === 'function'
-}
-
-function readInsertedId(value: unknown) {
-  if (typeof value !== 'object' || value === null || !('id' in value) || typeof value.id !== 'string') return null
-  return value.id
+function readNumber(value: unknown) {
+  if (typeof value === 'number' && Number.isFinite(value)) return value
+  if (typeof value === 'string' && value.trim() !== '' && Number.isFinite(Number(value))) return Number(value)
+  return undefined
 }
 
 async function getActorUsuarioId(supabase: Awaited<ReturnType<typeof createSupabaseServerClient>>) {
@@ -383,7 +344,7 @@ function toTicketSummary(ticket: Omit<SupportTicketRow, 'description' | 'reporte
   return { id: ticket.id, ticketNumber: ticket.ticket_number, title: ticket.title, status: ticket.status, category: ticket.category, severity: ticket.severity, createdAt: ticket.created_at, updatedAt: ticket.updated_at }
 }
 
-function toTicketDetail(ticket: SupportTicketRow, messages: SupportMessageRow[], attachments: SupportAttachmentRow[], supportCapabilities: SupportCapability[], profiles: Map<string, UsuarioProfileRow> = new Map()) {
+function toTicketDetail(ticket: SupportTicketRow, messages: SupportMessageRow[], attachments: SupportAttachmentRow[], supportCapabilities: SupportCapability[], profiles: Map<string, UsuarioProfileRow> = new Map(), events: SafeSupportTicketEvent[] = []) {
   return {
     ...toTicketSummary(ticket),
     description: ticket.description,
@@ -392,10 +353,64 @@ function toTicketDetail(ticket: SupportTicketRow, messages: SupportMessageRow[],
     reporter: toSafeUsuarioProfile(ticket.reporter ?? profiles.get(ticket.reporter_usuario_id)),
     assignee: toSafeUsuarioProfile(ticket.assignee ?? (ticket.assignee_usuario_id ? profiles.get(ticket.assignee_usuario_id) : null)),
     evidence: { currentRoute: ticket.current_route, browserName: ticket.browser_name, osName: ticket.os_name, viewport: ticket.viewport, appBuildVersion: ticket.app_build_version, sentryEventId: ticket.sentry_event_id, diagnosticsConsent: ticket.diagnostics_consent },
-    messages: messages.map((message) => ({ id: message.id, body: message.body, authorUsuarioId: message.author_usuario_id, author: toSafeUsuarioProfile(message.author ?? profiles.get(message.author_usuario_id)), createdAt: message.created_at })),
+    messages: messages.map((message) => ({ id: message.id, body: message.body, isInternal: message.is_internal, authorUsuarioId: message.author_usuario_id, author: toSafeUsuarioProfile(message.author ?? profiles.get(message.author_usuario_id)), createdAt: message.created_at })),
     attachments: attachments.map((attachment) => ({ id: attachment.id, filename: attachment.original_filename, kind: attachment.kind, contentType: attachment.content_type, byteSize: attachment.byte_size, status: attachment.status })),
+    events,
     supportCapabilities,
   }
+}
+
+type SafeSupportTicketEvent = {
+  type: string
+  createdAt: string
+  actorUsuarioId: string | null
+  metadata: {
+    source?: string
+    status?: string
+    category?: string
+    actor?: string
+  }
+}
+
+async function fetchSafeSupportTicketEvents(supabase: Awaited<ReturnType<typeof createSupabaseServerClient>>, ticketId: string): Promise<SafeSupportTicketEvent[] | null> {
+  const { data, error } = await supabase
+    .from('support_ticket_events')
+    .select('action,actor_usuario_id,created_at,metadata')
+    .eq('ticket_id', ticketId)
+    .order('created_at', { ascending: true })
+
+  if (error) return null
+  return (data ?? []).map((event) => toSafeSupportTicketEvent(event as SupportTicketEventRow))
+}
+
+function toSafeSupportTicketEvent(event: SupportTicketEventRow): SafeSupportTicketEvent {
+  return {
+    type: event.action,
+    createdAt: event.created_at,
+    actorUsuarioId: event.actor_usuario_id,
+    metadata: pickSafeSupportEventMetadata(event.metadata),
+  }
+}
+
+function pickSafeSupportEventMetadata(metadata: unknown): SafeSupportTicketEvent['metadata'] {
+  if (!metadata || typeof metadata !== 'object' || Array.isArray(metadata)) return {}
+  const source = readSafeMetadataString((metadata as Record<string, unknown>).source)
+  const status = readSafeMetadataString((metadata as Record<string, unknown>).status)
+  const category = readSafeMetadataString((metadata as Record<string, unknown>).category)
+  const actor = readSafeMetadataString((metadata as Record<string, unknown>).actor)
+  return {
+    ...(source ? { source } : {}),
+    ...(status ? { status } : {}),
+    ...(category ? { category } : {}),
+    ...(actor ? { actor } : {}),
+  }
+}
+
+function readSafeMetadataString(value: unknown) {
+  if (typeof value !== 'string') return undefined
+  const trimmed = value.trim()
+  if (trimmed.length === 0 || trimmed.length > 120) return undefined
+  return trimmed
 }
 
 async function fetchVisibleSupportProfiles(ticket: SupportTicketRow, messages: SupportMessageRow[]) {

--- a/lib/supabase/database.types.ts
+++ b/lib/supabase/database.types.ts
@@ -2383,6 +2383,59 @@ export type Database = {
           },
         ]
       }
+      support_event_outbox: {
+        Row: {
+          attempts: number
+          available_at: string
+          created_at: string
+          event_key: string
+          event_type: string
+          id: string
+          last_error: string | null
+          locked_at: string | null
+          payload: Json
+          status: string
+          ticket_id: string
+          updated_at: string
+        }
+        Insert: {
+          attempts?: number
+          available_at?: string
+          created_at?: string
+          event_key: string
+          event_type: string
+          id?: string
+          last_error?: string | null
+          locked_at?: string | null
+          payload?: Json
+          status?: string
+          ticket_id: string
+          updated_at?: string
+        }
+        Update: {
+          attempts?: number
+          available_at?: string
+          created_at?: string
+          event_key?: string
+          event_type?: string
+          id?: string
+          last_error?: string | null
+          locked_at?: string | null
+          payload?: Json
+          status?: string
+          ticket_id?: string
+          updated_at?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "support_event_outbox_ticket_id_fkey"
+            columns: ["ticket_id"]
+            isOneToOne: false
+            referencedRelation: "support_tickets"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
       support_ticket_attachments: {
         Row: {
           bucket: string
@@ -3861,20 +3914,6 @@ export type Database = {
         }
         Returns: boolean
       }
-      record_support_external_inbound_update: {
-        Args: {
-          p_ticket_id: string
-          p_author_usuario_id: string
-          p_message_body: string
-          p_idempotency_key: string
-          p_is_internal: boolean
-        }
-        Returns: {
-          duplicate: boolean
-          event_id: string
-          message_id: string | null
-        }[]
-      }
       actualizar_rol_miembro: {
         Args: {
           p_auth_id: string
@@ -3947,6 +3986,10 @@ export type Database = {
         }
         Returns: Json
       }
+      assign_support_ticket: {
+        Args: { p_assignee_usuario_id: string; p_ticket_id: string }
+        Returns: undefined
+      }
       buscar_usuarios_para_grupo: {
         Args: {
           p_auth_id: string
@@ -3962,6 +4005,29 @@ export type Database = {
           telefono: string
           ya_es_miembro: boolean
         }[]
+      }
+      claim_support_event_outbox_batch: {
+        Args: { p_limit?: number; p_lock_timeout?: string }
+        Returns: {
+          attempts: number
+          available_at: string
+          created_at: string
+          event_key: string
+          event_type: string
+          id: string
+          last_error: string | null
+          locked_at: string | null
+          payload: Json
+          status: string
+          ticket_id: string
+          updated_at: string
+        }[]
+        SetofOptions: {
+          from: "*"
+          to: "support_event_outbox"
+          isOneToOne: false
+          isSetofReturn: true
+        }
       }
       contar_solicitudes_pendientes: {
         Args: { p_auth_id: string }
@@ -3989,6 +4055,33 @@ export type Database = {
         }
         Returns: Json
       }
+      create_staff_support_ticket_reply: {
+        Args: { p_body: string; p_ticket_id: string }
+        Returns: string
+      }
+      create_staff_support_ticket_reply_with_outbox: {
+        Args: { p_body: string; p_ticket_id: string }
+        Returns: Json
+      }
+      create_support_ticket_message_with_outbox: {
+        Args: { p_body: string; p_ticket_id: string }
+        Returns: Json
+      }
+      create_support_ticket_with_outbox: {
+        Args: {
+          p_app_build_version?: string
+          p_browser_name?: string
+          p_category: string
+          p_current_route?: string
+          p_description: string
+          p_diagnostics_consent?: boolean
+          p_os_name?: string
+          p_sentry_event_id?: string
+          p_subject: string
+          p_viewport?: string
+        }
+        Returns: Json
+      }
       eliminar_miembro_de_grupo: {
         Args: { p_auth_id: string; p_grupo_id: string; p_usuario_id: string }
         Returns: Json
@@ -4013,6 +4106,10 @@ export type Database = {
       es_superadmin: { Args: { p_auth_uid: string }; Returns: boolean }
       expirar_solicitudes_vencidas: { Args: never; Returns: number }
       get_my_internal_id: { Args: never; Returns: string }
+      grant_support_capability: {
+        Args: { p_capability: string; p_target_usuario_id: string }
+        Returns: undefined
+      }
       is_admin: { Args: never; Returns: boolean }
       listar_eventos_grupo: {
         Args: {
@@ -4348,6 +4445,20 @@ export type Database = {
         Args: { p_target_user_id: string; p_viewer_id: string }
         Returns: boolean
       }
+      record_support_external_inbound_update: {
+        Args: {
+          p_author_usuario_id: string
+          p_idempotency_key: string
+          p_is_internal: boolean
+          p_message_body: string
+          p_ticket_id: string
+        }
+        Returns: {
+          duplicate: boolean
+          event_id: string
+          message_id: string
+        }[]
+      }
       registrar_asistencia: {
         Args: {
           p_asistencias?: Json
@@ -4368,6 +4479,10 @@ export type Database = {
         Returns: Json
       }
       resumen_dashboard_admin: { Args: { p_campus_id?: string }; Returns: Json }
+      revoke_support_capability: {
+        Args: { p_capability: string; p_target_usuario_id: string }
+        Returns: undefined
+      }
       show_limit: { Args: never; Returns: number }
       show_trgm: { Args: { "": string }; Returns: string[] }
       sugerir_nombre_grupo: {
@@ -4379,6 +4494,14 @@ export type Database = {
         Returns: string
       }
       tiene_rol_de_liderazgo: { Args: { p_auth_id: string }; Returns: boolean }
+      update_support_ticket_status: {
+        Args: { p_status: string; p_ticket_id: string }
+        Returns: undefined
+      }
+      update_support_ticket_status_with_outbox: {
+        Args: { p_status: string; p_ticket_id: string }
+        Returns: Json
+      }
     }
     Enums: {
       enum_dia_semana:

--- a/lib/support/inngest-route.ts
+++ b/lib/support/inngest-route.ts
@@ -30,6 +30,12 @@ const SUPPORT_EVENT_NAMES = new Set([
   'support/external.update.received',
 ])
 
+const SUPPORT_NOTIFICATION_EVENT_NAMES = new Set([
+  'support/ticket.created',
+  'support/ticket.message.created',
+  'support/ticket.status.changed',
+])
+
 export async function supportInngestRoute(request: Request): Promise<Response> {
   const secret = process.env.SUPPORT_INNGEST_WEBHOOK_SECRET
   if (!secret) {
@@ -51,7 +57,9 @@ export async function supportInngestRoute(request: Request): Promise<Response> {
   }
 
   if (process.env.SUPABASE_URL && process.env.SUPABASE_SERVICE_ROLE_KEY) {
-    await deliverSupportNotificationEvent(toSupportNotificationEvent(event), createSupabaseAdminClient())
+    if (SUPPORT_NOTIFICATION_EVENT_NAMES.has(event.name)) {
+      await deliverSupportNotificationEvent(toSupportNotificationEvent(event), createSupabaseAdminClient())
+    }
   }
 
   return jsonResponse({ accepted: true, eventId: event.data.eventId, name: event.name }, 202)

--- a/lib/support/outbox.ts
+++ b/lib/support/outbox.ts
@@ -1,0 +1,252 @@
+type SupportEventOutboxClient = {
+  rpc: (functionName: string, args: Record<string, unknown>) => Promise<{ data?: SupportEventOutboxClaimedRow[] | null; error?: SupportEventOutboxError | null }>
+  from: (table: string) => {
+    upsert: (
+      values: SupportEventOutboxRow,
+      options: { onConflict: 'event_key'; ignoreDuplicates: true },
+    ) => Promise<{ error?: SupportEventOutboxError | null }>
+    update: (values: Record<string, unknown>) => {
+      eq: (column: string, value: string) => Promise<{ error?: SupportEventOutboxError | null }>
+    }
+  }
+}
+
+type SupportEventOutboxError = {
+  code?: string
+  message?: string
+}
+
+type SupportEventOutboxRow = {
+  ticket_id: string
+  event_type: string
+  event_key: string
+  payload: unknown
+}
+
+type SupportEventOutboxClaimedRow = SupportEventOutboxRow & {
+  id: string
+  attempts: number
+}
+
+type SupportEventOutboxDispatchEvent = {
+  id: string
+  name: 'support/ticket.created' | 'support/ticket.message.created' | 'support/ticket.status.changed'
+  data: {
+    eventId: string
+    ticketId: string
+    actorUserId?: string
+    messageId?: string
+  }
+}
+
+type SupportEventOutboxDispatchResult =
+  | { success: true; skipped?: boolean; reason?: string; status?: number }
+  | { success: false; error?: unknown; status?: number }
+
+type DrainSupportEventOutboxOptions = {
+  limit?: number
+  now?: Date
+  dispatch?: (event: SupportEventOutboxDispatchEvent) => Promise<SupportEventOutboxDispatchResult>
+}
+
+const ALLOWED_SUPPORT_OUTBOX_EVENT_TYPES = new Set<SupportEventOutboxDispatchEvent['name']>([
+  'support/ticket.created',
+  'support/ticket.message.created',
+  'support/ticket.status.changed',
+])
+
+const DEFAULT_DRAIN_LIMIT = 10
+const MAX_DRAIN_LIMIT = 50
+const MAX_LAST_ERROR_LENGTH = 500
+
+export type EnqueueSupportEventOutboxInput = {
+  ticketId: string
+  eventType: string
+  eventKey: string
+  payload: unknown
+}
+
+export async function enqueueSupportEventOutbox(
+  supabase: SupportEventOutboxClient,
+  input: EnqueueSupportEventOutboxInput,
+) {
+  const { error } = await supabase
+    .from('support_event_outbox')
+    .upsert(
+      {
+        ticket_id: input.ticketId,
+        event_type: input.eventType,
+        event_key: input.eventKey,
+        payload: input.payload,
+      },
+      { onConflict: 'event_key', ignoreDuplicates: true },
+    )
+
+  if (!error || error.code === '23505') return { success: true as const }
+  return { success: false as const, error }
+}
+
+export async function drainSupportEventOutbox(
+  supabase: SupportEventOutboxClient,
+  options: DrainSupportEventOutboxOptions = {},
+) {
+  const limit = clampDrainLimit(options.limit)
+  const now = options.now ?? new Date()
+  const dispatch = options.dispatch ?? defaultDispatchSupportOutboxEvent
+  const { data, error } = await supabase.rpc('claim_support_event_outbox_batch', { p_limit: limit })
+
+  if (error) return { success: false as const, error, claimed: 0, dispatched: 0, failed: 0 }
+
+  const rows = data ?? []
+  let dispatched = 0
+  let failed = 0
+
+  for (const row of rows) {
+    if (!isSupportedSupportOutboxEventType(row.event_type)) {
+      failed += 1
+      await markSupportOutboxFailed(supabase, row, `Unsupported support outbox event type: ${row.event_type}`, now)
+      continue
+    }
+
+    const event = toSupportOutboxDispatchEvent(row)
+    if (!event.success) {
+      failed += 1
+      await markSupportOutboxRetry(supabase, row, event.error, now)
+      continue
+    }
+
+    const result = await dispatch(event.event)
+    if (result.success) {
+      dispatched += 1
+      await markSupportOutboxDispatched(supabase, row.id)
+      continue
+    }
+
+    failed += 1
+    await markSupportOutboxRetry(supabase, row, dispatchErrorMessage(result), now)
+  }
+
+  return { success: true as const, claimed: rows.length, dispatched, failed }
+}
+
+function toSupportOutboxDispatchEvent(row: SupportEventOutboxClaimedRow) {
+  const name = row.event_type as SupportEventOutboxDispatchEvent['name']
+
+  if (!row.payload || typeof row.payload !== 'object') {
+    return { success: false as const, error: 'Invalid support outbox payload' }
+  }
+
+  const payload = row.payload as Record<string, unknown>
+  const eventId = readString(payload.eventId)
+  const ticketId = readString(payload.ticketId)
+  if (!eventId || !ticketId) return { success: false as const, error: 'Invalid support outbox payload ids' }
+
+  if (row.event_type === 'support/ticket.message.created') {
+    const messageId = readString(payload.messageId)
+    if (!messageId) return { success: false as const, error: 'Invalid support outbox message payload' }
+    return { success: true as const, event: { id: row.event_key, name, data: { eventId, ticketId, messageId, actorUserId: readString(payload.actorUserId) } } }
+  }
+
+  return { success: true as const, event: { id: row.event_key, name, data: { eventId, ticketId, actorUserId: readString(payload.actorUserId) } } }
+}
+
+async function defaultDispatchSupportOutboxEvent(event: SupportEventOutboxDispatchEvent) {
+  const {
+    dispatchSupportInngestEvent,
+    createSupportTicketCreatedEvent,
+    createSupportTicketMessageCreatedEvent,
+    createSupportTicketStatusChangedEvent,
+  } = await import('@/lib/support/inngest')
+
+  if (event.name === 'support/ticket.message.created') {
+    return dispatchSupportInngestEvent(createSupportTicketMessageCreatedEvent({
+      eventId: event.data.eventId,
+      ticketId: event.data.ticketId,
+      messageId: event.data.messageId ?? '',
+      actorUserId: event.data.actorUserId,
+    }))
+  }
+
+  if (event.name === 'support/ticket.status.changed') {
+    return dispatchSupportInngestEvent(createSupportTicketStatusChangedEvent(event.data))
+  }
+
+  return dispatchSupportInngestEvent(createSupportTicketCreatedEvent(event.data))
+}
+
+async function markSupportOutboxDispatched(supabase: SupportEventOutboxClient, id: string) {
+  await supabase.from('support_event_outbox').update({
+    status: 'dispatched',
+    last_error: null,
+    locked_at: null,
+    updated_at: new Date().toISOString(),
+  }).eq('id', id)
+}
+
+async function markSupportOutboxRetry(
+  supabase: SupportEventOutboxClient,
+  row: SupportEventOutboxClaimedRow,
+  error: unknown,
+  now: Date,
+) {
+  const attempts = row.attempts + 1
+  await supabase.from('support_event_outbox').update({
+    status: 'pending',
+    attempts,
+    last_error: safeLastError(error),
+    available_at: backoffAvailableAt(now, attempts).toISOString(),
+    locked_at: null,
+    updated_at: now.toISOString(),
+  }).eq('id', row.id)
+}
+
+async function markSupportOutboxFailed(
+  supabase: SupportEventOutboxClient,
+  row: SupportEventOutboxClaimedRow,
+  error: unknown,
+  now: Date,
+) {
+  await supabase.from('support_event_outbox').update({
+    status: 'failed',
+    attempts: row.attempts + 1,
+    last_error: safeLastError(error),
+    locked_at: null,
+    updated_at: now.toISOString(),
+  }).eq('id', row.id)
+}
+
+function isSupportedSupportOutboxEventType(eventType: string): eventType is SupportEventOutboxDispatchEvent['name'] {
+  return ALLOWED_SUPPORT_OUTBOX_EVENT_TYPES.has(eventType as SupportEventOutboxDispatchEvent['name'])
+}
+
+function clampDrainLimit(limit = DEFAULT_DRAIN_LIMIT) {
+  if (!Number.isFinite(limit)) return DEFAULT_DRAIN_LIMIT
+  return Math.min(Math.max(Math.trunc(limit), 1), MAX_DRAIN_LIMIT)
+}
+
+function backoffAvailableAt(now: Date, attempts: number) {
+  const seconds = Math.min(300, 2 ** Math.min(attempts, 8))
+  return new Date(now.getTime() + seconds * 1000)
+}
+
+function dispatchErrorMessage(result: Extract<SupportEventOutboxDispatchResult, { success: false }>) {
+  if (result.error) return result.error
+  if (result.status) return `Support event dispatch failed with status ${result.status}`
+  return 'Support event dispatch failed'
+}
+
+function safeLastError(error: unknown) {
+  const message = error instanceof Error
+    ? error.message
+    : typeof error === 'string'
+      ? error
+      : typeof error === 'object' && error && 'message' in error && typeof error.message === 'string'
+        ? error.message
+        : 'Support event dispatch failed'
+
+  return message.replace(/[\r\n\t]+/g, ' ').slice(0, MAX_LAST_ERROR_LENGTH)
+}
+
+function readString(value: unknown) {
+  return typeof value === 'string' && value.trim() ? value : undefined
+}

--- a/supabase/migrations/20260614220959_add_support_event_outbox.sql
+++ b/supabase/migrations/20260614220959_add_support_event_outbox.sql
@@ -1,0 +1,27 @@
+CREATE TABLE IF NOT EXISTS public.support_event_outbox (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  ticket_id uuid NOT NULL REFERENCES public.support_tickets(id) ON DELETE CASCADE,
+  event_type text NOT NULL,
+  event_key text NOT NULL UNIQUE,
+  payload jsonb NOT NULL DEFAULT '{}'::jsonb,
+  status text NOT NULL DEFAULT 'pending' CHECK (status IN ('pending', 'dispatched', 'failed')),
+  attempts integer NOT NULL DEFAULT 0 CHECK (attempts >= 0),
+  last_error text,
+  available_at timestamptz NOT NULL DEFAULT timezone('utc', now()),
+  created_at timestamptz NOT NULL DEFAULT timezone('utc', now()),
+  updated_at timestamptz NOT NULL DEFAULT timezone('utc', now())
+);
+
+CREATE INDEX IF NOT EXISTS support_event_outbox_pending_idx
+  ON public.support_event_outbox (available_at, created_at)
+  WHERE status = 'pending';
+
+CREATE INDEX IF NOT EXISTS support_event_outbox_ticket_idx
+  ON public.support_event_outbox (ticket_id, created_at DESC);
+
+ALTER TABLE public.support_event_outbox ENABLE ROW LEVEL SECURITY;
+
+REVOKE ALL PRIVILEGES ON TABLE public.support_event_outbox FROM PUBLIC;
+REVOKE ALL PRIVILEGES ON TABLE public.support_event_outbox FROM anon;
+REVOKE ALL PRIVILEGES ON TABLE public.support_event_outbox FROM authenticated;
+GRANT SELECT, INSERT, UPDATE, DELETE ON TABLE public.support_event_outbox TO service_role;

--- a/supabase/migrations/20260614221719_add_atomic_support_outbox_rpcs.sql
+++ b/supabase/migrations/20260614221719_add_atomic_support_outbox_rpcs.sql
@@ -1,0 +1,270 @@
+-- Add support mutation RPCs that write audit rows and durable outbox rows in the
+-- same database transaction. These functions are additive and leave existing RPCs
+-- in place for compatibility.
+-- noqa: insert-into
+
+CREATE OR REPLACE FUNCTION public.create_support_ticket_with_outbox(
+  p_subject text,
+  p_description text,
+  p_category text,
+  p_current_route text DEFAULT NULL,
+  p_browser_name text DEFAULT NULL,
+  p_os_name text DEFAULT NULL,
+  p_viewport text DEFAULT NULL,
+  p_app_build_version text DEFAULT NULL,
+  p_sentry_event_id text DEFAULT NULL,
+  p_diagnostics_consent boolean DEFAULT false
+)
+RETURNS jsonb
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path TO 'public', 'support_private'
+AS $$
+DECLARE
+  v_actor_usuario_id uuid;
+  v_ticket_id uuid;
+  v_ticket_number bigint;
+  v_event_id uuid;
+BEGIN
+  v_actor_usuario_id := support_private.current_usuario_id();
+
+  IF v_actor_usuario_id IS NULL THEN
+    RAISE EXCEPTION 'not authorized';
+  END IF;
+
+  INSERT INTO public.support_tickets (
+    reporter_usuario_id,
+    status,
+    title,
+    description,
+    category,
+    severity,
+    current_route,
+    browser_name,
+    os_name,
+    viewport,
+    app_build_version,
+    sentry_event_id,
+    diagnostics_consent
+  )
+  VALUES (
+    v_actor_usuario_id,
+    'received',
+    p_subject,
+    p_description,
+    p_category,
+    'normal',
+    p_current_route,
+    p_browser_name,
+    p_os_name,
+    p_viewport,
+    p_app_build_version,
+    p_sentry_event_id,
+    p_diagnostics_consent
+  )
+  RETURNING id, ticket_number INTO v_ticket_id, v_ticket_number;
+
+  INSERT INTO public.support_ticket_events (ticket_id, actor_usuario_id, action, target_type, target_id, metadata)
+  VALUES (v_ticket_id, v_actor_usuario_id, 'support.ticket.created', 'support_ticket', v_ticket_id, jsonb_build_object('source', 'reporter'))
+  RETURNING id INTO v_event_id;
+
+  INSERT INTO public.support_event_outbox (ticket_id, event_type, event_key, payload)
+  VALUES (
+    v_ticket_id,
+    'support/ticket.created',
+    'support:' || v_event_id::text,
+    jsonb_build_object(
+      'eventId', v_event_id::text,
+      'ticketId', v_ticket_id::text,
+      'actorUserId', v_actor_usuario_id::text
+    )
+  );
+
+  RETURN jsonb_build_object(
+    'ticketId', v_ticket_id::text,
+    'ticketNumber', v_ticket_number,
+    'eventId', v_event_id::text,
+    'actorUserId', v_actor_usuario_id::text
+  );
+END;
+$$;
+
+REVOKE ALL ON FUNCTION public.create_support_ticket_with_outbox(text, text, text, text, text, text, text, text, text, boolean) FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION public.create_support_ticket_with_outbox(text, text, text, text, text, text, text, text, text, boolean) TO authenticated;
+
+CREATE OR REPLACE FUNCTION public.create_support_ticket_message_with_outbox(p_ticket_id uuid, p_body text)
+RETURNS jsonb
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path TO 'public', 'support_private'
+AS $$
+DECLARE
+  v_actor_usuario_id uuid;
+  v_message_id uuid;
+  v_event_id uuid;
+BEGIN
+  v_actor_usuario_id := support_private.current_usuario_id();
+
+  IF v_actor_usuario_id IS NULL THEN
+    RAISE EXCEPTION 'not authorized';
+  END IF;
+
+  IF nullif(btrim(p_body), '') IS NULL THEN
+    RAISE EXCEPTION 'invalid support ticket message';
+  END IF;
+
+  IF NOT EXISTS (
+    SELECT 1
+    FROM public.support_tickets st
+    WHERE st.id = p_ticket_id
+      AND st.reporter_usuario_id = v_actor_usuario_id
+  ) THEN
+    RAISE EXCEPTION 'support ticket not found';
+  END IF;
+
+  INSERT INTO public.support_ticket_messages (ticket_id, author_usuario_id, body, is_internal)
+  VALUES (p_ticket_id, v_actor_usuario_id, p_body, false)
+  RETURNING id INTO v_message_id;
+
+  INSERT INTO public.support_ticket_events (ticket_id, actor_usuario_id, action, target_type, target_id, metadata)
+  VALUES (p_ticket_id, v_actor_usuario_id, 'support.reporter_message.created', 'support_ticket_message', v_message_id, jsonb_build_object('source', 'reporter'))
+  RETURNING id INTO v_event_id;
+
+  INSERT INTO public.support_event_outbox (ticket_id, event_type, event_key, payload)
+  VALUES (
+    p_ticket_id,
+    'support/ticket.message.created',
+    'support:' || v_event_id::text,
+    jsonb_build_object(
+      'eventId', v_event_id::text,
+      'ticketId', p_ticket_id::text,
+      'messageId', v_message_id::text,
+      'actorUserId', v_actor_usuario_id::text
+    )
+  );
+
+  RETURN jsonb_build_object(
+    'messageId', v_message_id::text,
+    'eventId', v_event_id::text,
+    'actorUserId', v_actor_usuario_id::text
+  );
+END;
+$$;
+
+REVOKE ALL ON FUNCTION public.create_support_ticket_message_with_outbox(uuid, text) FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION public.create_support_ticket_message_with_outbox(uuid, text) TO authenticated;
+
+CREATE OR REPLACE FUNCTION public.create_staff_support_ticket_reply_with_outbox(p_ticket_id uuid, p_body text)
+RETURNS jsonb
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path TO 'public', 'support_private'
+AS $$
+DECLARE
+  v_actor_usuario_id uuid;
+  v_message_id uuid;
+  v_event_id uuid;
+BEGIN
+  v_actor_usuario_id := support_private.current_usuario_id();
+
+  IF v_actor_usuario_id IS NULL OR NOT support_private.has_capability('support.reply') THEN
+    RAISE EXCEPTION 'not authorized';
+  END IF;
+
+  IF nullif(btrim(p_body), '') IS NULL THEN
+    RAISE EXCEPTION 'invalid support ticket reply';
+  END IF;
+
+  INSERT INTO public.support_ticket_messages (ticket_id, author_usuario_id, body, is_internal)
+  VALUES (p_ticket_id, v_actor_usuario_id, p_body, false)
+  RETURNING id INTO v_message_id;
+
+  INSERT INTO public.support_ticket_events (ticket_id, actor_usuario_id, action, target_type, target_id, metadata)
+  VALUES (p_ticket_id, v_actor_usuario_id, 'support.staff_reply.created', 'support_ticket_message', v_message_id, '{}'::jsonb)
+  RETURNING id INTO v_event_id;
+
+  INSERT INTO public.support_event_outbox (ticket_id, event_type, event_key, payload)
+  VALUES (
+    p_ticket_id,
+    'support/ticket.message.created',
+    'support:' || v_event_id::text,
+    jsonb_build_object(
+      'eventId', v_event_id::text,
+      'ticketId', p_ticket_id::text,
+      'messageId', v_message_id::text,
+      'actorUserId', v_actor_usuario_id::text
+    )
+  );
+
+  RETURN jsonb_build_object(
+    'messageId', v_message_id::text,
+    'eventId', v_event_id::text,
+    'actorUserId', v_actor_usuario_id::text
+  );
+END;
+$$;
+
+REVOKE ALL ON FUNCTION public.create_staff_support_ticket_reply_with_outbox(uuid, text) FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION public.create_staff_support_ticket_reply_with_outbox(uuid, text) TO authenticated;
+
+CREATE OR REPLACE FUNCTION public.update_support_ticket_status_with_outbox(p_ticket_id uuid, p_status text)
+RETURNS jsonb
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path TO 'public', 'support_private'
+AS $$
+DECLARE
+  v_actor_usuario_id uuid;
+  v_event_id uuid;
+BEGIN
+  v_actor_usuario_id := support_private.current_usuario_id();
+
+  IF v_actor_usuario_id IS NULL OR NOT support_private.has_capability('support.manage') THEN
+    RAISE EXCEPTION 'not authorized';
+  END IF;
+
+  IF p_status NOT IN ('received', 'in_review', 'in_progress', 'resolved', 'closed') THEN
+    RAISE EXCEPTION 'invalid support ticket status';
+  END IF;
+
+  UPDATE public.support_tickets
+  SET status = p_status,
+      closed_at = CASE WHEN p_status = 'closed' THEN now() ELSE NULL END
+  WHERE id = p_ticket_id;
+
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'support ticket not found';
+  END IF;
+
+  INSERT INTO public.support_ticket_events (ticket_id, actor_usuario_id, action, target_type, target_id, metadata)
+  VALUES (
+    p_ticket_id,
+    v_actor_usuario_id,
+    'support.ticket.status_changed',
+    'support_ticket',
+    p_ticket_id,
+    jsonb_build_object('status', p_status)
+  )
+  RETURNING id INTO v_event_id;
+
+  INSERT INTO public.support_event_outbox (ticket_id, event_type, event_key, payload)
+  VALUES (
+    p_ticket_id,
+    'support/ticket.status.changed',
+    'support:' || v_event_id::text,
+    jsonb_build_object(
+      'eventId', v_event_id::text,
+      'ticketId', p_ticket_id::text,
+      'actorUserId', v_actor_usuario_id::text
+    )
+  );
+
+  RETURN jsonb_build_object(
+    'eventId', v_event_id::text,
+    'actorUserId', v_actor_usuario_id::text
+  );
+END;
+$$;
+
+REVOKE ALL ON FUNCTION public.update_support_ticket_status_with_outbox(uuid, text) FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION public.update_support_ticket_status_with_outbox(uuid, text) TO authenticated;

--- a/supabase/migrations/20260614222756_close_support_outbox_bypasses.sql
+++ b/supabase/migrations/20260614222756_close_support_outbox_bypasses.sql
@@ -1,0 +1,34 @@
+-- Close legacy/direct support mutation paths now that support mutations write to
+-- support_event_outbox atomically through dedicated RPCs.
+-- Production safety: privilege/RLS policy hardening only; no data mutation.
+
+REVOKE INSERT, UPDATE, DELETE ON TABLE public.support_tickets FROM anon;
+REVOKE INSERT, UPDATE, DELETE ON TABLE public.support_tickets FROM authenticated;
+
+REVOKE INSERT, UPDATE, DELETE ON TABLE public.support_ticket_messages FROM anon;
+REVOKE INSERT, UPDATE, DELETE ON TABLE public.support_ticket_messages FROM authenticated;
+
+REVOKE INSERT, UPDATE, DELETE ON TABLE public.support_ticket_events FROM anon;
+REVOKE INSERT, UPDATE, DELETE ON TABLE public.support_ticket_events FROM authenticated;
+
+REVOKE UPDATE, DELETE ON TABLE public.support_ticket_attachments FROM anon;
+REVOKE UPDATE, DELETE ON TABLE public.support_ticket_attachments FROM authenticated;
+
+-- Keep authenticated INSERT on support_ticket_attachments: the attachment intent
+-- route inserts pending_upload metadata using the caller client so RLS verifies
+-- the reporter/staff relationship before issuing the R2 upload URL. Finalization
+-- updates already use the admin client and remain unavailable to authenticated.
+
+DROP POLICY IF EXISTS support_tickets_insert ON public.support_tickets;
+DROP POLICY IF EXISTS support_tickets_update ON public.support_tickets;
+DROP POLICY IF EXISTS support_messages_insert ON public.support_ticket_messages;
+
+REVOKE ALL ON FUNCTION public.create_staff_support_ticket_reply(uuid, text) FROM PUBLIC;
+REVOKE ALL ON FUNCTION public.create_staff_support_ticket_reply(uuid, text) FROM anon;
+REVOKE ALL ON FUNCTION public.create_staff_support_ticket_reply(uuid, text) FROM authenticated;
+REVOKE ALL ON FUNCTION public.create_staff_support_ticket_reply(uuid, text) FROM service_role;
+
+REVOKE ALL ON FUNCTION public.update_support_ticket_status(uuid, text) FROM PUBLIC;
+REVOKE ALL ON FUNCTION public.update_support_ticket_status(uuid, text) FROM anon;
+REVOKE ALL ON FUNCTION public.update_support_ticket_status(uuid, text) FROM authenticated;
+REVOKE ALL ON FUNCTION public.update_support_ticket_status(uuid, text) FROM service_role;

--- a/supabase/migrations/20260614225100_restrict_support_ticket_events_select.sql
+++ b/supabase/migrations/20260614225100_restrict_support_ticket_events_select.sql
@@ -1,0 +1,10 @@
+-- Restrict direct support event reads to support staff only.
+-- Reporter-facing ticket detail uses tickets/messages/attachments and must not rely
+-- on direct support_ticket_events visibility.
+
+REVOKE SELECT ON TABLE public.support_ticket_events FROM anon;
+
+DROP POLICY IF EXISTS support_events_select ON public.support_ticket_events;
+CREATE POLICY support_events_select ON public.support_ticket_events
+  FOR SELECT TO authenticated
+  USING (support_private.has_capability('support.view'));

--- a/supabase/migrations/20260615090000_add_support_outbox_claiming.sql
+++ b/supabase/migrations/20260615090000_add_support_outbox_claiming.sql
@@ -1,0 +1,50 @@
+ALTER TABLE public.support_event_outbox
+  ADD COLUMN IF NOT EXISTS locked_at timestamptz;
+
+ALTER TABLE public.support_event_outbox
+  DROP CONSTRAINT IF EXISTS support_event_outbox_status_check;
+
+ALTER TABLE public.support_event_outbox
+  ADD CONSTRAINT support_event_outbox_status_check
+  CHECK (status IN ('pending', 'processing', 'dispatched', 'failed'));
+
+CREATE INDEX IF NOT EXISTS support_event_outbox_processing_idx
+  ON public.support_event_outbox (locked_at)
+  WHERE status = 'processing';
+
+CREATE OR REPLACE FUNCTION public.claim_support_event_outbox_batch(
+  p_limit integer DEFAULT 10,
+  p_lock_timeout interval DEFAULT interval '5 minutes'
+)
+RETURNS SETOF public.support_event_outbox
+LANGUAGE sql
+SECURITY DEFINER
+SET search_path TO 'public', 'pg_temp'
+AS $$
+  WITH candidates AS (
+    SELECT id
+    FROM public.support_event_outbox
+    WHERE (
+      status = 'pending'
+      AND available_at <= timezone('utc', now())
+    ) OR (
+      status = 'processing'
+      AND locked_at < timezone('utc', now()) - p_lock_timeout
+    )
+    ORDER BY created_at ASC
+    LIMIT LEAST(GREATEST(COALESCE(p_limit, 10), 1), 50)
+    FOR UPDATE SKIP LOCKED
+  )
+  UPDATE public.support_event_outbox outbox
+  SET status = 'processing',
+      locked_at = timezone('utc', now()),
+      updated_at = timezone('utc', now())
+  FROM candidates
+  WHERE outbox.id = candidates.id
+  RETURNING outbox.*;
+$$;
+
+REVOKE ALL ON FUNCTION public.claim_support_event_outbox_batch(integer, interval) FROM PUBLIC;
+REVOKE ALL ON FUNCTION public.claim_support_event_outbox_batch(integer, interval) FROM anon;
+REVOKE ALL ON FUNCTION public.claim_support_event_outbox_batch(integer, interval) FROM authenticated;
+GRANT EXECUTE ON FUNCTION public.claim_support_event_outbox_batch(integer, interval) TO service_role;

--- a/supabase/migrations/20260615100000_tighten_support_outbox_grants.sql
+++ b/supabase/migrations/20260615100000_tighten_support_outbox_grants.sql
@@ -1,0 +1,13 @@
+-- Forward cleanup after staging verification of support outbox grants.
+-- Keep the service role limited to the DML needed by the outbox worker.
+
+REVOKE TRUNCATE, REFERENCES, TRIGGER ON TABLE public.support_event_outbox FROM service_role;
+GRANT SELECT, INSERT, UPDATE, DELETE ON TABLE public.support_event_outbox TO service_role;
+
+REVOKE INSERT, UPDATE, DELETE ON TABLE public.support_ticket_events FROM anon;
+REVOKE INSERT, UPDATE, DELETE ON TABLE public.support_ticket_events FROM authenticated;
+
+REVOKE INSERT, UPDATE, DELETE ON TABLE public.support_event_outbox FROM anon;
+REVOKE INSERT, UPDATE, DELETE ON TABLE public.support_event_outbox FROM authenticated;
+
+DROP POLICY IF EXISTS support_events_reporter_insert ON public.support_ticket_events;

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,9 @@
+{
+  "$schema": "https://openapi.vercel.sh/vercel.json",
+  "crons": [
+    {
+      "path": "/api/support/outbox/drain",
+      "schedule": "*/5 * * * *"
+    }
+  ]
+}

--- a/vercel.json
+++ b/vercel.json
@@ -3,7 +3,7 @@
   "crons": [
     {
       "path": "/api/support/outbox/drain",
-      "schedule": "*/5 * * * *"
+      "schedule": "0 8 * * *"
     }
   ]
 }


### PR DESCRIPTION
Closes #175

## PR Type
- [ ] Bug fix
- [x] New feature
- [ ] Documentation only
- [ ] Code refactoring
- [ ] Maintenance/tooling
- [ ] Breaking change

## Summary
- Adds a durable support outbox with atomic ticket/audit/outbox RPCs and closes direct/legacy bypasses.
- Adds staff-only activity timeline/RLS hardening and a protected drain-only dispatch route.
- Wires Vercel Cron-compatible daily drain config and documents scheduler/secret operations.

## Review note: size exception
This PR intentionally uses the `size:exception` label. The changed files are a coupled security unit: migrations, RPCs, RLS/grants, drain route, generated types, tests, and runbook updates need to be reviewed together to avoid unsafe intermediate states.

## Changes
| File | Change |
|------|--------|
| `supabase/migrations/*support*outbox*.sql` | Add support outbox, atomic mutation RPCs, bypass hardening, event RLS, claiming, and grant cleanup |
| `lib/actions/support.actions.ts` | Move support mutations to atomic outbox RPCs and remove immediate event dispatch |
| `lib/support/outbox.ts` | Add enqueue/drain helpers with retry, dead-letter, and allowed event dispatch handling |
| `app/api/support/outbox/drain/route.ts` | Add protected GET/POST drain endpoint |
| `app/(auth)/ayuda/tickets/[id]/page.tsx` | Add staff-only activity timeline and internal-note visibility |
| `lib/support/inngest-route.ts` | Restrict notification side effects to supported support events |
| `vercel.json` | Add daily Vercel Cron for the drain route |
| `docs/support-operations.md` | Document drain-only support event architecture and scheduler setup |
| `lib/supabase/database.types.ts` | Regenerate Supabase types for staging schema |
| `__tests__/**` | Add/update support, outbox, route, docs, and migration coverage |

## Test Plan
- [x] Focused Jest support checks: 10 suites / 125 tests passed
- [x] Typecheck: `pnpm exec tsc --noEmit --incremental false`
- [x] Migration lint: `pnpm lint:migrations` passed with existing historical warnings only
- [x] Whitespace: `git diff --check`
- [x] Staging DB migrations applied and schema/grants/policies verified
- [x] Preview deploy smoke: protected drain route POST/GET returned counts only
- [x] Functional staging smoke with ticket #5: create ticket -> outbox pending -> drain dispatched; staff reply/status -> outbox pending -> drain dispatched

## Staging smoke evidence
- Preview: `https://global-connect-8qo4rlsvu-dataglobalministries-4825s-projects.vercel.app`
- Ticket: `#5` (`c897d090-ebea-425e-b0e4-8d42763abde6`)
- Drain results:
  - ticket created: `{"claimed":1,"dispatched":1,"failed":0}`
  - staff reply + status: `{"claimed":2,"dispatched":2,"failed":0}`
- Final outbox statuses: all three smoke events `dispatched`, `last_error = null`

## Operational follow-ups before Production
- Configure `SUPPORT_OUTBOX_DRAIN_SECRET` and `CRON_SECRET` in Production with the same value.
- Apply migrations to Production only after explicit approval.
- Confirm daily cron cadence is acceptable or increase cadence after plan confirmation.
- Run Production smoke after deploy.

## Contributor Checklist
- [x] Linked an approved issue
- [x] Added exactly one `type:*` label
- [x] Docs updated if behavior changed
- [x] Conventional commit format
- [x] No `Co-Authored-By` trailers
