### PR TITLE
feat(casas): conectar permisos en paginas anfitrionas

### DIFF
--- a/__tests__/app/casas-anfitrionas-pages.test.tsx
+++ b/__tests__/app/casas-anfitrionas-pages.test.tsx
@@ -1,0 +1,221 @@
+import React from 'react'
+import { render, screen } from '@testing-library/react'
+
+const createSupabaseServerClient = jest.fn()
+const createSupabaseAdminClient = jest.fn()
+const redirect = jest.fn((path: string) => {
+  throw new Error(`redirect:${path}`)
+})
+const notFound = jest.fn(() => {
+  throw new Error('notFound')
+})
+
+jest.mock('@/lib/supabase/server', () => ({ createSupabaseServerClient: () => createSupabaseServerClient() }))
+jest.mock('@/lib/supabase/admin', () => ({ createSupabaseAdminClient: () => createSupabaseAdminClient() }))
+jest.mock('next/navigation', () => ({
+  notFound: () => notFound(),
+  redirect: (path: string) => redirect(path),
+  useRouter: () => ({ refresh: jest.fn() }),
+}))
+jest.mock('next/link', () => ({
+  __esModule: true,
+  default: ({ href, children }: { href: string; children: React.ReactNode }) => <a href={href}>{children}</a>,
+}))
+jest.mock('@/components/layout/dashboard-layout', () => ({
+  DashboardLayout: ({ children }: { children: React.ReactNode }) => <main>{children}</main>,
+}))
+jest.mock('@/components/ui/BotonFlotante', () => ({
+  BotonFlotante: ({ href, label }: { href: string; label: string }) => <a href={href}>{label}</a>,
+}))
+jest.mock('@/components/ui/sistema-diseno', () => ({
+  BadgeSistema: ({ children }: { children: React.ReactNode }) => <span>{children}</span>,
+  BotonSistema: ({ children }: { children: React.ReactNode }) => <button>{children}</button>,
+  ContenedorDashboard: ({ accionPrincipal, children, titulo }: { accionPrincipal?: React.ReactNode; children: React.ReactNode; titulo: string }) => (
+    <section>
+      <h1>{titulo}</h1>
+      {accionPrincipal}
+      {children}
+    </section>
+  ),
+  SeparadorSistema: () => <hr />,
+  TarjetaSistema: ({ children }: { children: React.ReactNode }) => <article>{children}</article>,
+  TextareaSistema: ({ label }: { label: string }) => <label>{label}<textarea /></label>,
+  TextoSistema: ({ children }: { children: React.ReactNode }) => <span>{children}</span>,
+  TituloSistema: ({ children }: { children: React.ReactNode }) => <h2>{children}</h2>,
+}))
+jest.mock('@/hooks/use-notificaciones', () => ({ useNotificaciones: () => ({ success: jest.fn(), error: jest.fn() }) }))
+jest.mock('@/lib/actions/casas-anfitrionas.actions', () => ({ procesarAprobacionCasa: jest.fn() }))
+
+const authId = '11111111-1111-1111-1111-111111111111'
+const casaId = '22222222-2222-2222-2222-222222222222'
+
+describe('casas anfitrionas App Router permission wiring', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    createSupabaseServerClient.mockResolvedValue(createServerClient())
+    createSupabaseAdminClient.mockReturnValue(createAdminClient())
+  })
+
+  it('shows list page primary action and FAB only when backend create flags allow them', async () => {
+    createSupabaseServerClient.mockResolvedValue(createServerClient({ canCreateOwn: true }))
+    const { default: CasasAnfitrionasPage } = await import('@/app/(auth)/grupos-vida/casas-anfitrionas/page')
+
+    render(await CasasAnfitrionasPage())
+
+    expect(screen.getByRole('link', { name: 'Registrar casa' })).toHaveAttribute('href', '/grupos-vida/casas-anfitrionas/nueva')
+    expect(screen.getByRole('link', { name: 'Registrar casa anfitriona' })).toHaveAttribute('href', '/grupos-vida/casas-anfitrionas/nueva')
+  })
+
+  it('hides list page primary action and FAB when backend create flags deny them', async () => {
+    createSupabaseServerClient.mockResolvedValue(createServerClient({ canCreateOwn: false, canCreateForOthers: false }))
+    const { default: CasasAnfitrionasPage } = await import('@/app/(auth)/grupos-vida/casas-anfitrionas/page')
+
+    render(await CasasAnfitrionasPage())
+
+    expect(screen.queryByRole('link', { name: 'Registrar casa' })).not.toBeInTheDocument()
+    expect(screen.queryByRole('link', { name: 'Registrar casa anfitriona' })).not.toBeInTheDocument()
+  })
+
+  it('queries enriched list rows only for backend-visible house ids', async () => {
+    const visibleCasaIds = [casaId]
+    const casasQuery = createCasasListQuery([])
+    createSupabaseServerClient.mockResolvedValue(createServerClient({ visibleCasaIds }))
+    createSupabaseAdminClient.mockReturnValue(createAdminClient({ casasListQuery: casasQuery }))
+    const { default: CasasAnfitrionasPage } = await import('@/app/(auth)/grupos-vida/casas-anfitrionas/page')
+
+    render(await CasasAnfitrionasPage())
+
+    expect(casasQuery.in).toHaveBeenCalledWith('id', visibleCasaIds)
+  })
+
+  it('denies detail access before creating the admin client when visibility RPC rejects the house', async () => {
+    createSupabaseServerClient.mockResolvedValue(createServerClient({ canViewDetail: false }))
+    const { default: DetalleCasaAnfitrionaPage } = await import('@/app/(auth)/grupos-vida/casas-anfitrionas/[id]/page')
+
+    await expect(DetalleCasaAnfitrionaPage({ params: Promise.resolve({ id: casaId }) })).rejects.toThrow('notFound')
+
+    const serverClient = await createSupabaseServerClient.mock.results[0].value
+    expect(serverClient.rpc).toHaveBeenCalledWith('puede_ver_casa_anfitriona', { p_auth_id: authId, p_casa_id: casaId })
+    expect(createSupabaseAdminClient).not.toHaveBeenCalled()
+  })
+
+  it('renders detail edit and approval controls from backend permission booleans', async () => {
+    createSupabaseServerClient.mockResolvedValue(createServerClient({ canApprove: true, canEdit: true }))
+    const { default: DetalleCasaAnfitrionaPage } = await import('@/app/(auth)/grupos-vida/casas-anfitrionas/[id]/page')
+
+    render(await DetalleCasaAnfitrionaPage({ params: Promise.resolve({ id: casaId }) }))
+
+    expect(screen.getByRole('link', { name: 'Editar' })).toHaveAttribute('href', `/grupos-vida/casas-anfitrionas/${casaId}/editar`)
+    expect(screen.getByRole('button', { name: 'Aprobar' })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Rechazar' })).toBeInTheDocument()
+  })
+
+  it('hides detail edit and approval controls when backend permission booleans deny them', async () => {
+    createSupabaseServerClient.mockResolvedValue(createServerClient({ canApprove: false, canEdit: false }))
+    const { default: DetalleCasaAnfitrionaPage } = await import('@/app/(auth)/grupos-vida/casas-anfitrionas/[id]/page')
+
+    render(await DetalleCasaAnfitrionaPage({ params: Promise.resolve({ id: casaId }) }))
+
+    expect(screen.queryByRole('link', { name: 'Editar' })).not.toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: 'Aprobar' })).not.toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: 'Rechazar' })).not.toBeInTheDocument()
+  })
+})
+
+function createServerClient(overrides: {
+  canApprove?: boolean
+  canCreateForOthers?: boolean
+  canCreateOwn?: boolean
+  canEdit?: boolean
+  canViewDetail?: boolean
+  visibleCasaIds?: string[]
+} = {}) {
+  return {
+    auth: { getUser: jest.fn().mockResolvedValue({ data: { user: { id: authId } }, error: null }) },
+    rpc: jest.fn((name: string, args: Record<string, unknown>) => {
+      if (name === 'obtener_casas_visibles_ids') return Promise.resolve({ data: overrides.visibleCasaIds ?? [], error: null })
+      if (name === 'puede_ver_casa_anfitriona') return Promise.resolve({ data: overrides.canViewDetail ?? true, error: null })
+      if (name === 'obtener_permisos_casa_anfitriona') {
+        return Promise.resolve({
+          data: {
+            puede_ver: true,
+            puede_crear_propia: overrides.canCreateOwn ?? false,
+            puede_crear_para_otros: overrides.canCreateForOthers ?? false,
+            puede_aprobar: overrides.canApprove ?? false,
+            puede_editar: overrides.canEdit ?? false,
+            puede_cambiar_estado: false,
+          },
+          error: null,
+        })
+      }
+      throw new Error(`Unexpected RPC ${name} with ${JSON.stringify(args)}`)
+    }),
+  }
+}
+
+function createAdminClient(overrides: { casasListQuery?: ReturnType<typeof createCasasListQuery> } = {}) {
+  return {
+    from: jest.fn((table: string) => {
+      if (table === 'casas_anfitrionas') return overrides.casasListQuery ?? createCasasDetailQuery()
+      if (table === 'grupos') return createGruposQuery()
+      if (table === 'relaciones_usuarios') return createRelacionesQuery()
+      if (table === 'usuarios') return createUsuariosQuery()
+      throw new Error(`Unexpected admin table ${table}`)
+    }),
+  }
+}
+
+function createCasasListQuery(rows: unknown[]) {
+  return {
+    in: jest.fn().mockReturnThis(),
+    order: jest.fn().mockResolvedValue({ data: rows, error: null }),
+    select: jest.fn().mockReturnThis(),
+  }
+}
+
+function createCasasDetailQuery() {
+  return {
+    select: jest.fn().mockReturnThis(),
+    eq: jest.fn().mockReturnThis(),
+    single: jest.fn().mockResolvedValue({
+      data: {
+        id: casaId,
+        activa: true,
+        aprobada: false,
+        capacidad_maxima: 10,
+        creado_en: '2026-06-17T00:00:00.000Z',
+        descripcion: null,
+        direcciones: null,
+        disponibilidad: [],
+        nombre_lugar: 'Casa de Ana',
+        notas_publicas: null,
+        usuarios: { id: authId, nombre: 'Ana', apellido: 'Pérez', email: null, telefono: null, foto_perfil_url: null },
+        co_anfitrion: null,
+      },
+      error: null,
+    }),
+  }
+}
+
+function createGruposQuery() {
+  return {
+    select: jest.fn().mockReturnThis(),
+    not: jest.fn().mockResolvedValue({ data: [], error: null }),
+    eq: jest.fn().mockReturnThis(),
+  }
+}
+
+function createRelacionesQuery() {
+  return {
+    select: jest.fn().mockReturnThis(),
+    eq: jest.fn().mockReturnThis(),
+    or: jest.fn().mockResolvedValue({ data: null, error: null }),
+  }
+}
+
+function createUsuariosQuery() {
+  return {
+    select: jest.fn().mockReturnThis(),
+    in: jest.fn().mockResolvedValue({ data: null, error: null }),
+  }
+}

