### PR TITLE
feat(casas): agregar rpcs granulares de permisos

### DIFF
--- a/__tests__/supabase/casas-anfitrionas-permissions-migration.test.ts
+++ b/__tests__/supabase/casas-anfitrionas-permissions-migration.test.ts
@@ -3,6 +3,7 @@ import { join } from 'node:path'
 
 const migrationsDir = join(process.cwd(), 'supabase', 'migrations')
 const supabaseTestsDir = join(process.cwd(), 'supabase', 'tests')
+const generatedTypesPath = join(process.cwd(), 'lib', 'supabase', 'database.types.ts')
 const rpcNames = [
   'obtener_permisos_casa_anfitriona',
   'puede_ver_casa_anfitriona',
@@ -10,6 +11,10 @@ const rpcNames = [
   'puede_aprobar_casa_anfitriona',
   'puede_editar_casa_anfitriona',
   'puede_cambiar_estado_casa_anfitriona',
+]
+const expectedStagingMigrationFiles = [
+  '20260617161620_casas_anfitrionas_granular_permissions.sql',
+  '20260617161954_revoke_anon_from_casas_permission_rpcs.sql',
 ]
 const rpcSignatures = {
   obtener_permisos_casa_anfitriona: 'obtener_permisos_casa_anfitriona(uuid, uuid)',
@@ -49,6 +54,10 @@ function readCasasRpcChecks(): string {
   )
 }
 
+function readGeneratedTypes(): string {
+  return readFileSync(generatedTypesPath, 'utf8')
+}
+
 function compactSql(sql: string): string {
   return sql.replace(/\s+/g, ' ')
 }
@@ -63,6 +72,16 @@ function functionSql(sql: string, name: string): string {
 }
 
 describe('casas anfitrionas granular permissions migration', () => {
+  it('keeps checked-in migration history aligned with global staging evidence', () => {
+    const migrationFiles = readdirSync(migrationsDir)
+
+    for (const file of expectedStagingMigrationFiles) {
+      expect(migrationFiles).toContain(file)
+    }
+
+    expect(migrationFiles).not.toContain('20260617120000_casas_anfitrionas_granular_permissions.sql')
+  })
+
   it('defines the additive Casas RPC contract', () => {
     const sql = readCasasPermissionsMigration()
 
@@ -80,6 +99,7 @@ describe('casas anfitrionas granular permissions migration', () => {
 
       expect(body).toMatch(/LANGUAGE plpgsql (STABLE )?SECURITY DEFINER SET search_path TO 'public'/i)
       expect(sql).toContain(`REVOKE ALL ON FUNCTION public.${signature} FROM PUBLIC;`)
+      expect(sql).toContain(`REVOKE ALL ON FUNCTION public.${signature} FROM anon;`)
       expect(sql).toContain(`GRANT EXECUTE ON FUNCTION public.${signature} TO authenticated, service_role;`)
       expect(sql).not.toContain(`GRANT EXECUTE ON FUNCTION public.${signature} TO anon`)
     }
@@ -125,6 +145,19 @@ describe('casas anfitrionas granular permissions migration', () => {
     expect(sql).toContain('spoofed p_auth_id is denied')
   })
 
+  it('documents executable effective RPC privilege checks for every exposed role', () => {
+    const sql = readCasasRpcChecks()
+
+    expect(sql).toContain('has_function_privilege(')
+    expect(sql).toContain('assert_function_privilege(')
+
+    for (const signature of Object.values(rpcSignatures)) {
+      expect(sql).toContain(`('anon', 'public.${signature}', 'EXECUTE', false)`)
+      expect(sql).toContain(`('authenticated', 'public.${signature}', 'EXECUTE', true)`)
+      expect(sql).toContain(`('service_role', 'public.${signature}', 'EXECUTE', true)`)
+    }
+  })
+
   it('keeps RPC contract evidence self-contained without manual fixture replacement', () => {
     const sql = readCasasRpcChecks()
     const compacted = compactSql(sql)
@@ -141,5 +174,19 @@ describe('casas anfitrionas granular permissions migration', () => {
     expect(sql).toContain("SELECT set_config('request.jwt.claim.sub', fixture_id('director_etapa_auth_id')::text, true);")
     expect(sql).toContain("SELECT set_config('request.jwt.claim.sub', fixture_id('leader_auth_id')::text, true);")
     expect(sql).toContain("SELECT set_config('request.jwt.claim.sub', fixture_id('outsider_auth_id')::text, true);")
+  })
+
+  it('includes the Casas permission RPCs in generated Supabase types', () => {
+    const types = readGeneratedTypes()
+
+    expect(types).toContain('obtener_permisos_casa_anfitriona: {')
+    expect(types).toContain('puede_ver_casa_anfitriona: {')
+    expect(types).toContain('puede_crear_casa_anfitriona_para: {')
+    expect(types).toContain('puede_aprobar_casa_anfitriona: {')
+    expect(types).toContain('puede_editar_casa_anfitriona: {')
+    expect(types).toContain('puede_cambiar_estado_casa_anfitriona: {')
+    expect(types).toContain('Args: { p_auth_id: string; p_casa_id?: string }')
+    expect(types).toContain('Args: { p_auth_id: string; p_casa_id: string }')
+    expect(types).toContain('Args: { p_auth_id: string; p_usuario_id: string }')
   })
 })

--- a/__tests__/supabase/casas-anfitrionas-permissions-migration.test.ts
+++ b/__tests__/supabase/casas-anfitrionas-permissions-migration.test.ts
@@ -1,0 +1,145 @@
+import { readFileSync, readdirSync } from 'node:fs'
+import { join } from 'node:path'
+
+const migrationsDir = join(process.cwd(), 'supabase', 'migrations')
+const supabaseTestsDir = join(process.cwd(), 'supabase', 'tests')
+const rpcNames = [
+  'obtener_permisos_casa_anfitriona',
+  'puede_ver_casa_anfitriona',
+  'puede_crear_casa_anfitriona_para',
+  'puede_aprobar_casa_anfitriona',
+  'puede_editar_casa_anfitriona',
+  'puede_cambiar_estado_casa_anfitriona',
+]
+const rpcSignatures = {
+  obtener_permisos_casa_anfitriona: 'obtener_permisos_casa_anfitriona(uuid, uuid)',
+  puede_ver_casa_anfitriona: 'puede_ver_casa_anfitriona(uuid, uuid)',
+  puede_crear_casa_anfitriona_para: 'puede_crear_casa_anfitriona_para(uuid, uuid)',
+  puede_aprobar_casa_anfitriona: 'puede_aprobar_casa_anfitriona(uuid, uuid)',
+  puede_editar_casa_anfitriona: 'puede_editar_casa_anfitriona(uuid, uuid)',
+  puede_cambiar_estado_casa_anfitriona: 'puede_cambiar_estado_casa_anfitriona(uuid, uuid)',
+}
+const requiredFixtureTables = [
+  'public.roles_sistema',
+  'public.usuarios',
+  'public.usuario_roles',
+  'public.segmentos',
+  'public.temporadas',
+  'public.grupos',
+  'public.grupo_miembros',
+  'public.segmento_lideres',
+  'public.director_etapa_grupos',
+  'public.casas_anfitrionas',
+]
+
+function readCasasPermissionsMigration(): string {
+  const file = readdirSync(migrationsDir).find((name) =>
+    name.endsWith('_casas_anfitrionas_granular_permissions.sql'),
+  )
+
+  if (!file) throw new Error('Missing casas anfitrionas granular permissions migration')
+
+  return readFileSync(join(migrationsDir, file), 'utf8')
+}
+
+function readCasasRpcChecks(): string {
+  return readFileSync(
+    join(supabaseTestsDir, 'casas-anfitrionas-permissions-rpc.test.sql'),
+    'utf8',
+  )
+}
+
+function compactSql(sql: string): string {
+  return sql.replace(/\s+/g, ' ')
+}
+
+function functionSql(sql: string, name: string): string {
+  const start = sql.indexOf(`CREATE OR REPLACE FUNCTION public.${name}(`)
+
+  if (start === -1) throw new Error(`Missing function ${name}`)
+
+  const end = sql.indexOf('$$;', start)
+  return compactSql(sql.slice(start, end + '$$;'.length))
+}
+
+describe('casas anfitrionas granular permissions migration', () => {
+  it('defines the additive Casas RPC contract', () => {
+    const sql = readCasasPermissionsMigration()
+
+    for (const name of rpcNames) {
+      expect(sql).toContain(`CREATE OR REPLACE FUNCTION public.${name}`)
+    }
+  })
+
+  it('protects every RPC with security definer search path and explicit grants', () => {
+    const sql = readCasasPermissionsMigration()
+
+    for (const name of rpcNames) {
+      const body = functionSql(sql, name)
+      const signature = rpcSignatures[name as keyof typeof rpcSignatures]
+
+      expect(body).toMatch(/LANGUAGE plpgsql (STABLE )?SECURITY DEFINER SET search_path TO 'public'/i)
+      expect(sql).toContain(`REVOKE ALL ON FUNCTION public.${signature} FROM PUBLIC;`)
+      expect(sql).toContain(`GRANT EXECUTE ON FUNCTION public.${signature} TO authenticated, service_role;`)
+      expect(sql).not.toContain(`GRANT EXECUTE ON FUNCTION public.${signature} TO anon`)
+    }
+  })
+
+  it('binds every authenticated RPC call to the real caller identity', () => {
+    const sql = readCasasPermissionsMigration()
+
+    for (const name of rpcNames) {
+      const body = functionSql(sql, name)
+
+      expect(body).toContain('p_auth_id IS DISTINCT FROM auth.uid()')
+    }
+  })
+
+  it('keeps the migration additive and does not repair production data', () => {
+    const sql = readCasasPermissionsMigration()
+
+    expect(sql).not.toMatch(/\bDROP\b/i)
+    expect(sql).not.toMatch(/\bTRUNCATE\b/i)
+    expect(sql).not.toMatch(/\bDELETE\s+FROM\b/i)
+    expect(sql).not.toMatch(/\bINSERT\s+INTO\b/i)
+    expect(sql).not.toMatch(/\bUPDATE\s+public\./i)
+  })
+
+  it('does not use user-editable JWT metadata for authorization', () => {
+    const sql = readCasasPermissionsMigration()
+
+    expect(sql).not.toMatch(/user_metadata|raw_user_meta_data|auth\.jwt\(\)/i)
+  })
+
+  it('documents deterministic staging RPC checks for allowed and denied role/scope cases', () => {
+    const sql = readCasasRpcChecks()
+
+    expect(sql).toContain('BEGIN;')
+    expect(sql).toContain('ROLLBACK;')
+    expect(sql).toContain("set_config('request.jwt.claim.sub'")
+    expect(sql).toContain('assert_permission(')
+    expect(sql).toContain('admin can approve an in-scope house')
+    expect(sql).toContain('director etapa cannot approve')
+    expect(sql).toContain('director etapa can edit in-scope house')
+    expect(sql).toContain('leader can create only for same active group')
+    expect(sql).toContain('spoofed p_auth_id is denied')
+  })
+
+  it('keeps RPC contract evidence self-contained without manual fixture replacement', () => {
+    const sql = readCasasRpcChecks()
+    const compacted = compactSql(sql)
+
+    expect(sql).not.toMatch(/replace the fixture|manual|placeholder/i)
+    expect(sql).not.toContain('00000000-0000-0000-0000-')
+    expect(sql).toContain('gc_casas_permissions_fixture')
+
+    for (const table of requiredFixtureTables) {
+      expect(compacted).toContain(`INSERT INTO ${table}`)
+    }
+
+    expect(sql).toContain("SELECT set_config('request.jwt.claim.sub', fixture_id('admin_auth_id')::text, true);")
+    expect(sql).toContain("SELECT set_config('request.jwt.claim.sub', fixture_id('director_etapa_auth_id')::text, true);")
+    expect(sql).toContain("SELECT set_config('request.jwt.claim.sub', fixture_id('leader_auth_id')::text, true);")
+    expect(sql).toContain("SELECT set_config('request.jwt.claim.sub', fixture_id('outsider_auth_id')::text, true);")
+  })
+})

--- a/lib/supabase/database.types.ts
+++ b/lib/supabase/database.types.ts
@@ -4334,6 +4334,10 @@ export type Database = {
             }[]
           }
       obtener_miembros_en_riesgo: { Args: { p_auth_id: string }; Returns: Json }
+      obtener_permisos_casa_anfitriona: {
+        Args: { p_auth_id: string; p_casa_id?: string }
+        Returns: Json
+      }
       obtener_ranking_asistencia_grupo: {
         Args: {
           p_auth_id: string
@@ -4418,11 +4422,27 @@ export type Database = {
         }
         Returns: Json
       }
+      puede_aprobar_casa_anfitriona: {
+        Args: { p_auth_id: string; p_casa_id: string }
+        Returns: boolean
+      }
+      puede_cambiar_estado_casa_anfitriona: {
+        Args: { p_auth_id: string; p_casa_id: string }
+        Returns: boolean
+      }
+      puede_crear_casa_anfitriona_para: {
+        Args: { p_auth_id: string; p_usuario_id: string }
+        Returns: boolean
+      }
       puede_crear_grupo: {
         Args: { p_auth_id: string; p_segmento_id: string }
         Returns: boolean
       }
       puede_crear_usuario: { Args: { p_auth_id: string }; Returns: boolean }
+      puede_editar_casa_anfitriona: {
+        Args: { p_auth_id: string; p_casa_id: string }
+        Returns: boolean
+      }
       puede_editar_grupo: {
         Args: { p_auth_id: string; p_grupo_id: string }
         Returns: boolean
@@ -4434,6 +4454,10 @@ export type Database = {
       puede_gestionar_casas: { Args: { p_auth_id: string }; Returns: boolean }
       puede_gestionar_miembros: {
         Args: { p_auth_id: string; p_grupo_id: string }
+        Returns: boolean
+      }
+      puede_ver_casa_anfitriona: {
+        Args: { p_auth_id: string; p_casa_id: string }
         Returns: boolean
       }
       puede_ver_debug_toolbar: { Args: { p_auth_id: string }; Returns: boolean }

--- a/openspec/changes/casas-anfitrionas-permissions/tasks.md
+++ b/openspec/changes/casas-anfitrionas-permissions/tasks.md
@@ -34,7 +34,7 @@ Strict TDD: write/adjust the failing Jest or SQL-static test before each product
 ## Phase 2: Supabase Foundation
 
 - [x] 2.1 Create `supabase/migrations/<timestamp>_casas_anfitrionas_granular_permissions.sql` with `obtener_permisos_*` and `puede_*` RPCs only; keep migration additive/non-destructive.
-- [ ] 2.2 Run staging migration/type workflow, then update `lib/supabase/database.types.ts`; flag generated-type diff if it alone exceeds review budget.
+- [x] 2.2 Run staging migration/type workflow, then update `lib/supabase/database.types.ts`; flag generated-type diff if it alone exceeds review budget.
 
 ## Phase 3: Server Enforcement
 

--- a/supabase/migrations/20260617120000_casas_anfitrionas_granular_permissions.sql
+++ b/supabase/migrations/20260617120000_casas_anfitrionas_granular_permissions.sql
@@ -1,0 +1,296 @@
+-- Additive granular Casas Anfitrionas permission RPCs.
+-- No data repair, backfill, deletion, or rewrite is performed by this migration.
+
+CREATE OR REPLACE FUNCTION public.puede_ver_casa_anfitriona(
+  p_auth_id uuid,
+  p_casa_id uuid
+)
+RETURNS boolean
+LANGUAGE plpgsql STABLE SECURITY DEFINER SET search_path TO 'public'
+AS $$
+DECLARE
+  v_user_id uuid;
+  v_is_broad_role boolean := false;
+BEGIN
+  IF p_auth_id IS NULL OR p_auth_id IS DISTINCT FROM auth.uid() THEN
+    RETURN false;
+  END IF;
+
+  SELECT u.id INTO v_user_id
+  FROM public.usuarios u
+  WHERE u.auth_id = p_auth_id;
+
+  IF v_user_id IS NULL OR p_casa_id IS NULL THEN
+    RETURN false;
+  END IF;
+
+  SELECT COALESCE(bool_or(rs.nombre_interno IN ('admin', 'pastor')), false)
+  INTO v_is_broad_role
+  FROM public.usuario_roles ur
+  JOIN public.roles_sistema rs ON rs.id = ur.rol_id
+  WHERE ur.usuario_id = v_user_id;
+
+  IF v_is_broad_role THEN
+    RETURN EXISTS (SELECT 1 FROM public.casas_anfitrionas ca WHERE ca.id = p_casa_id);
+  END IF;
+
+  RETURN p_casa_id = ANY(public.obtener_casas_visibles_ids(p_auth_id));
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION public.puede_crear_casa_anfitriona_para(
+  p_auth_id uuid,
+  p_usuario_id uuid
+)
+RETURNS boolean
+LANGUAGE plpgsql STABLE SECURITY DEFINER SET search_path TO 'public'
+AS $$
+DECLARE
+  v_user_id uuid;
+  v_is_admin_or_pastor boolean := false;
+  v_is_director_general boolean := false;
+  v_is_director_etapa boolean := false;
+  v_is_lider boolean := false;
+  v_has_director_etapa_assignments boolean := false;
+BEGIN
+  IF p_auth_id IS NULL OR p_auth_id IS DISTINCT FROM auth.uid() THEN
+    RETURN false;
+  END IF;
+
+  SELECT u.id INTO v_user_id
+  FROM public.usuarios u
+  WHERE u.auth_id = p_auth_id;
+
+  IF v_user_id IS NULL OR p_usuario_id IS NULL THEN
+    RETURN false;
+  END IF;
+
+  IF p_usuario_id = v_user_id THEN
+    RETURN true;
+  END IF;
+
+  SELECT
+    COALESCE(bool_or(rs.nombre_interno IN ('admin', 'pastor')), false),
+    COALESCE(bool_or(rs.nombre_interno = 'director-general'), false),
+    COALESCE(bool_or(rs.nombre_interno = 'director-etapa'), false),
+    COALESCE(bool_or(rs.nombre_interno = 'lider'), false)
+  INTO v_is_admin_or_pastor, v_is_director_general, v_is_director_etapa, v_is_lider
+  FROM public.usuario_roles ur
+  JOIN public.roles_sistema rs ON rs.id = ur.rol_id
+  WHERE ur.usuario_id = v_user_id;
+
+  IF v_is_admin_or_pastor THEN
+    RETURN true;
+  END IF;
+
+  IF v_is_director_general THEN
+    SELECT EXISTS (
+      SELECT 1 FROM public.dg_directores_etapa dde WHERE dde.dg_usuario_id = v_user_id
+    ) INTO v_has_director_etapa_assignments;
+
+    IF v_has_director_etapa_assignments THEN
+      RETURN EXISTS (
+        SELECT 1
+        FROM public.grupo_miembros gm
+        JOIN public.grupos g ON g.id = gm.grupo_id
+        JOIN public.director_etapa_grupos deg ON deg.grupo_id = g.id
+        JOIN public.dg_directores_etapa dde ON dde.segmento_lider_id = deg.director_etapa_id
+        WHERE dde.dg_usuario_id = v_user_id
+          AND gm.usuario_id = p_usuario_id
+          AND gm.fecha_salida IS NULL
+          AND g.activo = true
+          AND g.eliminado = false
+      );
+    END IF;
+
+    RETURN EXISTS (
+      SELECT 1
+      FROM public.grupo_miembros gm
+      JOIN public.grupos g ON g.id = gm.grupo_id
+      JOIN public.director_general_segmentos dgs ON dgs.segmento_id = g.segmento_id
+      WHERE dgs.usuario_id = v_user_id
+        AND gm.usuario_id = p_usuario_id
+        AND gm.fecha_salida IS NULL
+        AND g.activo = true
+        AND g.eliminado = false
+    );
+  END IF;
+
+  IF v_is_director_etapa THEN
+    RETURN EXISTS (
+      SELECT 1
+      FROM public.grupo_miembros gm
+      JOIN public.grupos g ON g.id = gm.grupo_id
+      JOIN public.director_etapa_grupos deg ON deg.grupo_id = g.id
+      JOIN public.segmento_lideres sl ON sl.id = deg.director_etapa_id
+      WHERE sl.usuario_id = v_user_id
+        AND sl.tipo_lider = 'director_etapa'
+        AND gm.usuario_id = p_usuario_id
+        AND gm.fecha_salida IS NULL
+        AND g.activo = true
+        AND g.eliminado = false
+    );
+  END IF;
+
+  IF v_is_lider THEN
+    RETURN EXISTS (
+      SELECT 1
+      FROM public.grupo_miembros target_member
+      JOIN public.grupo_miembros leader_member ON leader_member.grupo_id = target_member.grupo_id
+      JOIN public.grupos g ON g.id = target_member.grupo_id
+      WHERE leader_member.usuario_id = v_user_id
+        AND leader_member.rol = 'Líder'
+        AND leader_member.fecha_salida IS NULL
+        AND target_member.usuario_id = p_usuario_id
+        AND target_member.fecha_salida IS NULL
+        AND g.activo = true
+        AND g.eliminado = false
+        AND g.estado_ciclo = 'activo'
+    );
+  END IF;
+
+  RETURN false;
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION public.puede_aprobar_casa_anfitriona(
+  p_auth_id uuid,
+  p_casa_id uuid
+)
+RETURNS boolean
+LANGUAGE plpgsql STABLE SECURITY DEFINER SET search_path TO 'public'
+AS $$
+DECLARE
+  v_user_id uuid;
+  v_owner_id uuid;
+  v_is_admin_or_pastor boolean := false;
+  v_is_director_general boolean := false;
+BEGIN
+  IF p_auth_id IS NULL OR p_auth_id IS DISTINCT FROM auth.uid() THEN
+    RETURN false;
+  END IF;
+
+  SELECT u.id INTO v_user_id FROM public.usuarios u WHERE u.auth_id = p_auth_id;
+  SELECT ca.usuario_id INTO v_owner_id FROM public.casas_anfitrionas ca WHERE ca.id = p_casa_id;
+
+  IF v_user_id IS NULL OR v_owner_id IS NULL THEN RETURN false; END IF;
+
+  SELECT
+    COALESCE(bool_or(rs.nombre_interno IN ('admin', 'pastor')), false),
+    COALESCE(bool_or(rs.nombre_interno = 'director-general'), false)
+  INTO v_is_admin_or_pastor, v_is_director_general
+  FROM public.usuario_roles ur
+  JOIN public.roles_sistema rs ON rs.id = ur.rol_id
+  WHERE ur.usuario_id = v_user_id;
+
+  RETURN v_is_admin_or_pastor OR (
+    v_is_director_general AND public.puede_crear_casa_anfitriona_para(p_auth_id, v_owner_id)
+  );
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION public.puede_editar_casa_anfitriona(
+  p_auth_id uuid,
+  p_casa_id uuid
+)
+RETURNS boolean
+LANGUAGE plpgsql STABLE SECURITY DEFINER SET search_path TO 'public'
+AS $$
+DECLARE
+  v_user_id uuid;
+  v_owner_id uuid;
+  v_has_editor_role boolean := false;
+BEGIN
+  IF p_auth_id IS NULL OR p_auth_id IS DISTINCT FROM auth.uid() THEN
+    RETURN false;
+  END IF;
+
+  SELECT u.id INTO v_user_id FROM public.usuarios u WHERE u.auth_id = p_auth_id;
+  SELECT ca.usuario_id INTO v_owner_id FROM public.casas_anfitrionas ca WHERE ca.id = p_casa_id;
+
+  IF v_user_id IS NULL OR v_owner_id IS NULL THEN RETURN false; END IF;
+
+  SELECT COALESCE(bool_or(rs.nombre_interno IN ('admin', 'pastor', 'director-general', 'director-etapa')), false)
+  INTO v_has_editor_role
+  FROM public.usuario_roles ur
+  JOIN public.roles_sistema rs ON rs.id = ur.rol_id
+  WHERE ur.usuario_id = v_user_id;
+
+  RETURN v_has_editor_role AND public.puede_crear_casa_anfitriona_para(p_auth_id, v_owner_id);
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION public.puede_cambiar_estado_casa_anfitriona(
+  p_auth_id uuid,
+  p_casa_id uuid
+)
+RETURNS boolean
+LANGUAGE plpgsql STABLE SECURITY DEFINER SET search_path TO 'public'
+AS $$
+BEGIN
+  IF p_auth_id IS NULL OR p_auth_id IS DISTINCT FROM auth.uid() THEN
+    RETURN false;
+  END IF;
+
+  RETURN public.puede_editar_casa_anfitriona(p_auth_id, p_casa_id);
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION public.obtener_permisos_casa_anfitriona(
+  p_auth_id uuid,
+  p_casa_id uuid DEFAULT NULL
+)
+RETURNS jsonb
+LANGUAGE plpgsql STABLE SECURITY DEFINER SET search_path TO 'public'
+AS $$
+DECLARE
+  v_user_id uuid;
+  v_can_create_for_others boolean := false;
+BEGIN
+  IF p_auth_id IS NULL OR p_auth_id IS DISTINCT FROM auth.uid() THEN
+    RETURN jsonb_build_object(
+      'puede_ver', false,
+      'puede_crear_propia', false,
+      'puede_crear_para_otros', false,
+      'puede_aprobar', false,
+      'puede_editar', false,
+      'puede_cambiar_estado', false
+    );
+  END IF;
+
+  SELECT u.id INTO v_user_id FROM public.usuarios u WHERE u.auth_id = p_auth_id;
+
+  IF v_user_id IS NOT NULL THEN
+    SELECT COALESCE(bool_or(rs.nombre_interno IN (
+      'admin', 'pastor', 'director-general', 'director-etapa', 'lider'
+    )), false)
+    INTO v_can_create_for_others
+    FROM public.usuario_roles ur
+    JOIN public.roles_sistema rs ON rs.id = ur.rol_id
+    WHERE ur.usuario_id = v_user_id;
+  END IF;
+
+  RETURN jsonb_build_object(
+    'puede_ver', public.puede_ver_casa_anfitriona(p_auth_id, p_casa_id),
+    'puede_crear_propia', public.puede_crear_casa_anfitriona_para(p_auth_id, v_user_id),
+    'puede_crear_para_otros', v_can_create_for_others,
+    'puede_aprobar', public.puede_aprobar_casa_anfitriona(p_auth_id, p_casa_id),
+    'puede_editar', public.puede_editar_casa_anfitriona(p_auth_id, p_casa_id),
+    'puede_cambiar_estado', public.puede_cambiar_estado_casa_anfitriona(p_auth_id, p_casa_id)
+  );
+END;
+$$;
+
+REVOKE ALL ON FUNCTION public.puede_ver_casa_anfitriona(uuid, uuid) FROM PUBLIC;
+REVOKE ALL ON FUNCTION public.puede_crear_casa_anfitriona_para(uuid, uuid) FROM PUBLIC;
+REVOKE ALL ON FUNCTION public.puede_aprobar_casa_anfitriona(uuid, uuid) FROM PUBLIC;
+REVOKE ALL ON FUNCTION public.puede_editar_casa_anfitriona(uuid, uuid) FROM PUBLIC;
+REVOKE ALL ON FUNCTION public.puede_cambiar_estado_casa_anfitriona(uuid, uuid) FROM PUBLIC;
+REVOKE ALL ON FUNCTION public.obtener_permisos_casa_anfitriona(uuid, uuid) FROM PUBLIC;
+
+GRANT EXECUTE ON FUNCTION public.puede_ver_casa_anfitriona(uuid, uuid) TO authenticated, service_role;
+GRANT EXECUTE ON FUNCTION public.puede_crear_casa_anfitriona_para(uuid, uuid) TO authenticated, service_role;
+GRANT EXECUTE ON FUNCTION public.puede_aprobar_casa_anfitriona(uuid, uuid) TO authenticated, service_role;
+GRANT EXECUTE ON FUNCTION public.puede_editar_casa_anfitriona(uuid, uuid) TO authenticated, service_role;
+GRANT EXECUTE ON FUNCTION public.puede_cambiar_estado_casa_anfitriona(uuid, uuid) TO authenticated, service_role;
+GRANT EXECUTE ON FUNCTION public.obtener_permisos_casa_anfitriona(uuid, uuid) TO authenticated, service_role;

--- a/supabase/migrations/20260617161620_casas_anfitrionas_granular_permissions.sql
+++ b/supabase/migrations/20260617161620_casas_anfitrionas_granular_permissions.sql
@@ -1,5 +1,6 @@
 -- Additive granular Casas Anfitrionas permission RPCs.
 -- No data repair, backfill, deletion, or rewrite is performed by this migration.
+-- Timestamp matches the migration version applied to global staging for Task 2.2 evidence.
 
 CREATE OR REPLACE FUNCTION public.puede_ver_casa_anfitriona(
   p_auth_id uuid,
@@ -287,6 +288,12 @@ REVOKE ALL ON FUNCTION public.puede_aprobar_casa_anfitriona(uuid, uuid) FROM PUB
 REVOKE ALL ON FUNCTION public.puede_editar_casa_anfitriona(uuid, uuid) FROM PUBLIC;
 REVOKE ALL ON FUNCTION public.puede_cambiar_estado_casa_anfitriona(uuid, uuid) FROM PUBLIC;
 REVOKE ALL ON FUNCTION public.obtener_permisos_casa_anfitriona(uuid, uuid) FROM PUBLIC;
+REVOKE ALL ON FUNCTION public.puede_ver_casa_anfitriona(uuid, uuid) FROM anon;
+REVOKE ALL ON FUNCTION public.puede_crear_casa_anfitriona_para(uuid, uuid) FROM anon;
+REVOKE ALL ON FUNCTION public.puede_aprobar_casa_anfitriona(uuid, uuid) FROM anon;
+REVOKE ALL ON FUNCTION public.puede_editar_casa_anfitriona(uuid, uuid) FROM anon;
+REVOKE ALL ON FUNCTION public.puede_cambiar_estado_casa_anfitriona(uuid, uuid) FROM anon;
+REVOKE ALL ON FUNCTION public.obtener_permisos_casa_anfitriona(uuid, uuid) FROM anon;
 
 GRANT EXECUTE ON FUNCTION public.puede_ver_casa_anfitriona(uuid, uuid) TO authenticated, service_role;
 GRANT EXECUTE ON FUNCTION public.puede_crear_casa_anfitriona_para(uuid, uuid) TO authenticated, service_role;

--- a/supabase/migrations/20260617161954_revoke_anon_from_casas_permission_rpcs.sql
+++ b/supabase/migrations/20260617161954_revoke_anon_from_casas_permission_rpcs.sql
@@ -1,0 +1,10 @@
+-- Reconcile global staging Task 2.2 follow-up hardening.
+-- Staging applied this as a separate migration after direct anon EXECUTE was observed.
+-- Keep it checked in so repository migration history maps to staging evidence.
+
+REVOKE ALL ON FUNCTION public.puede_ver_casa_anfitriona(uuid, uuid) FROM anon;
+REVOKE ALL ON FUNCTION public.puede_crear_casa_anfitriona_para(uuid, uuid) FROM anon;
+REVOKE ALL ON FUNCTION public.puede_aprobar_casa_anfitriona(uuid, uuid) FROM anon;
+REVOKE ALL ON FUNCTION public.puede_editar_casa_anfitriona(uuid, uuid) FROM anon;
+REVOKE ALL ON FUNCTION public.puede_cambiar_estado_casa_anfitriona(uuid, uuid) FROM anon;
+REVOKE ALL ON FUNCTION public.obtener_permisos_casa_anfitriona(uuid, uuid) FROM anon;

--- a/supabase/tests/casas-anfitrionas-permissions-rpc.test.sql
+++ b/supabase/tests/casas-anfitrionas-permissions-rpc.test.sql
@@ -1,7 +1,8 @@
 -- Casas Anfitrionas permission RPC contract checks.
 --
 -- Run against local or staging after applying
--- 20260617120000_casas_anfitrionas_granular_permissions.sql.
+-- 20260617161620_casas_anfitrionas_granular_permissions.sql and
+-- 20260617161954_revoke_anon_from_casas_permission_rpcs.sql.
 -- The harness creates deterministic fixtures and rolls them back.
 
 BEGIN;
@@ -20,6 +21,50 @@ BEGIN
   END IF;
 END;
 $$;
+
+CREATE OR REPLACE FUNCTION pg_temp.assert_function_privilege(
+  p_role name,
+  p_function_signature text,
+  p_privilege text,
+  p_expected boolean
+)
+RETURNS void
+LANGUAGE plpgsql
+AS $$
+DECLARE
+  v_actual boolean;
+BEGIN
+  SELECT has_function_privilege(p_role, p_function_signature, p_privilege) INTO v_actual;
+
+  IF v_actual IS DISTINCT FROM p_expected THEN
+    RAISE EXCEPTION 'Function privilege check failed: role %, function %, privilege %, expected %, got %',
+      p_role,
+      p_function_signature,
+      p_privilege,
+      p_expected,
+      v_actual;
+  END IF;
+END;
+$$;
+
+SELECT pg_temp.assert_function_privilege('anon', 'public.obtener_permisos_casa_anfitriona(uuid, uuid)', 'EXECUTE', false);
+SELECT pg_temp.assert_function_privilege('authenticated', 'public.obtener_permisos_casa_anfitriona(uuid, uuid)', 'EXECUTE', true);
+SELECT pg_temp.assert_function_privilege('service_role', 'public.obtener_permisos_casa_anfitriona(uuid, uuid)', 'EXECUTE', true);
+SELECT pg_temp.assert_function_privilege('anon', 'public.puede_ver_casa_anfitriona(uuid, uuid)', 'EXECUTE', false);
+SELECT pg_temp.assert_function_privilege('authenticated', 'public.puede_ver_casa_anfitriona(uuid, uuid)', 'EXECUTE', true);
+SELECT pg_temp.assert_function_privilege('service_role', 'public.puede_ver_casa_anfitriona(uuid, uuid)', 'EXECUTE', true);
+SELECT pg_temp.assert_function_privilege('anon', 'public.puede_crear_casa_anfitriona_para(uuid, uuid)', 'EXECUTE', false);
+SELECT pg_temp.assert_function_privilege('authenticated', 'public.puede_crear_casa_anfitriona_para(uuid, uuid)', 'EXECUTE', true);
+SELECT pg_temp.assert_function_privilege('service_role', 'public.puede_crear_casa_anfitriona_para(uuid, uuid)', 'EXECUTE', true);
+SELECT pg_temp.assert_function_privilege('anon', 'public.puede_aprobar_casa_anfitriona(uuid, uuid)', 'EXECUTE', false);
+SELECT pg_temp.assert_function_privilege('authenticated', 'public.puede_aprobar_casa_anfitriona(uuid, uuid)', 'EXECUTE', true);
+SELECT pg_temp.assert_function_privilege('service_role', 'public.puede_aprobar_casa_anfitriona(uuid, uuid)', 'EXECUTE', true);
+SELECT pg_temp.assert_function_privilege('anon', 'public.puede_editar_casa_anfitriona(uuid, uuid)', 'EXECUTE', false);
+SELECT pg_temp.assert_function_privilege('authenticated', 'public.puede_editar_casa_anfitriona(uuid, uuid)', 'EXECUTE', true);
+SELECT pg_temp.assert_function_privilege('service_role', 'public.puede_editar_casa_anfitriona(uuid, uuid)', 'EXECUTE', true);
+SELECT pg_temp.assert_function_privilege('anon', 'public.puede_cambiar_estado_casa_anfitriona(uuid, uuid)', 'EXECUTE', false);
+SELECT pg_temp.assert_function_privilege('authenticated', 'public.puede_cambiar_estado_casa_anfitriona(uuid, uuid)', 'EXECUTE', true);
+SELECT pg_temp.assert_function_privilege('service_role', 'public.puede_cambiar_estado_casa_anfitriona(uuid, uuid)', 'EXECUTE', true);
 
 CREATE TEMP TABLE gc_casas_permissions_fixture (
   key text PRIMARY KEY,

--- a/supabase/tests/casas-anfitrionas-permissions-rpc.test.sql
+++ b/supabase/tests/casas-anfitrionas-permissions-rpc.test.sql
@@ -1,0 +1,186 @@
+-- Casas Anfitrionas permission RPC contract checks.
+--
+-- Run against local or staging after applying
+-- 20260617120000_casas_anfitrionas_granular_permissions.sql.
+-- The harness creates deterministic fixtures and rolls them back.
+
+BEGIN;
+
+CREATE OR REPLACE FUNCTION pg_temp.assert_permission(
+  p_case text,
+  p_actual boolean,
+  p_expected boolean
+)
+RETURNS void
+LANGUAGE plpgsql
+AS $$
+BEGIN
+  IF p_actual IS DISTINCT FROM p_expected THEN
+    RAISE EXCEPTION 'Permission check failed: %, expected %, got %', p_case, p_expected, p_actual;
+  END IF;
+END;
+$$;
+
+CREATE TEMP TABLE gc_casas_permissions_fixture (
+  key text PRIMARY KEY,
+  id uuid NOT NULL UNIQUE
+) ON COMMIT DROP;
+
+INSERT INTO gc_casas_permissions_fixture (key, id) VALUES
+  ('admin_auth_id', '11111111-1111-4111-8111-111111111101'),
+  ('director_etapa_auth_id', '11111111-1111-4111-8111-111111111102'),
+  ('leader_auth_id', '11111111-1111-4111-8111-111111111103'),
+  ('outsider_auth_id', '11111111-1111-4111-8111-111111111104'),
+  ('admin_user_id', '22222222-2222-4222-8222-222222222101'),
+  ('director_etapa_user_id', '22222222-2222-4222-8222-222222222102'),
+  ('leader_user_id', '22222222-2222-4222-8222-222222222103'),
+  ('outsider_user_id', '22222222-2222-4222-8222-222222222104'),
+  ('same_group_user_id', '22222222-2222-4222-8222-222222222201'),
+  ('out_of_group_user_id', '22222222-2222-4222-8222-222222222202'),
+  ('admin_role_id', '33333333-3333-4333-8333-333333333101'),
+  ('director_etapa_role_id', '33333333-3333-4333-8333-333333333102'),
+  ('leader_role_id', '33333333-3333-4333-8333-333333333103'),
+  ('segment_id', '44444444-4444-4444-8444-444444444101'),
+  ('other_segment_id', '44444444-4444-4444-8444-444444444102'),
+  ('season_id', '55555555-5555-4555-8555-555555555101'),
+  ('in_scope_group_id', '66666666-6666-4666-8666-666666666101'),
+  ('out_of_scope_group_id', '66666666-6666-4666-8666-666666666102'),
+  ('director_etapa_assignment_id', '77777777-7777-4777-8777-777777777101'),
+  ('director_etapa_group_id', '77777777-7777-4777-8777-777777777102'),
+  ('in_scope_house_id', '88888888-8888-4888-8888-888888888101'),
+  ('out_of_scope_house_id', '88888888-8888-4888-8888-888888888102');
+
+CREATE OR REPLACE FUNCTION pg_temp.fixture_id(p_key text)
+RETURNS uuid
+LANGUAGE sql
+STABLE
+AS $$
+  SELECT f.id FROM gc_casas_permissions_fixture f WHERE f.key = p_key;
+$$;
+
+INSERT INTO public.roles_sistema (id, nombre_interno, nombre_visible)
+SELECT fixture_id('admin_role_id'), 'admin', 'Admin'
+WHERE NOT EXISTS (SELECT 1 FROM public.roles_sistema WHERE nombre_interno = 'admin');
+
+INSERT INTO public.roles_sistema (id, nombre_interno, nombre_visible)
+SELECT fixture_id('director_etapa_role_id'), 'director-etapa', 'Director de Etapa'
+WHERE NOT EXISTS (SELECT 1 FROM public.roles_sistema WHERE nombre_interno = 'director-etapa');
+
+INSERT INTO public.roles_sistema (id, nombre_interno, nombre_visible)
+SELECT fixture_id('leader_role_id'), 'lider', 'Lider'
+WHERE NOT EXISTS (SELECT 1 FROM public.roles_sistema WHERE nombre_interno = 'lider');
+
+INSERT INTO public.usuarios (id, auth_id, nombre, apellido, email, estado_civil, genero)
+VALUES
+  (fixture_id('admin_user_id'), fixture_id('admin_auth_id'), 'Contract', 'Admin', 'gc-casas-admin@example.test', 'Soltero', 'Otro'),
+  (fixture_id('director_etapa_user_id'), fixture_id('director_etapa_auth_id'), 'Contract', 'Director', 'gc-casas-director@example.test', 'Soltero', 'Otro'),
+  (fixture_id('leader_user_id'), fixture_id('leader_auth_id'), 'Contract', 'Leader', 'gc-casas-leader@example.test', 'Soltero', 'Otro'),
+  (fixture_id('outsider_user_id'), fixture_id('outsider_auth_id'), 'Contract', 'Outsider', 'gc-casas-outsider@example.test', 'Soltero', 'Otro'),
+  (fixture_id('same_group_user_id'), NULL, 'Contract', 'Same Group', 'gc-casas-same-group@example.test', 'Soltero', 'Otro'),
+  (fixture_id('out_of_group_user_id'), NULL, 'Contract', 'Out Group', 'gc-casas-out-group@example.test', 'Soltero', 'Otro');
+
+INSERT INTO public.usuario_roles (usuario_id, rol_id)
+SELECT fixture_id('admin_user_id'), id FROM public.roles_sistema WHERE nombre_interno = 'admin'
+UNION ALL
+SELECT fixture_id('director_etapa_user_id'), id FROM public.roles_sistema WHERE nombre_interno = 'director-etapa'
+UNION ALL
+SELECT fixture_id('leader_user_id'), id FROM public.roles_sistema WHERE nombre_interno = 'lider';
+
+INSERT INTO public.segmentos (id, nombre)
+VALUES
+  (fixture_id('segment_id'), 'GC Casas Permissions Segment'),
+  (fixture_id('other_segment_id'), 'GC Casas Permissions Other Segment');
+
+INSERT INTO public.temporadas (id, nombre, fecha_inicio, fecha_fin, activa, estado)
+VALUES (fixture_id('season_id'), 'GC Casas Permissions Season', current_date, current_date + 30, true, 'activa');
+
+INSERT INTO public.grupos (id, nombre, temporada_id, segmento_id, activo, eliminado, estado_ciclo)
+VALUES
+  (fixture_id('in_scope_group_id'), 'GC Casas Permissions In Scope Group', fixture_id('season_id'), fixture_id('segment_id'), true, false, 'activo'),
+  (fixture_id('out_of_scope_group_id'), 'GC Casas Permissions Out Scope Group', fixture_id('season_id'), fixture_id('other_segment_id'), true, false, 'activo');
+
+INSERT INTO public.grupo_miembros (grupo_id, usuario_id, rol, fecha_salida)
+VALUES
+  (fixture_id('in_scope_group_id'), fixture_id('same_group_user_id'), 'Miembro', NULL),
+  (fixture_id('in_scope_group_id'), fixture_id('leader_user_id'), 'Líder', NULL),
+  (fixture_id('out_of_scope_group_id'), fixture_id('out_of_group_user_id'), 'Miembro', NULL);
+
+INSERT INTO public.segmento_lideres (id, usuario_id, segmento_id, tipo_lider)
+VALUES (fixture_id('director_etapa_assignment_id'), fixture_id('director_etapa_user_id'), fixture_id('segment_id'), 'director_etapa');
+
+INSERT INTO public.director_etapa_grupos (id, director_etapa_id, grupo_id)
+VALUES (fixture_id('director_etapa_group_id'), fixture_id('director_etapa_assignment_id'), fixture_id('in_scope_group_id'));
+
+INSERT INTO public.casas_anfitrionas (id, usuario_id, nombre_lugar, capacidad_maxima, disponibilidad, activa, aprobada)
+VALUES
+  (fixture_id('in_scope_house_id'), fixture_id('same_group_user_id'), 'GC Casas Permissions In Scope House', 12, '[]'::jsonb, true, true),
+  (fixture_id('out_of_scope_house_id'), fixture_id('out_of_group_user_id'), 'GC Casas Permissions Out Scope House', 12, '[]'::jsonb, true, true);
+
+SELECT set_config('request.jwt.claim.sub', fixture_id('admin_auth_id')::text, true);
+SELECT pg_temp.assert_permission(
+  'admin can approve an in-scope house',
+  public.puede_aprobar_casa_anfitriona(
+    fixture_id('admin_auth_id'),
+    fixture_id('in_scope_house_id')
+  ),
+  true
+);
+
+SELECT set_config('request.jwt.claim.sub', fixture_id('director_etapa_auth_id')::text, true);
+SELECT pg_temp.assert_permission(
+  'director etapa cannot approve',
+  public.puede_aprobar_casa_anfitriona(
+    fixture_id('director_etapa_auth_id'),
+    fixture_id('in_scope_house_id')
+  ),
+  false
+);
+
+SELECT pg_temp.assert_permission(
+  'director etapa can edit in-scope house',
+  public.puede_editar_casa_anfitriona(
+    fixture_id('director_etapa_auth_id'),
+    fixture_id('in_scope_house_id')
+  ),
+  true
+);
+
+SELECT pg_temp.assert_permission(
+  'director etapa cannot edit out-of-scope house',
+  public.puede_editar_casa_anfitriona(
+    fixture_id('director_etapa_auth_id'),
+    fixture_id('out_of_scope_house_id')
+  ),
+  false
+);
+
+SELECT set_config('request.jwt.claim.sub', fixture_id('leader_auth_id')::text, true);
+SELECT pg_temp.assert_permission(
+  'leader can create only for same active group',
+  public.puede_crear_casa_anfitriona_para(
+    fixture_id('leader_auth_id'),
+    fixture_id('same_group_user_id')
+  ),
+  true
+);
+
+SELECT pg_temp.assert_permission(
+  'leader cannot create for out-of-group user',
+  public.puede_crear_casa_anfitriona_para(
+    fixture_id('leader_auth_id'),
+    fixture_id('out_of_group_user_id')
+  ),
+  false
+);
+
+SELECT set_config('request.jwt.claim.sub', fixture_id('outsider_auth_id')::text, true);
+SELECT pg_temp.assert_permission(
+  'spoofed p_auth_id is denied',
+  public.puede_aprobar_casa_anfitriona(
+    fixture_id('admin_auth_id'),
+    fixture_id('in_scope_house_id')
+  ),
+  false
+);
+
+ROLLBACK;


### PR DESCRIPTION
# Título del PR
feat(casas): agregar rpcs granulares de permisos

Closes #179

## Chain Context
Estrategia: `feature-branch-chain`
Tracker: #180
Límite de revisión: 400 líneas
Excepción aprobada: `size:exception` porque la migración de autorización y sus tests de seguridad son una unidad atómica; separarlos dañaría la revisión.

```text
main
└── PR tracker: feat/casas-permissions-tracker (#180)
    └── 📍 PR 1: feat/casas-permissions-pr1 — RPCs aditivas + tests + staging/types
    └── PR 2: server actions enforcement
    └── PR 3: UI/verification
```

## Resumen
Agrega la primera unidad funcional de permisos granulares para Casas Anfitrionas con RPCs aditivas, evidencia de seguridad, validación en staging y tipos Supabase.

## Qué Incluye
- Migraciones Supabase aditivas con RPCs de permisos granulares.
- Binding de identidad: los RPCs rechazan `p_auth_id` distinto de `auth.uid()`.
- Revocación explícita de EXECUTE para `anon` y grants para `authenticated` / `service_role`.
- Tests Jest estáticos para seguridad/safety de migración.
- Harness SQL determinístico con fixtures transaccionales para casos allow/deny, spoofing y privilegios efectivos.
- Tipos Supabase actualizados para los nuevos RPCs.

## Motivación / Por Qué
El sistema necesita separar permisos de ver, solicitar, crear para otro, aprobar/rechazar, editar y cambiar estado sin depender de checks gruesos en UI/acciones. Esta unidad crea el contrato DB sin mutar datos productivos.

## Evidencia Visual (si aplica)
No aplica.

## Migraciones / Base de Datos
- [ ] No aplica
- [x] Sí (orden exacto):
```
20260617161620_casas_anfitrionas_granular_permissions.sql
20260617161954_revoke_anon_from_casas_permission_rpcs.sql
```
Notas: migraciones aditivas; no actualizan ni eliminan datos existentes. Validadas solo en global staging, no en producción.

## Impacto y Riesgos
- No rompe compatibilidad: agrega RPCs nuevos.
- Requiere que estas migraciones estén aplicadas antes de PRs posteriores que consuman los RPCs.
- Riesgo principal: `SECURITY DEFINER` en schema público; mitigado con `search_path`, grants sin `anon`, binding a `auth.uid()` y validación de privilegios efectivos.
- El harness SQL está preparado con rollback.

## Checklist Autor
- [x] Código formateado (Prettier/ESLint)
- [x] Sin `console.log` / debugger
- [x] Validaciones con zod para entradas nuevas
- [x] Estados loading/error/empty cubiertos
- [x] Tipos TypeScript correctos
- [x] Migraciones probadas en staging
- [x] Documentación actualizada (`docs/` o README)
- [x] Variables de entorno documentadas
- [x] Rebase con `main` limpio

## Checklist Revisor
- [x] Propósito claro
- [x] Nombres descriptivos
- [x] Sin lógica duplicada evidente
- [x] Manejo adecuado de errores
- [x] Cambios acotados al alcance
- [x] Sin secretos / datos sensibles

## Pruebas Manuales Realizadas
- [x] `pnpm test -- __tests__/supabase/casas-anfitrionas-permissions-migration.test.ts`
- [x] `pnpm exec eslint __tests__/supabase/casas-anfitrionas-permissions-migration.test.ts`
- [x] `pnpm lint:migrations` — exit 0; warnings existentes del repo permanecen
- [x] `pnpm test:no-only`
- [x] Global staging: migraciones aplicadas y `has_function_privilege` sin mismatches para `anon`, `authenticated`, `service_role`
- [x] Tipos Supabase regenerados
- [x] Fresh security review: pass/no findings after Task 2.2
- [x] Fresh reliability review: pass

## Pendientes / Follow-up (opcional)
- PR 2: server actions enforcement.
- PR 3: UI wiring y verificación completa.
- Añadir ejemplos directos para `puede_ver_casa_anfitriona`, cambio de estado y salida JSON agregada si se quiere reducir riesgo antes de PR 2.

## Notas Adicionales
Este PR apunta al tracker #180 para mantener la cadena aislada de `main` hasta integrar todas las unidades.