### PR TITLE
feat(casas): exigir permisos granulares en acciones

### DIFF
--- a/__tests__/lib/actions/casas-anfitrionas.actions.test.ts
+++ b/__tests__/lib/actions/casas-anfitrionas.actions.test.ts
@@ -1,0 +1,194 @@
+import { actualizarCasaAnfitriona, cambiarEstadoCasaAnfitriona, crearCasaAnfitriona, listarCasasAnfitrionas, obtenerDireccionUsuario, obtenerRelacionesFamiliares, procesarAprobacionCasa } from '@/lib/actions/casas-anfitrionas.actions'
+
+const createSupabaseServerClient = jest.fn()
+const createSupabaseAdminClient = jest.fn()
+const revalidatePath = jest.fn()
+
+jest.mock('@/lib/supabase/server', () => ({ createSupabaseServerClient: () => createSupabaseServerClient() }))
+jest.mock('@/lib/supabase/admin', () => ({ createSupabaseAdminClient: () => createSupabaseAdminClient() }))
+jest.mock('next/cache', () => ({ revalidatePath: (path: string) => revalidatePath(path) }))
+
+const [authId, actorUserId, targetUserId, coHostUserId, casaId] = ['11111111-1111-1111-1111-111111111111', '22222222-2222-2222-2222-222222222222', '33333333-3333-3333-3333-333333333333', '44444444-4444-4444-4444-444444444444', '55555555-5555-5555-5555-555555555555']
+
+describe('casas anfitrionas server actions permissions', () => {
+  beforeEach(() => {
+    createSupabaseServerClient.mockReset()
+    createSupabaseAdminClient.mockReset()
+    revalidatePath.mockReset()
+  })
+
+  it('denies create-for-another before any admin write when the granular RPC rejects the target owner', async () => {
+    const rpc = createPermissionRpcMock({ createFor: false })
+    createSupabaseServerClient.mockResolvedValue(createServerClient({ rpc }))
+
+    const result = await crearCasaAnfitriona(createCasaInput({ usuario_id: targetUserId }))
+
+    expect(result).toEqual({ success: false, error: 'No tienes permisos para crear una casa para este usuario' })
+    expect(rpc).toHaveBeenCalledWith('puede_crear_casa_anfitriona_para', { p_auth_id: authId, p_usuario_id: targetUserId })
+    expect(createSupabaseAdminClient).not.toHaveBeenCalled()
+  })
+
+  it('validates co-host scope before creating a house', async () => {
+    const rpc = createPermissionRpcMock({ createFor: true, coHost: false })
+    createSupabaseServerClient.mockResolvedValue(createServerClient({ rpc }))
+
+    const result = await crearCasaAnfitriona(createCasaInput({ co_anfitrion_id: coHostUserId }))
+
+    expect(result).toEqual({ success: false, error: 'No tienes permisos para asignar este co-anfitrión' })
+    expect(rpc).toHaveBeenCalledWith('puede_crear_casa_anfitriona_para', { p_auth_id: authId, p_usuario_id: actorUserId })
+    expect(rpc).toHaveBeenCalledWith('puede_crear_casa_anfitriona_para', { p_auth_id: authId, p_usuario_id: coHostUserId })
+    expect(createSupabaseAdminClient).not.toHaveBeenCalled()
+  })
+
+  it('denies approval before invoking the approval mutation RPC', async () => {
+    const rpc = createPermissionRpcMock({ approve: false })
+    createSupabaseServerClient.mockResolvedValue(createServerClient({ rpc }))
+
+    const result = await procesarAprobacionCasa(casaId, 'aprobar')
+
+    expect(result).toEqual({ success: false, error: 'No tienes permisos para aprobar o rechazar esta casa' })
+    expect(rpc).toHaveBeenCalledWith('puede_aprobar_casa_anfitriona', { p_auth_id: authId, p_casa_id: casaId })
+    expect(rpc).not.toHaveBeenCalledWith('procesar_aprobacion_casa_anfitriona', expect.anything())
+    expect(revalidatePath).not.toHaveBeenCalled()
+  })
+
+  it('denies edits before reading or writing with the admin client', async () => {
+    const rpc = createPermissionRpcMock({ edit: false })
+    createSupabaseServerClient.mockResolvedValue(createServerClient({ rpc }))
+
+    const result = await actualizarCasaAnfitriona(casaId, { nombre_lugar: 'Casa nueva' })
+
+    expect(result).toEqual({ success: false, error: 'No tienes permisos para editar esta casa' })
+    expect(rpc).toHaveBeenCalledWith('puede_editar_casa_anfitriona', { p_auth_id: authId, p_casa_id: casaId })
+    expect(createSupabaseAdminClient).not.toHaveBeenCalled()
+  })
+
+  it('returns approved sensitive edits to pending review when saving', async () => {
+    const rpc = createPermissionRpcMock({ edit: true })
+    const adminDb = createAdminClient({ existingCasa: { usuario_id: targetUserId, direccion_id: null, aprobada: true } })
+    createSupabaseServerClient.mockResolvedValue(createServerClient({ rpc }))
+    createSupabaseAdminClient.mockReturnValue(adminDb)
+
+    const result = await actualizarCasaAnfitriona(casaId, { capacidad_maxima: 20 })
+
+    expect(result).toEqual({ success: true })
+    expect(adminDb.updateCasasAnfitrionas).toHaveBeenCalledWith(expect.objectContaining({
+      capacidad_maxima: 20,
+      aprobada: false,
+      aprobada_en: null,
+      aprobada_por: null,
+    }))
+    expect(revalidatePath).toHaveBeenCalledWith(`/grupos-vida/casas-anfitrionas/${casaId}`)
+  })
+
+  it('filters the list by RPC-visible house ids before returning enriched rows', async () => {
+    const visibleCasaIds = [casaId]
+    const rpc = createPermissionRpcMock({ visibleCasaIds })
+    const listQuery = createListQuery([{ id: casaId, nombre_lugar: 'Casa visible' }])
+    createSupabaseServerClient.mockResolvedValue(createServerClient({ rpc, casasQuery: listQuery }))
+
+    const result = await listarCasasAnfitrionas()
+
+    expect(result).toEqual({ success: true, data: [{ id: casaId, nombre_lugar: 'Casa visible' }] })
+    expect(rpc).toHaveBeenCalledWith('obtener_casas_visibles_ids', { p_auth_id: authId })
+    expect(listQuery.in).toHaveBeenCalledWith('id', visibleCasaIds)
+  })
+
+  it('denies active-state changes before writing when the granular RPC rejects the house', async () => {
+    const rpc = createPermissionRpcMock({ changeState: false })
+    createSupabaseServerClient.mockResolvedValue(createServerClient({ rpc }))
+
+    const result = await cambiarEstadoCasaAnfitriona(casaId, false)
+
+    expect(result).toEqual({ success: false, error: 'No tienes permisos para cambiar el estado de esta casa' })
+    expect(rpc).toHaveBeenCalledWith('puede_cambiar_estado_casa_anfitriona', { p_auth_id: authId, p_casa_id: casaId })
+    expect(createSupabaseAdminClient).not.toHaveBeenCalled()
+  })
+
+  it('denies family relationship reads before using the admin client when the target user is out of scope', async () => {
+    const rpc = createPermissionRpcMock({ createFor: false })
+    createSupabaseServerClient.mockResolvedValue(createServerClient({ rpc }))
+
+    const result = await obtenerRelacionesFamiliares(targetUserId)
+
+    expect(result).toEqual({ success: false, error: 'No tienes permisos para consultar este usuario' })
+    expect(rpc).toHaveBeenCalledWith('puede_crear_casa_anfitriona_para', { p_auth_id: authId, p_usuario_id: targetUserId })
+    expect(createSupabaseAdminClient).not.toHaveBeenCalled()
+  })
+
+  it('denies user address reads before using the admin client when the target user is out of scope', async () => {
+    const rpc = createPermissionRpcMock({ createFor: false })
+    createSupabaseServerClient.mockResolvedValue(createServerClient({ rpc }))
+
+    const result = await obtenerDireccionUsuario(targetUserId)
+
+    expect(result).toEqual({ success: false, error: 'No tienes permisos para consultar este usuario' })
+    expect(rpc).toHaveBeenCalledWith('puede_crear_casa_anfitriona_para', { p_auth_id: authId, p_usuario_id: targetUserId })
+    expect(createSupabaseAdminClient).not.toHaveBeenCalled()
+  })
+})
+
+function createCasaInput(overrides: Record<string, unknown> = {}) {
+  return { nombre_lugar: 'Casa de Ana', calle: 'Calle 1', capacidad_maxima: 12, ...overrides }
+}
+
+function createPermissionRpcMock(input: {
+  approve?: boolean
+  changeState?: boolean
+  coHost?: boolean
+  createFor?: boolean
+  edit?: boolean
+  visibleCasaIds?: string[]
+}) {
+  return jest.fn((rpcName: string, args: Record<string, unknown>) => {
+    if (rpcName === 'puede_crear_casa_anfitriona_para') {
+      return Promise.resolve({ data: args.p_usuario_id === coHostUserId ? input.coHost : input.createFor, error: null })
+    }
+    if (rpcName === 'puede_aprobar_casa_anfitriona') return Promise.resolve({ data: input.approve, error: null })
+    if (rpcName === 'puede_editar_casa_anfitriona') return Promise.resolve({ data: input.edit, error: null })
+    if (rpcName === 'puede_cambiar_estado_casa_anfitriona') return Promise.resolve({ data: input.changeState, error: null })
+    if (rpcName === 'obtener_casas_visibles_ids') return Promise.resolve({ data: input.visibleCasaIds ?? [], error: null })
+    if (rpcName === 'procesar_aprobacion_casa_anfitriona') return Promise.resolve({ data: { ok: true, estado: 'aprobada' }, error: null })
+    return Promise.resolve({ data: false, error: null })
+  })
+}
+
+function createServerClient(input: { rpc: jest.Mock; casasQuery?: unknown }) {
+  return {
+    auth: { getUser: jest.fn().mockResolvedValue({ data: { user: { id: authId } }, error: null }) },
+    from: jest.fn((table: string) => {
+      if (table === 'usuarios') return createUsuarioQuery()
+      if (table === 'casas_anfitrionas' && input.casasQuery) return input.casasQuery
+      throw new Error(`Unexpected server table ${table}`)
+    }),
+    rpc: input.rpc,
+  }
+}
+
+function createUsuarioQuery() {
+  return { select: jest.fn().mockReturnValue({ eq: jest.fn().mockReturnValue({ single: jest.fn().mockResolvedValue({ data: { id: actorUserId }, error: null }) }) }) }
+}
+
+function createListQuery(rows: unknown[]) {
+  return {
+    select: jest.fn().mockReturnThis(),
+    order: jest.fn().mockReturnThis(),
+    in: jest.fn().mockResolvedValue({ data: rows, error: null }),
+  }
+}
+
+function createAdminClient(input: { existingCasa: { usuario_id: string; direccion_id: string | null; aprobada: boolean } }) {
+  const updateCasasAnfitrionas = jest.fn().mockReturnValue({ eq: jest.fn().mockResolvedValue({ error: null }) })
+  return {
+    updateCasasAnfitrionas,
+    from: jest.fn((table: string) => {
+      if (table === 'casas_anfitrionas') {
+        return {
+          update: updateCasasAnfitrionas,
+          select: jest.fn().mockReturnValue({ eq: jest.fn().mockReturnValue({ single: jest.fn().mockResolvedValue({ data: input.existingCasa, error: null }) }) }),
+        }
+      }
+      throw new Error(`Unexpected admin table ${table}`)
+    }),
+  }
+}

