### PR TITLE
fix(casas): endurecer rpc de aprobacion anfitriona

### DIFF
--- a/__tests__/supabase/casas-anfitrionas-permissions-migration.test.ts
+++ b/__tests__/supabase/casas-anfitrionas-permissions-migration.test.ts
@@ -47,6 +47,16 @@ function readCasasPermissionsMigration(): string {
   return readFileSync(join(migrationsDir, file), 'utf8')
 }
 
+function readCasasApprovalHardeningMigration(): string {
+  const file = readdirSync(migrationsDir).find((name) =>
+    name.endsWith('_harden_casas_approval_rpc.sql'),
+  )
+
+  if (!file) throw new Error('Missing casas approval RPC hardening migration')
+
+  return readFileSync(join(migrationsDir, file), 'utf8')
+}
+
 function readCasasRpcChecks(): string {
   return readFileSync(
     join(supabaseTestsDir, 'casas-anfitrionas-permissions-rpc.test.sql'),
@@ -188,5 +198,34 @@ describe('casas anfitrionas granular permissions migration', () => {
     expect(types).toContain('Args: { p_auth_id: string; p_casa_id?: string }')
     expect(types).toContain('Args: { p_auth_id: string; p_casa_id: string }')
     expect(types).toContain('Args: { p_auth_id: string; p_usuario_id: string }')
+  })
+
+  it('hardens direct approval RPC execution with caller binding and granular approval permission', () => {
+    const sql = readCasasApprovalHardeningMigration()
+    const body = functionSql(sql, 'procesar_aprobacion_casa_anfitriona')
+
+    expect(body).toContain('p_auth_id IS DISTINCT FROM auth.uid()')
+    expect(body).toContain('public.puede_aprobar_casa_anfitriona(p_auth_id, p_casa_id)')
+    expect(body).not.toContain('public.puede_gestionar_casas')
+    expect(sql).toContain('REVOKE ALL ON FUNCTION public.procesar_aprobacion_casa_anfitriona(uuid, uuid, text, text) FROM PUBLIC;')
+    expect(sql).toContain('REVOKE ALL ON FUNCTION public.procesar_aprobacion_casa_anfitriona(uuid, uuid, text, text) FROM anon;')
+    expect(sql).toContain('GRANT EXECUTE ON FUNCTION public.procesar_aprobacion_casa_anfitriona(uuid, uuid, text, text) TO authenticated, service_role;')
+  })
+
+  it('documents executable direct approval RPC behavior for allow, deny, and failure paths', () => {
+    const sql = readCasasRpcChecks()
+    const compacted = compactSql(sql)
+
+    expect(sql).toContain('assert_rpc_exception(')
+    expect(sql).toContain('assert_json_text(')
+    expect(sql).toContain('assert_house_approval_state(')
+    expect(sql).toContain('public.procesar_aprobacion_casa_anfitriona(')
+    expect(sql).toContain('direct approval RPC denies spoofed p_auth_id')
+    expect(sql).toContain('direct approval RPC denies unauthorized director etapa')
+    expect(sql).toContain('direct approval RPC allows authorized admin approval')
+    expect(sql).toContain('direct approval RPC rejects invalid action')
+    expect(compacted).toContain("'accion', 'aprobar'")
+    expect(compacted).toContain("'estado', 'aprobada'")
+    expect(sql).not.toMatch(/TODO|placeholder|manual/i)
   })
 })