--- a/__tests__/lib/casas-anfitrionas/ui-permissions.test.ts
+++ b/__tests__/lib/casas-anfitrionas/ui-permissions.test.ts
@@ -1,0 +1,145 @@
+import {
+  obtenerPermisosCasaAnfitrionaUI,
+  puedeMostrarRegistroCasa,
+  puedeVerCasaAnfitrionaUI,
+} from '@/lib/casas-anfitrionas/ui-permissions'
+
+const authId = '11111111-1111-1111-1111-111111111111'
+const casaId = '22222222-2222-2222-2222-222222222222'
+
+describe('casas anfitrionas UI permission helpers', () => {
+  it('uses backend permissions to decide whether create controls are visible on the list page', async () => {
+    const rpc = jest.fn().mockResolvedValue({
+      data: {
+        puede_ver: false,
+        puede_crear_propia: true,
+        puede_crear_para_otros: false,
+        puede_aprobar: false,
+        puede_editar: false,
+        puede_cambiar_estado: false,
+      },
+      error: null,
+    })
+
+    const permissions = await obtenerPermisosCasaAnfitrionaUI({ rpc }, authId)
+
+    expect(rpc).toHaveBeenCalledWith('obtener_permisos_casa_anfitriona', { p_auth_id: authId })
+    expect(puedeMostrarRegistroCasa(permissions)).toBe(true)
+  })
+
+  it('hides create controls when the backend denies both self and delegated creation', async () => {
+    const rpc = jest.fn().mockResolvedValue({
+      data: {
+        puede_ver: false,
+        puede_crear_propia: false,
+        puede_crear_para_otros: false,
+        puede_aprobar: false,
+        puede_editar: false,
+        puede_cambiar_estado: false,
+      },
+      error: null,
+    })
+
+    const permissions = await obtenerPermisosCasaAnfitrionaUI({ rpc }, authId)
+
+    expect(puedeMostrarRegistroCasa(permissions)).toBe(false)
+  })
+
+  it('checks detail visibility with the granular visibility RPC before enriched reads', async () => {
+    const rpc = jest.fn().mockResolvedValue({ data: true, error: null })
+
+    const allowed = await puedeVerCasaAnfitrionaUI({ rpc }, authId, casaId)
+
+    expect(rpc).toHaveBeenCalledWith('puede_ver_casa_anfitriona', { p_auth_id: authId, p_casa_id: casaId })
+    expect(allowed).toBe(true)
+  })
+
+  it('normalizes detail permission flags from the backend for edit, approval, and active-state controls', async () => {
+    const rpc = jest.fn().mockResolvedValue({
+      data: {
+        puede_ver: true,
+        puede_crear_propia: false,
+        puede_crear_para_otros: false,
+        puede_aprobar: true,
+        puede_editar: false,
+        puede_cambiar_estado: true,
+      },
+      error: null,
+    })
+
+    const permissions = await obtenerPermisosCasaAnfitrionaUI({ rpc }, authId, casaId)
+
+    expect(rpc).toHaveBeenCalledWith('obtener_permisos_casa_anfitriona', { p_auth_id: authId, p_casa_id: casaId })
+    expect(permissions).toMatchObject({
+      puedeVer: true,
+      puedeAprobar: true,
+      puedeEditar: false,
+      puedeCambiarEstado: true,
+    })
+  })
+
+  it('denies every permission flag when the permissions RPC returns an error', async () => {
+    const rpc = jest.fn().mockResolvedValue({ data: null, error: { message: 'permission lookup failed' } })
+
+    const permissions = await obtenerPermisosCasaAnfitrionaUI({ rpc }, authId, casaId)
+
+    expect(permissions).toEqual({
+      puedeVer: false,
+      puedeCrearPropia: false,
+      puedeCrearParaOtros: false,
+      puedeAprobar: false,
+      puedeEditar: false,
+      puedeCambiarEstado: false,
+    })
+  })
+
+  it.each([null, [], 'invalid', true])('denies every permission flag for malformed payload %#', async (payload) => {
+    const rpc = jest.fn().mockResolvedValue({ data: payload, error: null })
+
+    const permissions = await obtenerPermisosCasaAnfitrionaUI({ rpc }, authId, casaId)
+
+    expect(permissions).toEqual({
+      puedeVer: false,
+      puedeCrearPropia: false,
+      puedeCrearParaOtros: false,
+      puedeAprobar: false,
+      puedeEditar: false,
+      puedeCambiarEstado: false,
+    })
+  })
+
+  it('treats non-boolean truthy permission values as denied by default', async () => {
+    const rpc = jest.fn().mockResolvedValue({
+      data: {
+        puede_ver: 'true',
+        puede_crear_propia: 1,
+        puede_crear_para_otros: 'yes',
+        puede_aprobar: {},
+        puede_editar: ['true'],
+        puede_cambiar_estado: new Boolean(true),
+      },
+      error: null,
+    })
+
+    const permissions = await obtenerPermisosCasaAnfitrionaUI({ rpc }, authId, casaId)
+
+    expect(permissions).toEqual({
+      puedeVer: false,
+      puedeCrearPropia: false,
+      puedeCrearParaOtros: false,
+      puedeAprobar: false,
+      puedeEditar: false,
+      puedeCambiarEstado: false,
+    })
+  })
+
+  it('denies detail visibility when the visibility RPC errors or returns a non-boolean truthy value', async () => {
+    const rpc = jest
+      .fn()
+      .mockResolvedValueOnce({ data: true, error: { message: 'visibility lookup failed' } })
+      .mockResolvedValueOnce({ data: 'true', error: null })
+
+    await expect(puedeVerCasaAnfitrionaUI({ rpc }, authId, casaId)).resolves.toBe(false)
+    await expect(puedeVerCasaAnfitrionaUI({ rpc }, authId, casaId)).resolves.toBe(false)
+  })
+})