--- a/lib/actions/casas-anfitrionas.actions.ts
+++ b/lib/actions/casas-anfitrionas.actions.ts
@@ -140,6 +140,77 @@ async function validarAuthYPermisos(requiereGestion = false): Promise<{
   return { supabase, userId: usuario.id, authId: user.id };
 }
 
+async function verificarPermisoCasa(
+  supabase: Awaited<ReturnType<typeof createSupabaseServerClient>>,
+  rpcName:
+    | "puede_aprobar_casa_anfitriona"
+    | "puede_cambiar_estado_casa_anfitriona"
+    | "puede_editar_casa_anfitriona"
+    | "puede_ver_casa_anfitriona",
+  authId: string,
+  casaId: string,
+  error: string
+): Promise<string | null> {
+  const { data: puede, error: rpcError } = await supabase.rpc(rpcName, {
+    p_auth_id: authId,
+    p_casa_id: casaId,
+  });
+
+  if (rpcError) return rpcError.message;
+  return puede ? null : error;
+}
+
+async function verificarUsuarioEnScope(
+  supabase: Awaited<ReturnType<typeof createSupabaseServerClient>>,
+  authId: string,
+  usuarioId: string,
+  error: string
+): Promise<string | null> {
+  const { data: puede, error: rpcError } = await supabase.rpc(
+    "puede_crear_casa_anfitriona_para",
+    {
+      p_auth_id: authId,
+      p_usuario_id: usuarioId,
+    }
+  );
+
+  if (rpcError) return rpcError.message;
+  return puede ? null : error;
+}
+
+async function validarUsuarioConsultable(usuarioId: string): Promise<string | null> {
+  const { supabase, authId, error } = await validarAuthYPermisos();
+  if (error) return error;
+
+  return verificarUsuarioEnScope(
+    supabase,
+    authId,
+    usuarioId,
+    "No tienes permisos para consultar este usuario"
+  );
+}
+
+function tieneEdicionSensible(datos: z.infer<typeof actualizarCasaSchema>): boolean {
+  return [
+    "capacidad_maxima",
+    "calle",
+    "barrio",
+    "codigo_postal",
+    "co_anfitrion_id",
+    "disponibilidad",
+    "lat",
+    "lng",
+    "parroquia_id",
+    "referencia",
+    "usuario_id",
+  ].some((campo) => campo in datos);
+}
+
+function revalidarCasa(casaId: string): void {
+  revalidatePath("/grupos-vida/casas-anfitrionas");
+  revalidatePath(`/grupos-vida/casas-anfitrionas/${casaId}`);
+}
+
 // ─── Actions ─────────────────────────────────────────────────────────
 
 /** Familiar del usuario con su relación */