--- a/supabase/migrations/20260617183000_harden_casas_approval_rpc.sql
+++ b/supabase/migrations/20260617183000_harden_casas_approval_rpc.sql
@@ -1,0 +1,67 @@
+-- Harden direct execution of the Casas Anfitrionas approval mutation RPC.
+-- This corrective migration is additive/idempotent: it replaces function logic only.
+
+CREATE OR REPLACE FUNCTION public.procesar_aprobacion_casa_anfitriona(
+  p_auth_id uuid,
+  p_casa_id uuid,
+  p_accion text,
+  p_notas text DEFAULT NULL
+)
+RETURNS jsonb
+LANGUAGE plpgsql SECURITY DEFINER SET search_path TO 'public'
+AS $$
+DECLARE
+  v_usuario_id uuid;
+  v_rows_updated integer;
+BEGIN
+  IF p_auth_id IS NULL OR p_auth_id IS DISTINCT FROM auth.uid() THEN
+    RAISE EXCEPTION 'sin_permisos';
+  END IF;
+
+  SELECT id INTO v_usuario_id
+  FROM public.usuarios
+  WHERE auth_id = p_auth_id;
+
+  IF v_usuario_id IS NULL THEN
+    RAISE EXCEPTION 'usuario_no_encontrado';
+  END IF;
+
+  IF NOT public.puede_aprobar_casa_anfitriona(p_auth_id, p_casa_id) THEN
+    RAISE EXCEPTION 'sin_permisos';
+  END IF;
+
+  IF p_accion = 'aprobar' THEN
+    UPDATE public.casas_anfitrionas
+    SET aprobada = true,
+        activa = true,
+        aprobada_por = v_usuario_id,
+        aprobada_en = now(),
+        actualizado_en = now()
+    WHERE id = p_casa_id;
+  ELSIF p_accion = 'rechazar' THEN
+    UPDATE public.casas_anfitrionas
+    SET aprobada = false,
+        activa = false,
+        notas_privadas = COALESCE(p_notas, notas_privadas),
+        actualizado_en = now()
+    WHERE id = p_casa_id;
+  ELSE
+    RAISE EXCEPTION 'accion_invalida';
+  END IF;
+
+  GET DIAGNOSTICS v_rows_updated = ROW_COUNT;
+  IF v_rows_updated = 0 THEN
+    RAISE EXCEPTION 'casa_no_encontrada';
+  END IF;
+
+  RETURN jsonb_build_object(
+    'ok', true,
+    'accion', p_accion,
+    'estado', CASE WHEN p_accion = 'aprobar' THEN 'aprobada' ELSE 'rechazada' END
+  );
+END;
+$$;
+
+REVOKE ALL ON FUNCTION public.procesar_aprobacion_casa_anfitriona(uuid, uuid, text, text) FROM PUBLIC;
+REVOKE ALL ON FUNCTION public.procesar_aprobacion_casa_anfitriona(uuid, uuid, text, text) FROM anon;
+GRANT EXECUTE ON FUNCTION public.procesar_aprobacion_casa_anfitriona(uuid, uuid, text, text) TO authenticated, service_role;

--- a/supabase/tests/casas-anfitrionas-permissions-rpc.test.sql
+++ b/supabase/tests/casas-anfitrionas-permissions-rpc.test.sql
@@ -2,7 +2,8 @@
 --
 -- Run against local or staging after applying
 -- 20260617161620_casas_anfitrionas_granular_permissions.sql and
--- 20260617161954_revoke_anon_from_casas_permission_rpcs.sql.
+-- 20260617161954_revoke_anon_from_casas_permission_rpcs.sql and
+-- 20260617183000_harden_casas_approval_rpc.sql.
 -- The harness creates deterministic fixtures and rolls them back.
 
 BEGIN;
@@ -44,6 +45,95 @@ BEGIN
       p_expected,
       v_actual;
   END IF;
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION pg_temp.assert_json_text(
+  p_case text,
+  p_actual jsonb,
+  p_key text,
+  p_expected text
+)
+RETURNS void
+LANGUAGE plpgsql
+AS $$
+DECLARE
+  v_actual text;
+BEGIN
+  v_actual := p_actual ->> p_key;
+
+  IF v_actual IS DISTINCT FROM p_expected THEN
+    RAISE EXCEPTION 'JSON check failed: %, key %, expected %, got %', p_case, p_key, p_expected, v_actual;
+  END IF;
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION pg_temp.assert_house_approval_state(
+  p_case text,
+  p_house_id uuid,
+  p_expected_approved boolean,
+  p_expected_active boolean,
+  p_expected_approver_id uuid
+)
+RETURNS void
+LANGUAGE plpgsql
+AS $$
+DECLARE
+  v_approved boolean;
+  v_active boolean;
+  v_approver_id uuid;
+BEGIN
+  SELECT ca.aprobada, ca.activa, ca.aprobada_por
+  INTO v_approved, v_active, v_approver_id
+  FROM public.casas_anfitrionas ca
+  WHERE ca.id = p_house_id;
+
+  IF v_approved IS DISTINCT FROM p_expected_approved
+    OR v_active IS DISTINCT FROM p_expected_active
+    OR v_approver_id IS DISTINCT FROM p_expected_approver_id THEN
+    RAISE EXCEPTION 'House approval state check failed: %, expected approved %, active %, approver %, got approved %, active %, approver %',
+      p_case,
+      p_expected_approved,
+      p_expected_active,
+      p_expected_approver_id,
+      v_approved,
+      v_active,
+      v_approver_id;
+  END IF;
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION pg_temp.assert_rpc_exception(
+  p_case text,
+  p_expected_message text,
+  p_auth_claim uuid,
+  p_call_auth_id uuid,
+  p_house_id uuid,
+  p_action text
+)
+RETURNS void
+LANGUAGE plpgsql
+AS $$
+BEGIN
+  PERFORM set_config('request.jwt.claim.sub', p_auth_claim::text, true);
+  PERFORM public.procesar_aprobacion_casa_anfitriona(
+    p_call_auth_id,
+    p_house_id,
+    p_action,
+    'contract check'
+  );
+
+  RAISE EXCEPTION 'RPC exception check failed: %, expected exception % but call succeeded',
+    p_case,
+    p_expected_message;
+EXCEPTION
+  WHEN OTHERS THEN
+    IF SQLERRM IS DISTINCT FROM p_expected_message THEN
+      RAISE EXCEPTION 'RPC exception check failed: %, expected exception %, got %',
+        p_case,
+        p_expected_message,
+        SQLERRM;
+    END IF;
 END;
 $$;
 