--- a/app/(auth)/grupos-vida/casas-anfitrionas/[id]/page.tsx
+++ b/app/(auth)/grupos-vida/casas-anfitrionas/[id]/page.tsx
@@ -15,10 +15,11 @@ import {
     SeparadorSistema,
 } from "@/components/ui/sistema-diseno";
 import {
-    Home, MapPin, Users, Calendar, CheckCircle, XCircle,
+    Home, MapPin, Users, Calendar, CheckCircle,
     Pencil, Phone, Mail, FileText, Clock, Info
 } from "lucide-react";
 import { AprobacionCasaClient } from "./aprobacion-client";
+import { obtenerPermisosCasaAnfitrionaUI, puedeVerCasaAnfitrionaUI } from "@/lib/casas-anfitrionas/ui-permissions";
 
 interface PageProps {
     params: Promise<{ id: string }>;
@@ -27,11 +28,14 @@ interface PageProps {
 export default async function DetalleCasaAnfitrionaPage({ params }: PageProps) {
     const { id } = await params;
     const supabase = await createSupabaseServerClient();
-    const adminDb = createSupabaseAdminClient();
     const { data: { user } } = await supabase.auth.getUser();
     if (!user) redirect("/login");
 
-    // Usar admin para leer los datos completos sin restricciones RLS en joins
+    const puedeVer = await puedeVerCasaAnfitrionaUI(supabase, user.id, id);
+    if (!puedeVer) notFound();
+
+    // Usar admin solo después de validar visibilidad por RPC.
+    const adminDb = createSupabaseAdminClient();
     const { data: casa } = await adminDb
         .from("casas_anfitrionas")
         .select(`
@@ -54,27 +58,7 @@ export default async function DetalleCasaAnfitrionaPage({ params }: PageProps) {
 
     if (!casa) notFound();
 
-    // Verificar permisos de gestión (admin/pastor/director)
-    const { data: puedeGestionar } = await supabase.rpc("puede_gestionar_casas", {
-        p_auth_id: user.id,
-    });
-
-    // Obtener roles del usuario para determinar si puede aprobar
-    const { data: rolesUsuario } = await supabase.rpc("obtener_roles_usuario", {
-        p_auth_id: user.id,
-    });
-    // obtener_roles_usuario retorna text[] directamente
-    const roles: string[] = Array.isArray(rolesUsuario) ? rolesUsuario : [];
-    const puedeAprobar = roles.some((r) => ["admin", "pastor", "director-general"].includes(r));
-
-    // Verificar si es dueño de la casa
-    const { data: currentUser } = await supabase
-        .from("usuarios")
-        .select("id")
-        .eq("auth_id", user.id)
-        .single();
-    const esDueno = currentUser?.id === casa.usuario_id;
-    const puedeEditar = esDueno || puedeGestionar;
+    const permisosCasa = await obtenerPermisosCasaAnfitrionaUI(supabase, user.id, id);
 
     // Contar grupos usando esta casa
     const { count: gruposUsando } = await adminDb
@@ -121,7 +105,7 @@ export default async function DetalleCasaAnfitrionaPage({ params }: PageProps) {
             <ContenedorDashboard
                 titulo={casa.nombre_lugar}
                 botonRegreso={{ href: "/grupos-vida/casas-anfitrionas", texto: "Casas Anfitrionas" }}
-                accionPrincipal={puedeEditar ? (
+                accionPrincipal={permisosCasa.puedeEditar ? (
                     <Link href={`/grupos-vida/casas-anfitrionas/${id}/editar`}>
                         <BotonSistema variante="outline" icono={Pencil} tamaño="sm">
                             Editar
@@ -351,8 +335,8 @@ export default async function DetalleCasaAnfitrionaPage({ params }: PageProps) {
                             </div>
                         </TarjetaSistema>
 
-                        {/* Aprobación — solo admin/pastor/director (NO líderes) */}
-                        {puedeAprobar && !casa.aprobada && (
+                        {/* Aprobación — definida por el predicado backend granular. */}
+                        {permisosCasa.puedeAprobar && !casa.aprobada && (
                             <AprobacionCasaClient casaId={casa.id} />
                         )}
                     </div>

--- a/app/(auth)/grupos-vida/casas-anfitrionas/page.tsx
+++ b/app/(auth)/grupos-vida/casas-anfitrionas/page.tsx
@@ -7,6 +7,7 @@ import { ContenedorDashboard, TarjetaSistema, TextoSistema, BotonSistema, BadgeS
 import { Plus, Home } from "lucide-react";
 import Link from "next/link";
 import { BotonFlotante } from "@/components/ui/BotonFlotante";
+import { obtenerPermisosCasaAnfitrionaUI, puedeMostrarRegistroCasa } from "@/lib/casas-anfitrionas/ui-permissions";
 
 /**
  * Página de listado de casas anfitrionas.
@@ -18,15 +19,17 @@ export default async function CasasAnfitrionasPage() {
     const { data: { user } } = await supabase.auth.getUser();
     if (!user) redirect("/login");
 
-    // Usar admin client para que el join a usuarios funcione sin importar el rol del usuario
-    const adminDb = createSupabaseAdminClient();
-
-    // Obtener IDs de casas visibles según el rol del usuario
-    const { data: casasVisiblesIds } = await supabase.rpc("obtener_casas_visibles_ids", {
-        p_auth_id: user.id,
-    });
+    // Obtener permisos y IDs visibles desde los predicados backend.
+    const [permisosCasa, { data: casasVisiblesIds }] = await Promise.all([
+        obtenerPermisosCasaAnfitrionaUI(supabase, user.id),
+        supabase.rpc("obtener_casas_visibles_ids", { p_auth_id: user.id }),
+    ]);
 
     const idsVisibles: string[] = casasVisiblesIds ?? [];
+    const puedeRegistrarCasa = puedeMostrarRegistroCasa(permisosCasa);
+
+    // Usar admin client para que el join a usuarios funcione sin importar el rol del usuario
+    const adminDb = createSupabaseAdminClient();
 
     // Obtener casas filtradas por visibilidad con datos del anfitrión, dirección y foto
     const { data: casas } = idsVisibles.length > 0
@@ -108,11 +111,6 @@ export default async function CasasAnfitrionasPage() {
         }
     }
 
-    // Verificar si el usuario puede gestionar casas
-    const { data: puedeGestionar } = await supabase.rpc("puede_gestionar_casas", {
-        p_auth_id: user.id,
-    });
-
     const totalCasas = casas?.length ?? 0;
     const aprobadas = casas?.filter((c) => c.aprobada && c.activa).length ?? 0;
     const pendientes = casas?.filter((c) => !c.aprobada).length ?? 0;
@@ -123,13 +121,13 @@ export default async function CasasAnfitrionasPage() {
             <ContenedorDashboard
                 titulo="Casas Anfitrionas"
                 botonRegreso={{ href: "/grupos-vida", texto: "Grupos de Vida" }}
-                accionPrincipal={
+                accionPrincipal={puedeRegistrarCasa ? (
                     <Link href="/grupos-vida/casas-anfitrionas/nueva">
                         <BotonSistema variante="primario" icono={Plus} tamaño="sm">
                             Registrar casa
                         </BotonSistema>
                     </Link>
-                }
+                ) : undefined}
             >
                 {/* Stats rápidos — sin colores hardcoded (G-08) */}
                 <div className="grid grid-cols-2 gap-3 sm:grid-cols-4">
@@ -314,7 +312,7 @@ export default async function CasasAnfitrionasPage() {
                     <TarjetaSistema variante="outlined" className="py-12 text-center">
                         <Home className="mx-auto mb-3 h-12 w-12 text-muted-foreground" />
                         <TextoSistema variante="muted">
-                            {puedeGestionar
+                            {puedeRegistrarCasa
                                 ? "No hay casas anfitrionas registradas aún."
                                 : "No hay casas anfitrionas disponibles."}
                         </TextoSistema>
@@ -323,7 +321,7 @@ export default async function CasasAnfitrionasPage() {
             </ContenedorDashboard>
 
             {/* FAB móvil para registrar casa */}
-            {puedeGestionar && (
+            {puedeRegistrarCasa && (
                 <BotonFlotante
                     href="/grupos-vida/casas-anfitrionas/nueva"
                     label="Registrar casa anfitriona"

--- a/lib/casas-anfitrionas/ui-permissions.ts
+++ b/lib/casas-anfitrionas/ui-permissions.ts
@@ -1,0 +1,76 @@
+type RpcError = { message: string }
+
+type CasasRpcName = 'obtener_permisos_casa_anfitriona' | 'puede_ver_casa_anfitriona'
+
+type CasasRpcArgs = { p_auth_id: string; p_casa_id?: string }
+
+export interface CasasRpcClient {
+  rpc: (name: CasasRpcName, args: CasasRpcArgs) => PromiseLike<{ data: unknown; error: RpcError | null }>
+}
+
+export interface CasaPermissionFlags {
+  puedeVer: boolean
+  puedeCrearPropia: boolean
+  puedeCrearParaOtros: boolean
+  puedeAprobar: boolean
+  puedeEditar: boolean
+  puedeCambiarEstado: boolean
+}
+
+const DENIED_CASA_PERMISSIONS: CasaPermissionFlags = {
+  puedeVer: false,
+  puedeCrearPropia: false,
+  puedeCrearParaOtros: false,
+  puedeAprobar: false,
+  puedeEditar: false,
+  puedeCambiarEstado: false,
+}
+
+export async function obtenerPermisosCasaAnfitrionaUI(
+  client: CasasRpcClient,
+  authId: string,
+  casaId?: string
+): Promise<CasaPermissionFlags> {
+  const args: CasasRpcArgs = { p_auth_id: authId }
+  if (casaId) args.p_casa_id = casaId
+
+  const { data, error } = await client.rpc('obtener_permisos_casa_anfitriona', args)
+
+  if (error) return DENIED_CASA_PERMISSIONS
+  return normalizeCasaPermissionFlags(data)
+}
+
+export async function puedeVerCasaAnfitrionaUI(
+  client: CasasRpcClient,
+  authId: string,
+  casaId: string
+): Promise<boolean> {
+  const { data, error } = await client.rpc('puede_ver_casa_anfitriona', {
+    p_auth_id: authId,
+    p_casa_id: casaId,
+  })
+
+  if (error) return false
+  return data === true
+}
+
+export function puedeMostrarRegistroCasa(permissions: CasaPermissionFlags): boolean {
+  return permissions.puedeCrearPropia || permissions.puedeCrearParaOtros
+}
+
+function normalizeCasaPermissionFlags(raw: unknown): CasaPermissionFlags {
+  if (!isPermissionPayload(raw)) return DENIED_CASA_PERMISSIONS
+
+  return {
+    puedeVer: raw.puede_ver === true,
+    puedeCrearPropia: raw.puede_crear_propia === true,
+    puedeCrearParaOtros: raw.puede_crear_para_otros === true,
+    puedeAprobar: raw.puede_aprobar === true,
+    puedeEditar: raw.puede_editar === true,
+    puedeCambiarEstado: raw.puede_cambiar_estado === true,
+  }
+}
+
+function isPermissionPayload(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value)
+}

--- a/openspec/changes/casas-anfitrionas-permissions/tasks.md
+++ b/openspec/changes/casas-anfitrionas-permissions/tasks.md
@@ -44,8 +44,8 @@ Strict TDD: write/adjust the failing Jest or SQL-static test before each product
 
 ## Phase 4: App Router UI Wiring
 
-- [ ] 4.1 Update `app/(auth)/grupos-vida/casas-anfitrionas/page.tsx` to use backend list visibility and create permissions.
-- [ ] 4.2 Update `app/(auth)/grupos-vida/casas-anfitrionas/[id]/page.tsx` to call visibility RPC before enriched `adminDb` detail reads.
+- [x] 4.1 Update `app/(auth)/grupos-vida/casas-anfitrionas/page.tsx` to use backend list visibility and create permissions.
+- [x] 4.2 Update `app/(auth)/grupos-vida/casas-anfitrionas/[id]/page.tsx` to call visibility RPC before enriched `adminDb` detail reads.
 - [ ] 4.3 Update `app/(auth)/grupos-vida/casas-anfitrionas/nueva/page.tsx` and `[id]/editar/page.tsx` to use backend-derived assignable users/permissions.
 - [ ] 4.4 Keep `components/grupos-vida/form-casa-anfitriona.tsx` presentational; remove local role inference and consume passed permissions/options only.
 


### PR DESCRIPTION
# Título del PR
feat(casas): conectar permisos en paginas anfitrionas

Refs #179

## Chain Context
Estrategia: `feature-branch-chain`
Tracker: #180
Límite de revisión: 400 líneas
Excepción aprobada: `size:exception` porque el wiring UI/App Router y sus tests de autorización son una unidad atómica.

```text
main
└── PR tracker: feat/casas-permissions-tracker (#180)
    └── PR 1: RPCs aditivas + staging/types (#181, merged)
    └── PR 2a: hardening RPC legacy (#182, merged)
    └── PR 2b: server actions enforcement (#183, merged)
    └── 📍 PR 3: feat/casas-permissions-pr3 — list/detail UI permission wiring
```

## Resumen
Conecta las páginas de listado y detalle de Casas Anfitrionas con permisos backend-derived para mostrar acciones autorizadas y negar detalle antes de lecturas enriquecidas.

## Qué Incluye
- Helper deny-by-default para permisos UI vía RPCs.
- Listado usa permisos backend para mostrar/ocultar CTA principal y FAB.
- Listado consulta filas enriquecidas solo para IDs visibles por backend.
- Detalle valida `puede_ver_casa_anfitriona` antes de cualquier read enriquecido con `adminDb`.
- Controles de editar/aprobar/rechazar reflejan booleans backend.
- Tests de helper y comportamiento App Router.

## Motivación / Por Qué
La UI no debe inferir permisos desde roles locales si el backend ya define el contrato granular. Este PR reduce divergencia UI/backend y bloquea lectura directa de detalles fuera de alcance.

## Evidencia Visual (si aplica)
No aplica.

## Migraciones / Base de Datos
- [x] No aplica
- [ ] Sí (orden exacto):
```
N/A
```
Notas: consume RPCs ya agregados en PRs previos.

## Impacto y Riesgos
- Cambia visibilidad de acciones UI según permisos backend.
- Detalle puede responder 404 si backend niega `puede_ver_casa_anfitriona`.
- No incluye create/edit form wiring; queda para siguiente PR.

## Checklist Autor
- [x] Código formateado (Prettier/ESLint)
- [x] Sin `console.log` / debugger
- [x] Validaciones con zod para entradas nuevas
- [x] Estados loading/error/empty cubiertos
- [x] Tipos TypeScript correctos
- [x] Migraciones probadas local
- [x] Documentación actualizada (`docs/` o README)
- [x] Variables de entorno documentadas
- [x] Rebase con `main` limpio

## Checklist Revisor
- [x] Propósito claro
- [x] Nombres descriptivos
- [x] Sin lógica duplicada evidente
- [x] Manejo adecuado de errores
- [x] Cambios acotados al alcance
- [x] Sin secretos / datos sensibles

## Pruebas Manuales Realizadas
- [x] `pnpm test -- __tests__/lib/casas-anfitrionas/ui-permissions.test.ts __tests__/app/casas-anfitrionas-pages.test.tsx`
- [x] `pnpm test -- __tests__/lib/actions/casas-anfitrionas.actions.test.ts`
- [x] `pnpm exec tsc --noEmit`
- [x] `pnpm test:no-only`
- [x] `pnpm lint:migrations`
- [x] `pnpm lint` — pasó con warnings existentes
- [x] Fresh security review: pass
- [x] Fresh reliability review: pass after route-level test hardening

## Pendientes / Follow-up (opcional)
- Tasks 4.3–4.4: new/edit pages backend-derived assignable users/permissions and presentational form cleanup.
- Task 5.1: final verification.

## Notas Adicionales
`size:exception` aprobado: separar tests de este wiring de autorización haría peor la revisión.