@@ -160,6 +231,9 @@ export async function obtenerRelacionesFamiliares(
     usuarioId: string
 ): Promise<ResultadoAccion<FamiliarRelacion[]>> {
     try {
+        const scopeError = await validarUsuarioConsultable(usuarioId);
+        if (scopeError) return { success: false, error: scopeError };
+
         const adminDb = createSupabaseAdminClient();
 
         const { data, error } = await adminDb
@@ -232,11 +306,10 @@ export async function obtenerDireccionUsuario(
   usuarioId: string
 ): Promise<ResultadoAccion<DireccionUsuario>> {
   try {
-    const supabase = await createSupabaseServerClient();
-    const { data: { user } } = await supabase.auth.getUser();
-    if (!user) return { success: false, error: "No autenticado" };
+    const scopeError = await validarUsuarioConsultable(usuarioId);
+    if (scopeError) return { success: false, error: scopeError };
 
-    // Usar admin para bypasear RLS (el rol ya fue validado al cargar la página)
+    // Usar admin después de validar scope con RPC para obtener joins enriquecidos.
     const admin = createSupabaseAdminClient();
     const { data: usuario } = await admin
       .from("usuarios")
@@ -300,24 +373,29 @@ export async function crearCasaAnfitriona(
     const { supabase, userId, authId, error } = await validarAuthYPermisos();
     if (error) return { success: false, error };
 
-    // Determinar el propietario: si se pasa usuario_id y el creador tiene rol de gestión, usar ese
-    let propietarioId = userId;
-    let puedeGestionar = false;
-    if (parsed.usuario_id && parsed.usuario_id !== userId) {
-      const { data: puede } = await supabase.rpc("puede_gestionar_casas", {
-        p_auth_id: authId,
-      });
-      if (puede) {
-        propietarioId = parsed.usuario_id;
-        puedeGestionar = true;
-      }
+    const propietarioId = parsed.usuario_id ?? userId;
+    const ownerScopeError = await verificarUsuarioEnScope(
+      supabase,
+      authId,
+      propietarioId,
+      "No tienes permisos para crear una casa para este usuario"
+    );
+    if (ownerScopeError) return { success: false, error: ownerScopeError };
+
+    if (parsed.co_anfitrion_id) {
+      const coHostScopeError = await verificarUsuarioEnScope(
+        supabase,
+        authId,
+        parsed.co_anfitrion_id,
+        "No tienes permisos para asignar este co-anfitrión"
+      );
+      if (coHostScopeError) return { success: false, error: coHostScopeError };
     }
 
-    // Usar admin client si se asigna a otro usuario (RLS solo permite insertar para sí mismo)
-    const dbInsert = puedeGestionar ? createSupabaseAdminClient() : supabase;
+    const adminDb = createSupabaseAdminClient();
 
     // 1. Crear dirección con lat/lng
-    const { data: direccion, error: dirError } = await dbInsert
+    const { data: direccion, error: dirError } = await adminDb
       .from("direcciones")
       .insert({
         calle: parsed.calle,
@@ -339,7 +417,7 @@ export async function crearCasaAnfitriona(
       disponible: true,
     }));
 
-    const { data: casa, error: casaError } = await dbInsert
+    const { data: casa, error: casaError } = await adminDb
       .from("casas_anfitrionas")
       .insert({
         usuario_id: propietarioId,
@@ -379,25 +457,47 @@ export async function actualizarCasaAnfitriona(
 ): Promise<ResultadoAccion<void>> {
   try {
     const parsed = actualizarCasaSchema.parse(datos);
-    const { supabase, userId, authId, error } = await validarAuthYPermisos();
+    const { supabase, authId, error } = await validarAuthYPermisos();
     if (error) return { success: false, error };
 
-    // Verificar propiedad o permisos
-    const { data: casa } = await supabase
+    const permissionError = await verificarPermisoCasa(
+      supabase,
+      "puede_editar_casa_anfitriona",
+      authId,
+      casaId,
+      "No tienes permisos para editar esta casa"
+    );
+    if (permissionError) return { success: false, error: permissionError };
+
+    if (parsed.usuario_id) {
+      const ownerScopeError = await verificarUsuarioEnScope(
+        supabase,
+        authId,
+        parsed.usuario_id,
+        "No tienes permisos para asignar este propietario"
+      );
+      if (ownerScopeError) return { success: false, error: ownerScopeError };
+    }
+
+    if (parsed.co_anfitrion_id) {
+      const coHostScopeError = await verificarUsuarioEnScope(
+        supabase,
+        authId,
+        parsed.co_anfitrion_id,
+        "No tienes permisos para asignar este co-anfitrión"
+      );
+      if (coHostScopeError) return { success: false, error: coHostScopeError };
+    }
+
+    const adminDb = createSupabaseAdminClient();
+
+    const { data: casa } = await adminDb
       .from("casas_anfitrionas")
-      .select("usuario_id, direccion_id")
+      .select("usuario_id, direccion_id, aprobada")
       .eq("id", casaId)
       .single();
 
     if (!casa) return { success: false, error: "Casa no encontrada" };
-
-    const esDueno = casa.usuario_id === userId;
-    if (!esDueno) {
-      const { data: puede } = await supabase.rpc("puede_gestionar_casas", {
-        p_auth_id: authId,
-      });
-      if (!puede) return { success: false, error: "No tienes permisos" };
-    }
 
     // Actualizar dirección si hay cambios
     if (casa.direccion_id && (parsed.calle || parsed.barrio || parsed.codigo_postal || parsed.referencia || parsed.parroquia_id || parsed.lat !== undefined || parsed.lng !== undefined)) {
@@ -411,7 +511,7 @@ export async function actualizarCasaAnfitriona(
       if (parsed.lng !== undefined) dirUpdate.longitud = parsed.lng;
 
       if (Object.keys(dirUpdate).length > 0) {
-        await supabase.from("direcciones").update(dirUpdate).eq("id", casa.direccion_id);
+        await adminDb.from("direcciones").update(dirUpdate).eq("id", casa.direccion_id);
       }
     }
 
@@ -422,6 +522,7 @@ export async function actualizarCasaAnfitriona(
     if (parsed.capacidad_maxima !== undefined) casaUpdate.capacidad_maxima = parsed.capacidad_maxima || null;
     if (parsed.notas_publicas !== undefined) casaUpdate.notas_publicas = parsed.notas_publicas || null;
     if (parsed.co_anfitrion_id !== undefined) casaUpdate.co_anfitrion_id = parsed.co_anfitrion_id || null;
+    if (parsed.usuario_id !== undefined) casaUpdate.usuario_id = parsed.usuario_id;
     if (parsed.disponibilidad !== undefined) {
       casaUpdate.disponibilidad = parsed.disponibilidad.map((dia) => ({
         dia,
@@ -429,15 +530,20 @@ export async function actualizarCasaAnfitriona(
       }));
     }
 
-    const { error: updateError } = await supabase
+    if (casa.aprobada && tieneEdicionSensible(parsed)) {
+      casaUpdate.aprobada = false;
+      casaUpdate.aprobada_en = null;
+      casaUpdate.aprobada_por = null;
+    }
+
+    const { error: updateError } = await adminDb
       .from("casas_anfitrionas")
       .update(casaUpdate)
       .eq("id", casaId);
 
     if (updateError) return { success: false, error: `Error al actualizar: ${updateError.message}` };
 
-    revalidatePath("/grupos-vida/casas-anfitrionas");
-    revalidatePath(`/grupos-vida/casas-anfitrionas/${casaId}`);
+    revalidarCasa(casaId);
     return { success: true };
   } catch (err) {
     if (err instanceof z.ZodError) {
@@ -459,8 +565,17 @@ export async function procesarAprobacionCasa(
   accion: "aprobar" | "rechazar",
   notas?: string | null
 ): Promise<ResultadoAccion<AprobacionCasaResultado>> {
-  const { supabase, authId, error } = await validarAuthYPermisos(true);
+  const { supabase, authId, error } = await validarAuthYPermisos();
   if (error) return { success: false, error };
+
+  const permissionError = await verificarPermisoCasa(
+    supabase,
+    "puede_aprobar_casa_anfitriona",
+    authId,
+    casaId,
+    "No tienes permisos para aprobar o rechazar esta casa"
+  );
+  if (permissionError) return { success: false, error: permissionError };
 
   const { data, error: rpcError } = await supabase.rpc(
     "procesar_aprobacion_casa_anfitriona",
@@ -474,8 +589,7 @@ export async function procesarAprobacionCasa(
 
   if (rpcError) return { success: false, error: rpcError.message };
 
-  revalidatePath("/grupos-vida/casas-anfitrionas");
-  revalidatePath(`/grupos-vida/casas-anfitrionas/${casaId}`);
+  revalidarCasa(casaId);
 
   // Validar estructura del resultado JSON de la RPC con Zod
   const aprobacionSchema = z.object({
@@ -498,8 +612,16 @@ export async function listarCasasAnfitrionas(filtros?: {
   limite?: number;
   offset?: number;
 }): Promise<ResultadoAccion<CasaAnfitrionaListItem[]>> {
-  const { supabase, error } = await validarAuthYPermisos();
+  const { supabase, authId, error } = await validarAuthYPermisos();
   if (error) return { success: false, error };
+
+  const { data: visibleIds, error: visibleError } = await supabase.rpc(
+    "obtener_casas_visibles_ids",
+    { p_auth_id: authId }
+  );
+
+  if (visibleError) return { success: false, error: visibleError.message };
+  if (!visibleIds || visibleIds.length === 0) return { success: true, data: [] };
 
   let query = supabase
     .from("casas_anfitrionas")
@@ -513,6 +635,7 @@ export async function listarCasasAnfitrionas(filtros?: {
     )
     .order("creado_en", { ascending: false });
 
+  query = query.in("id", visibleIds);
   if (filtros?.soloAprobadas) query = query.eq("aprobada", true);
   if (filtros?.soloActivas) query = query.eq("activa", true);
   if (filtros?.limite) query = query.limit(filtros.limite);
@@ -522,6 +645,41 @@ export async function listarCasasAnfitrionas(filtros?: {
 
   if (queryError) return { success: false, error: queryError.message };
   return { success: true, data };
+}
+
+export async function cambiarEstadoCasaAnfitriona(
+  casaId: string,
+  activa: boolean
+): Promise<ResultadoAccion<void>> {
+  try {
+    const { supabase, authId, error } = await validarAuthYPermisos();
+    if (error) return { success: false, error };
+
+    const permissionError = await verificarPermisoCasa(
+      supabase,
+      "puede_cambiar_estado_casa_anfitriona",
+      authId,
+      casaId,
+      "No tienes permisos para cambiar el estado de esta casa"
+    );
+    if (permissionError) return { success: false, error: permissionError };
+
+    const adminDb = createSupabaseAdminClient();
+    const { error: updateError } = await adminDb
+      .from("casas_anfitrionas")
+      .update({ activa, actualizado_en: new Date().toISOString() })
+      .eq("id", casaId);
+
+    if (updateError) return { success: false, error: `Error al cambiar estado: ${updateError.message}` };
+
+    revalidarCasa(casaId);
+    return { success: true };
+  } catch (err) {
+    return {
+      success: false,
+      error: err instanceof Error ? err.message : "Error desconocido",
+    };
+  }
 }
 
 /**

--- a/openspec/changes/casas-anfitrionas-permissions/tasks.md
+++ b/openspec/changes/casas-anfitrionas-permissions/tasks.md
@@ -29,7 +29,7 @@ Strict TDD: write/adjust the failing Jest or SQL-static test before each product
 ## Phase 1: RED Permission Contract Tests
 
 - [x] 1.1 Create `__tests__/supabase/casas-anfitrionas-permissions-migration.test.ts` asserting additive SQL, RPC names/grants, `SECURITY DEFINER SET search_path`, and no destructive repair SQL.
-- [ ] 1.2 Create `__tests__/lib/actions/casas-anfitrionas.actions.test.ts` for deny-before-write, granular RPC calls, owner/co-host scope checks, revalidation, and approved sensitive edits.
+- [x] 1.2 Create `__tests__/lib/actions/casas-anfitrionas.actions.test.ts` for deny-before-write, granular RPC calls, owner/co-host scope checks, revalidation, and approved sensitive edits.
 
 ## Phase 2: Supabase Foundation
 
@@ -38,9 +38,9 @@ Strict TDD: write/adjust the failing Jest or SQL-static test before each product
 
 ## Phase 3: Server Enforcement
 
-- [ ] 3.1 Update `lib/actions/casas-anfitrionas.actions.ts` to replace coarse role checks with action-specific RPC permission helpers.
-- [ ] 3.2 In the same file, validate submitted owner, co-host, group, and house ids before any `adminDb` read/write.
-- [ ] 3.3 In the same file, conservatively reject or return approved sensitive edits to pending/review per spec before saving.
+- [x] 3.1 Update `lib/actions/casas-anfitrionas.actions.ts` to replace coarse role checks with action-specific RPC permission helpers.
+- [x] 3.2 In the same file, validate submitted owner, co-host, group, and house ids before any `adminDb` read/write.
+- [x] 3.3 In the same file, conservatively reject or return approved sensitive edits to pending/review per spec before saving.
 
 ## Phase 4: App Router UI Wiring
 


### PR DESCRIPTION
# Título del PR
feat(casas): exigir permisos granulares en acciones

Refs #179

## Chain Context
Estrategia: `feature-branch-chain`
Tracker: #180
Depende de: #182
Límite de revisión: 400 líneas
Excepción aprobada: `size:exception` porque la implementación de server actions y sus tests de seguridad forman una unidad atómica; separarlos dañaría la revisión.

```text
main
└── PR tracker: feat/casas-permissions-tracker (#180)
    └── PR 1: RPCs aditivas + staging/types (#181, merged)
    └── PR 2a: hardening RPC legacy (#182)
        └── 📍 PR 2b: feat/casas-permissions-pr2-actions — server actions enforcement
    └── PR 3: UI/verification
```

## Resumen
Conecta las server actions de Casas Anfitrionas con permisos granulares RPC-backed antes de lecturas y mutaciones sensibles.

## Qué Incluye
- Validación RPC-backed antes de lecturas `adminDb` de dirección y relaciones familiares.
- Enforcement granular para listado, creación para otro usuario, aprobación/rechazo, edición y cambio de estado.
- Reset a pendiente ante edición sensible de una casa aprobada.
- Tests server-action deny-before-read/write y casos permitidos.

## Motivación / Por Qué
La autorización no puede depender de la UI ni de checks gruesos. Las server actions deben validar permisos antes de leer o mutar datos sensibles.

## Evidencia Visual (si aplica)
No aplica.

## Migraciones / Base de Datos
- [x] No aplica
- [ ] Sí (orden exacto):
```
N/A
```
Notas: consume los RPCs existentes de PR #181 y el hardening de #182.

## Impacto y Riesgos
- Cambia comportamiento backend para negar acciones fuera de permiso granular.
- Requiere #182 como base.
- No incluye wiring UI/App Router; eso queda para PR 3.

## Checklist Autor
- [x] Código formateado (Prettier/ESLint)
- [x] Sin `console.log` / debugger
- [x] Validaciones con zod para entradas nuevas
- [x] Estados loading/error/empty cubiertos
- [x] Tipos TypeScript correctos
- [x] Migraciones probadas local
- [x] Documentación actualizada (`docs/` o README)
- [x] Variables de entorno documentadas
- [x] Rebase con `main` limpio

## Checklist Revisor
- [x] Propósito claro
- [x] Nombres descriptivos
- [x] Sin lógica duplicada evidente
- [x] Manejo adecuado de errores
- [x] Cambios acotados al alcance
- [x] Sin secretos / datos sensibles

## Pruebas Manuales Realizadas
- [x] `pnpm test -- __tests__/lib/actions/casas-anfitrionas.actions.test.ts`
- [x] `pnpm test -- __tests__/supabase/casas-anfitrionas-permissions-migration.test.ts`
- [x] `pnpm exec eslint __tests__/lib/actions/casas-anfitrionas.actions.test.ts lib/actions/casas-anfitrionas.actions.ts`
- [x] `pnpm exec tsc --noEmit --pretty false`
- [x] `pnpm test:no-only`
- [x] Fresh security review: pass
- [x] Fresh reliability review: pass

## Pendientes / Follow-up (opcional)
- PR 3: UI/App Router wiring y verificación completa.

## Notas Adicionales
Diff ligeramente superior a 400 líneas por tests + enforcement inseparables; `size:exception` aprobado por el maintainer.