@@ -93,7 +183,14 @@ INSERT INTO gc_casas_permissions_fixture (key, id) VALUES
   ('director_etapa_assignment_id', '77777777-7777-4777-8777-777777777101'),
   ('director_etapa_group_id', '77777777-7777-4777-8777-777777777102'),
   ('in_scope_house_id', '88888888-8888-4888-8888-888888888101'),
-  ('out_of_scope_house_id', '88888888-8888-4888-8888-888888888102');
+  ('out_of_scope_house_id', '88888888-8888-4888-8888-888888888102'),
+  ('approval_success_house_id', '88888888-8888-4888-8888-888888888103'),
+  ('invalid_action_house_id', '88888888-8888-4888-8888-888888888104');
+
+CREATE TEMP TABLE gc_casas_rpc_results (
+  key text PRIMARY KEY,
+  result jsonb NOT NULL
+) ON COMMIT DROP;
 
 CREATE OR REPLACE FUNCTION pg_temp.fixture_id(p_key text)
 RETURNS uuid
@@ -159,7 +256,9 @@ VALUES (fixture_id('director_etapa_group_id'), fixture_id('director_etapa_assign
 INSERT INTO public.casas_anfitrionas (id, usuario_id, nombre_lugar, capacidad_maxima, disponibilidad, activa, aprobada)
 VALUES
   (fixture_id('in_scope_house_id'), fixture_id('same_group_user_id'), 'GC Casas Permissions In Scope House', 12, '[]'::jsonb, true, true),
-  (fixture_id('out_of_scope_house_id'), fixture_id('out_of_group_user_id'), 'GC Casas Permissions Out Scope House', 12, '[]'::jsonb, true, true);
+  (fixture_id('out_of_scope_house_id'), fixture_id('out_of_group_user_id'), 'GC Casas Permissions Out Scope House', 12, '[]'::jsonb, true, true),
+  (fixture_id('approval_success_house_id'), fixture_id('same_group_user_id'), 'GC Casas Permissions Approval Success House', 12, '[]'::jsonb, false, false),
+  (fixture_id('invalid_action_house_id'), fixture_id('same_group_user_id'), 'GC Casas Permissions Invalid Action House', 12, '[]'::jsonb, false, false);
 
 SELECT set_config('request.jwt.claim.sub', fixture_id('admin_auth_id')::text, true);
 SELECT pg_temp.assert_permission(
@@ -226,6 +325,88 @@ SELECT pg_temp.assert_permission(
     fixture_id('in_scope_house_id')
   ),
   false
+);
+
+SELECT pg_temp.assert_rpc_exception(
+  'direct approval RPC denies spoofed p_auth_id',
+  'sin_permisos',
+  fixture_id('outsider_auth_id'),
+  fixture_id('admin_auth_id'),
+  fixture_id('approval_success_house_id'),
+  'aprobar'
+);
+
+SELECT pg_temp.assert_house_approval_state(
+  'direct approval RPC spoof attempt leaves house pending',
+  fixture_id('approval_success_house_id'),
+  false,
+  false,
+  NULL
+);
+
+SELECT pg_temp.assert_rpc_exception(
+  'direct approval RPC denies unauthorized director etapa',
+  'sin_permisos',
+  fixture_id('director_etapa_auth_id'),
+  fixture_id('director_etapa_auth_id'),
+  fixture_id('approval_success_house_id'),
+  'aprobar'
+);
+
+SELECT pg_temp.assert_house_approval_state(
+  'direct approval RPC unauthorized role leaves house pending',
+  fixture_id('approval_success_house_id'),
+  false,
+  false,
+  NULL
+);
+
+SELECT set_config('request.jwt.claim.sub', fixture_id('admin_auth_id')::text, true);
+INSERT INTO gc_casas_rpc_results (key, result)
+SELECT 'admin_approval', public.procesar_aprobacion_casa_anfitriona(
+  fixture_id('admin_auth_id'),
+  fixture_id('approval_success_house_id'),
+  'aprobar',
+  'contract check'
+);
+
+SELECT pg_temp.assert_json_text(
+  'direct approval RPC allows authorized admin approval',
+  (SELECT result FROM gc_casas_rpc_results WHERE key = 'admin_approval'),
+  'accion',
+  'aprobar'
+);
+
+SELECT pg_temp.assert_json_text(
+  'direct approval RPC returns approved state',
+  (SELECT result FROM gc_casas_rpc_results WHERE key = 'admin_approval'),
+  'estado',
+  'aprobada'
+);
+
+SELECT pg_temp.assert_house_approval_state(
+  'direct approval RPC authorized admin marks house approved',
+  fixture_id('approval_success_house_id'),
+  true,
+  true,
+  fixture_id('admin_user_id')
+);
+
+SELECT pg_temp.assert_rpc_exception(
+  'direct approval RPC rejects invalid action',
+  'accion_invalida',
+  fixture_id('admin_auth_id'),
+  fixture_id('admin_auth_id'),
+  fixture_id('invalid_action_house_id'),
+  'archivar'
+);
+
+SELECT pg_temp.assert_house_approval_state(
+  'direct approval RPC invalid action leaves house pending',
+  fixture_id('invalid_action_house_id'),
+  false,
+  false,
+  NULL
 );
 
 ROLLBACK;


### PR DESCRIPTION
# Título del PR
fix(casas): endurecer rpc de aprobacion anfitriona

Refs #179

## Chain Context
Estrategia: `feature-branch-chain`
Tracker: #180

```text
main
└── PR tracker: feat/casas-permissions-tracker (#180)
    └── PR 1: RPCs aditivas + staging/types (#181, merged)
    └── 📍 PR 2a: feat/casas-permissions-pr2-rpc — hardening RPC legacy de aprobación
        └── PR 2b: feat/casas-permissions-pr2-actions — server actions enforcement
    └── PR 3: UI/verification
```

## Resumen
Endurece el RPC legacy `procesar_aprobacion_casa_anfitriona` para que no pueda saltarse la autorización granular por llamadas directas a Supabase.

## Qué Incluye
- Migración correctiva aditiva para reemplazar el RPC de aprobación.
- Binding de identidad: `p_auth_id` debe coincidir con `auth.uid()`.
- Uso de `puede_aprobar_casa_anfitriona(...)` en la frontera de mutación.
- Revoke explícito de `PUBLIC`/`anon` y grant a `authenticated`/`service_role`.
- Evidencia SQL ejecutable para spoofing, rol no autorizado, aprobación autorizada y acción inválida.

## Motivación / Por Qué
La capa server action no debe ser la única defensa. El RPC de mutación también debe protegerse porque puede invocarse directamente.

## Evidencia Visual (si aplica)
No aplica.

## Migraciones / Base de Datos
- [ ] No aplica
- [x] Sí (orden exacto):
```
20260617183000_harden_casas_approval_rpc.sql
```
Notas: migración correctiva; no toca datos existentes.

## Impacto y Riesgos
- Refuerza seguridad del RPC de aprobación.
- Requiere que PR #181 esté en el tracker.
- No cambia UI ni server actions.

## Checklist Autor
- [x] Código formateado (Prettier/ESLint)
- [x] Sin `console.log` / debugger
- [x] Validaciones con zod para entradas nuevas
- [x] Estados loading/error/empty cubiertos
- [x] Tipos TypeScript correctos
- [x] Migraciones probadas local
- [x] Documentación actualizada (`docs/` o README)
- [x] Variables de entorno documentadas
- [x] Rebase con `main` limpio

## Checklist Revisor
- [x] Propósito claro
- [x] Nombres descriptivos
- [x] Sin lógica duplicada evidente
- [x] Manejo adecuado de errores
- [x] Cambios acotados al alcance
- [x] Sin secretos / datos sensibles

## Pruebas Manuales Realizadas
- [x] `pnpm test -- __tests__/supabase/casas-anfitrionas-permissions-migration.test.ts`
- [x] `pnpm lint:migrations`
- [x] `pnpm test:no-only`
- [x] Fresh security review: pass
- [x] Fresh reliability review: pass after behavior evidence

## Pendientes / Follow-up (opcional)
- PR 2b conecta server actions con permisos granulares.
- PR 3 conecta UI/App Router.

## Notas Adicionales
Este PR apunta al tracker #180; PR 2b debe apuntar a esta rama para mantener el diff limpio.