### PR TITLE
fix(casas): proteger rpc de visibilidad anfitrionas

### DIFF
--- a/__tests__/supabase/casas-anfitrionas-permissions-migration.test.ts
+++ b/__tests__/supabase/casas-anfitrionas-permissions-migration.test.ts
@@ -15,6 +15,7 @@ const rpcNames = [
 const expectedStagingMigrationFiles = [
   '20260617161620_casas_anfitrionas_granular_permissions.sql',
   '20260617161954_revoke_anon_from_casas_permission_rpcs.sql',
+  '20260617214453_harden_obtener_casas_visibles_ids_rpc.sql',
 ]
 const rpcSignatures = {
   obtener_permisos_casa_anfitriona: 'obtener_permisos_casa_anfitriona(uuid, uuid)',
@@ -53,6 +54,16 @@ function readCasasApprovalHardeningMigration(): string {
   )
 
   if (!file) throw new Error('Missing casas approval RPC hardening migration')
+
+  return readFileSync(join(migrationsDir, file), 'utf8')
+}
+
+function readObtenerCasasVisiblesHardeningMigration(): string {
+  const file = readdirSync(migrationsDir).find((name) =>
+    name.endsWith('_harden_obtener_casas_visibles_ids_rpc.sql'),
+  )
+
+  if (!file) throw new Error('Missing obtener_casas_visibles_ids RPC hardening migration')
 
   return readFileSync(join(migrationsDir, file), 'utf8')
 }
@@ -227,5 +238,34 @@ describe('casas anfitrionas granular permissions migration', () => {
     expect(compacted).toContain("'accion', 'aprobar'")
     expect(compacted).toContain("'estado', 'aprobada'")
     expect(sql).not.toMatch(/TODO|placeholder|manual/i)
+  })
+
+  it('hardens direct legacy visibility RPC execution against spoofed p_auth_id', () => {
+    const sql = readObtenerCasasVisiblesHardeningMigration()
+    const body = functionSql(sql, 'obtener_casas_visibles_ids')
+
+    expect(body).toContain("v_request_role text := nullif(current_setting('request.jwt.claim.role', true), '')")
+    expect(body).toContain("coalesce(v_request_role, '') <> 'service_role'")
+    expect(body).toContain('p_auth_id IS DISTINCT FROM auth.uid()')
+    expect(body.indexOf('p_auth_id IS DISTINCT FROM auth.uid()')).toBeLessThan(
+      body.indexOf('FROM public.usuarios'),
+    )
+    expect(sql).toContain('REVOKE ALL ON FUNCTION public.obtener_casas_visibles_ids(uuid) FROM PUBLIC;')
+    expect(sql).toContain('REVOKE ALL ON FUNCTION public.obtener_casas_visibles_ids(uuid) FROM anon;')
+    expect(sql).toContain('GRANT EXECUTE ON FUNCTION public.obtener_casas_visibles_ids(uuid) TO authenticated, service_role;')
+    expect(sql).not.toMatch(/\bDROP\b|\bTRUNCATE\b|\bDELETE\s+FROM\b|\bINSERT\s+INTO\b|\bUPDATE\s+public\./i)
+  })
+
+  it('documents executable legacy visibility RPC spoof denial and authorized behavior', () => {
+    const sql = readCasasRpcChecks()
+
+    expect(sql).toContain('-- 20260617214453_harden_obtener_casas_visibles_ids_rpc.sql.')
+    expect(sql).toContain('assert_uuid_array_contains(')
+    expect(sql).toContain('assert_uuid_array_rpc_exception(')
+    expect(sql).toContain('obtener_casas_visibles_ids allows matching director etapa auth')
+    expect(sql).toContain('obtener_casas_visibles_ids excludes out-of-scope house')
+    expect(sql).toContain('direct obtener_casas_visibles_ids requires non-null p_auth_id')
+    expect(sql).toContain("'auth_id_required'")
+    expect(sql).toContain('direct obtener_casas_visibles_ids denies spoofed p_auth_id')
   })
 })

--- a/openspec/changes/archive/2026-06-17-casas-anfitrionas-permissions/archive-report.md
+++ b/openspec/changes/archive/2026-06-17-casas-anfitrionas-permissions/archive-report.md
@@ -49,3 +49,9 @@
 ## Result
 
 The Casas Anfitrionas permissions change has been planned, implemented, verified, synced to main specs, and archived. Tracker PR #180 can now be prepared from `feat/casas-permissions-tracker` with the archive commit included.
+
+## Corrective Addendum — 2026-06-17 Tracker Readiness Blocker
+
+After archive PR #187 merged, fresh tracker readiness review found that legacy `public.obtener_casas_visibles_ids(uuid)` still trusted caller-supplied `p_auth_id` when called directly. The tracker hardening branch adds `supabase/migrations/20260617214453_harden_obtener_casas_visibles_ids_rpc.sql`, extends SQL-static and deterministic SQL-harness evidence for spoofed and `NULL` `p_auth_id` calls, and updates `verify-report.md` with the corrective TDD/check results.
+
+**Corrective status**: blocker fixed with warnings. Static and focused Jest checks pass; direct SQL harness execution still requires a running local/staging Supabase database before production deployment.

--- a/openspec/changes/archive/2026-06-17-casas-anfitrionas-permissions/verify-report.md
+++ b/openspec/changes/archive/2026-06-17-casas-anfitrionas-permissions/verify-report.md
@@ -174,3 +174,53 @@ App Router page files were exercised by `__tests__/app/casas-anfitrionas-pages.t
 PASS WITH WARNINGS
 
 All required safe verification commands completed successfully, all 12 tasks are complete, and no blocker was found. Warnings are non-blocking repo-wide lint/migration debt and coverage gaps documented above.
+
+## Corrective Addendum — 2026-06-17 Tracker Readiness Blocker
+
+**Scope**: Post-archive hardening for direct execution of legacy `public.obtener_casas_visibles_ids(uuid)`. No production Supabase calls were made.
+
+### Fix
+
+- Added additive migration `supabase/migrations/20260617214453_harden_obtener_casas_visibles_ids_rpc.sql`.
+- The RPC now checks `p_auth_id` before user/role/scope lookup and raises `auth_id_spoofed` for non-`service_role` callers whose `p_auth_id` differs from `auth.uid()`.
+- The SQL harness now asserts the explicit invalid-input contract: `obtener_casas_visibles_ids(NULL)` raises `auth_id_required` before identity comparison or user lookup.
+- Preserved authenticated caller behavior when `p_auth_id = auth.uid()` and kept trusted `service_role` execution available.
+- Explicitly revoked `anon` execution and granted execution to `authenticated, service_role`.
+
+### TDD Evidence
+
+| Task | Test File | Layer | Safety Net | RED | GREEN | TRIANGULATE | REFACTOR |
+|------|-----------|-------|------------|-----|-------|-------------|----------|
+| Tracker blocker: harden `obtener_casas_visibles_ids` | `__tests__/supabase/casas-anfitrionas-permissions-migration.test.ts`; `supabase/tests/casas-anfitrionas-permissions-rpc.test.sql` | SQL-static + SQL harness | ✅ Baseline targeted Jest passed 14/14 before this corrective evidence edit | ✅ Static test failed on missing SQL harness header / NULL invalid-input coverage | ✅ Focused Casas suites passed 43/43 after harness + static evidence update | ✅ Direct RPC NULL denial, spoof denial, matching director-etapa allow/in-scope, and out-of-scope cases documented | ✅ Minimal evidence-only update; no unrelated docs touched |
+
+### Checks Run
+
+```text
+pnpm test -- __tests__/supabase/casas-anfitrionas-permissions-migration.test.ts --runInBand
+Baseline: passed 14/14 before this corrective evidence edit.
+RED: failed as expected while static evidence required stale header and NULL invalid-input coverage that the SQL harness did not yet contain.
+GREEN: passed 14/14 after adding SQL harness `obtener_casas_visibles_ids(NULL)` coverage and header evidence.
+
+pnpm test -- __tests__/supabase/casas-anfitrionas-permissions-migration.test.ts __tests__/lib/actions/casas-anfitrionas.actions.test.ts __tests__/lib/casas-anfitrionas/ui-permissions.test.ts __tests__/app/casas-anfitrionas-pages.test.tsx --runInBand
+Test Suites: 4 passed, 4 total
+Tests: 43 passed, 43 total
+
+pnpm test -- --runInBand
+Test Suites: 28 passed, 28 total
+Tests: 251 passed, 251 total
+
+pnpm lint:migrations
+Summary: 173 files checked
+Errors: 0
+Warnings: 185
+Info: 128
+
+pnpm test:no-only
+No focused Jest tests found.
+```
+
+`pnpm exec supabase status` showed the local Supabase container was not running (`No such container: supabase_db_Global_Connect`), so the SQL harness was not executed locally in this corrective slice.
+
+### Corrective Verdict
+
+PASS WITH WARNINGS — the tracker readiness blocker is fixed in code and covered by static/SQL-harness evidence. Remaining warning: executable SQL harness still requires a running local/staging Supabase database before deployment.

--- a/supabase/migrations/20260617214453_harden_obtener_casas_visibles_ids_rpc.sql
+++ b/supabase/migrations/20260617214453_harden_obtener_casas_visibles_ids_rpc.sql
@@ -1,0 +1,150 @@
+-- Harden legacy Casas visibility RPC against caller-supplied auth_id spoofing.
+-- This migration only replaces the RPC definition and tightens anon execution.
+
+CREATE OR REPLACE FUNCTION public.obtener_casas_visibles_ids(p_auth_id uuid)
+RETURNS uuid[]
+LANGUAGE plpgsql STABLE SECURITY DEFINER SET search_path TO 'public'
+AS $$
+DECLARE
+  v_user_id uuid;
+  v_es_admin boolean := false;
+  v_es_pastor boolean := false;
+  v_es_dg boolean := false;
+  v_es_de boolean := false;
+  v_es_lider boolean := false;
+  v_tiene_des boolean := false;
+  v_result uuid[];
+  v_request_role text := nullif(current_setting('request.jwt.claim.role', true), '');
+BEGIN
+  IF p_auth_id IS NULL THEN
+    RAISE EXCEPTION 'auth_id_required' USING ERRCODE = '42501';
+  END IF;
+
+  IF coalesce(v_request_role, '') <> 'service_role'
+     AND (auth.uid() IS NULL OR p_auth_id IS DISTINCT FROM auth.uid()) THEN
+    RAISE EXCEPTION 'auth_id_spoofed' USING ERRCODE = '42501';
+  END IF;
+
+  SELECT id INTO v_user_id
+  FROM public.usuarios
+  WHERE auth_id = p_auth_id;
+
+  IF v_user_id IS NULL THEN RETURN '{}'; END IF;
+
+  SELECT
+    COALESCE(bool_or(rs.nombre_interno = 'admin'), false),
+    COALESCE(bool_or(rs.nombre_interno = 'pastor'), false),
+    COALESCE(bool_or(rs.nombre_interno = 'director-general'), false),
+    COALESCE(bool_or(rs.nombre_interno = 'director-etapa'), false),
+    COALESCE(bool_or(rs.nombre_interno = 'lider'), false)
+  INTO v_es_admin, v_es_pastor, v_es_dg, v_es_de, v_es_lider
+  FROM public.usuario_roles ur
+  JOIN public.roles_sistema rs ON ur.rol_id = rs.id
+  WHERE ur.usuario_id = v_user_id;
+
+  IF v_es_admin OR v_es_pastor THEN
+    SELECT array_agg(ca.id)
+    INTO v_result
+    FROM public.casas_anfitrionas ca;
+    RETURN COALESCE(v_result, '{}');
+  END IF;
+
+  v_result := '{}';
+
+  IF v_es_dg THEN
+    SELECT EXISTS (
+      SELECT 1 FROM public.dg_directores_etapa dde WHERE dde.dg_usuario_id = v_user_id
+    ) INTO v_tiene_des;
+
+    IF v_tiene_des THEN
+      SELECT array_agg(DISTINCT ca.id)
+      INTO v_result
+      FROM public.casas_anfitrionas ca
+      WHERE ca.usuario_id IN (
+        SELECT gm.usuario_id
+        FROM public.grupo_miembros gm
+        JOIN public.grupos g ON g.id = gm.grupo_id
+        WHERE g.id IN (
+          SELECT deg.grupo_id
+          FROM public.director_etapa_grupos deg
+          JOIN public.dg_directores_etapa dde ON dde.segmento_lider_id = deg.director_etapa_id
+          WHERE dde.dg_usuario_id = v_user_id
+        )
+        AND g.activo = true AND g.eliminado = false
+      )
+      OR ca.usuario_id = v_user_id;
+    ELSE
+      SELECT array_agg(DISTINCT ca.id)
+      INTO v_result
+      FROM public.casas_anfitrionas ca
+      WHERE ca.usuario_id IN (
+        SELECT gm.usuario_id
+        FROM public.grupo_miembros gm
+        JOIN public.grupos g ON g.id = gm.grupo_id
+        WHERE g.segmento_id IN (
+          SELECT dgs.segmento_id
+          FROM public.director_general_segmentos dgs
+          WHERE dgs.usuario_id = v_user_id
+        )
+        AND g.activo = true AND g.eliminado = false
+      )
+      OR ca.usuario_id = v_user_id;
+    END IF;
+    RETURN COALESCE(v_result, '{}');
+  END IF;
+
+  IF v_es_de THEN
+    SELECT array_agg(DISTINCT ca.id)
+    INTO v_result
+    FROM public.casas_anfitrionas ca
+    WHERE ca.usuario_id IN (
+      SELECT gm.usuario_id
+      FROM public.grupo_miembros gm
+      JOIN public.grupos g ON g.id = gm.grupo_id
+      JOIN public.temporadas t ON t.id = g.temporada_id
+      WHERE g.segmento_id IN (
+        SELECT sl.segmento_id
+        FROM public.segmento_lideres sl
+        WHERE sl.usuario_id = v_user_id
+          AND sl.tipo_lider = 'director_etapa'
+      )
+      AND t.activa = true
+      AND g.activo = true AND g.eliminado = false
+    )
+    OR ca.usuario_id = v_user_id;
+    RETURN COALESCE(v_result, '{}');
+  END IF;
+
+  IF v_es_lider THEN
+    SELECT array_agg(DISTINCT ca.id)
+    INTO v_result
+    FROM public.casas_anfitrionas ca
+    WHERE ca.usuario_id IN (
+      SELECT gm2.usuario_id
+      FROM public.grupo_miembros gm2
+      WHERE gm2.grupo_id IN (
+        SELECT gm.grupo_id
+        FROM public.grupo_miembros gm
+        JOIN public.grupos g ON g.id = gm.grupo_id
+        WHERE gm.usuario_id = v_user_id
+          AND gm.rol = 'Líder'
+          AND g.activo = true AND g.eliminado = false
+          AND g.estado_ciclo = 'activo'
+      )
+    )
+    OR ca.usuario_id = v_user_id;
+    RETURN COALESCE(v_result, '{}');
+  END IF;
+
+  SELECT array_agg(ca.id)
+  INTO v_result
+  FROM public.casas_anfitrionas ca
+  WHERE ca.usuario_id = v_user_id;
+
+  RETURN COALESCE(v_result, '{}');
+END;
+$$;
+
+REVOKE ALL ON FUNCTION public.obtener_casas_visibles_ids(uuid) FROM PUBLIC;
+REVOKE ALL ON FUNCTION public.obtener_casas_visibles_ids(uuid) FROM anon;
+GRANT EXECUTE ON FUNCTION public.obtener_casas_visibles_ids(uuid) TO authenticated, service_role;

--- a/supabase/tests/casas-anfitrionas-permissions-rpc.test.sql
+++ b/supabase/tests/casas-anfitrionas-permissions-rpc.test.sql
@@ -3,7 +3,8 @@
 -- Run against local or staging after applying
 -- 20260617161620_casas_anfitrionas_granular_permissions.sql and
 -- 20260617161954_revoke_anon_from_casas_permission_rpcs.sql and
--- 20260617183000_harden_casas_approval_rpc.sql.
+-- 20260617183000_harden_casas_approval_rpc.sql and
+-- 20260617214453_harden_obtener_casas_visibles_ids_rpc.sql.
 -- The harness creates deterministic fixtures and rolls them back.
 
 BEGIN;
@@ -130,6 +131,58 @@ EXCEPTION
   WHEN OTHERS THEN
     IF SQLERRM IS DISTINCT FROM p_expected_message THEN
       RAISE EXCEPTION 'RPC exception check failed: %, expected exception %, got %',
+        p_case,
+        p_expected_message,
+        SQLERRM;
+    END IF;
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION pg_temp.assert_uuid_array_contains(
+  p_case text,
+  p_actual uuid[],
+  p_expected_id uuid,
+  p_expected_present boolean
+)
+RETURNS void
+LANGUAGE plpgsql
+AS $$
+DECLARE
+  v_actual_present boolean;
+BEGIN
+  v_actual_present := p_expected_id = ANY(COALESCE(p_actual, '{}'));
+
+  IF v_actual_present IS DISTINCT FROM p_expected_present THEN
+    RAISE EXCEPTION 'UUID array check failed: %, expected id % present %, got % in %',
+      p_case,
+      p_expected_id,
+      p_expected_present,
+      v_actual_present,
+      p_actual;
+  END IF;
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION pg_temp.assert_uuid_array_rpc_exception(
+  p_case text,
+  p_expected_message text,
+  p_auth_claim uuid,
+  p_call_auth_id uuid
+)
+RETURNS void
+LANGUAGE plpgsql
+AS $$
+BEGIN
+  PERFORM set_config('request.jwt.claim.sub', p_auth_claim::text, true);
+  PERFORM public.obtener_casas_visibles_ids(p_call_auth_id);
+
+  RAISE EXCEPTION 'UUID array RPC exception check failed: %, expected exception % but call succeeded',
+    p_case,
+    p_expected_message;
+EXCEPTION
+  WHEN OTHERS THEN
+    IF SQLERRM IS DISTINCT FROM p_expected_message THEN
+      RAISE EXCEPTION 'UUID array RPC exception check failed: %, expected exception %, got %',
         p_case,
         p_expected_message,
         SQLERRM;
@@ -289,6 +342,20 @@ SELECT pg_temp.assert_permission(
   true
 );
 
+SELECT pg_temp.assert_uuid_array_contains(
+  'obtener_casas_visibles_ids allows matching director etapa auth',
+  public.obtener_casas_visibles_ids(fixture_id('director_etapa_auth_id')),
+  fixture_id('in_scope_house_id'),
+  true
+);
+
+SELECT pg_temp.assert_uuid_array_contains(
+  'obtener_casas_visibles_ids excludes out-of-scope house',
+  public.obtener_casas_visibles_ids(fixture_id('director_etapa_auth_id')),
+  fixture_id('out_of_scope_house_id'),
+  false
+);
+
 SELECT pg_temp.assert_permission(
   'director etapa cannot edit out-of-scope house',
   public.puede_editar_casa_anfitriona(
@@ -325,6 +392,20 @@ SELECT pg_temp.assert_permission(
     fixture_id('in_scope_house_id')
   ),
   false
+);
+
+SELECT pg_temp.assert_uuid_array_rpc_exception(
+  'direct obtener_casas_visibles_ids requires non-null p_auth_id',
+  'auth_id_required',
+  fixture_id('director_etapa_auth_id'),
+  NULL
+);
+
+SELECT pg_temp.assert_uuid_array_rpc_exception(
+  'direct obtener_casas_visibles_ids denies spoofed p_auth_id',
+  'auth_id_spoofed',
+  fixture_id('outsider_auth_id'),
+  fixture_id('admin_auth_id')
 );
 
 SELECT pg_temp.assert_rpc_exception(


### PR DESCRIPTION
# Título del PR
fix(casas): proteger rpc de visibilidad anfitrionas

Refs #179

## Chain Context
Estrategia: `feature-branch-chain`
Tracker: #180

```text
main
└── PR tracker: feat/casas-permissions-tracker (#180)
    └── PRs 181–187 merged
    └── 📍 Final hardening: feat/casas-permissions-visibility-hardening
```

## Resumen
Endurece el RPC legacy `obtener_casas_visibles_ids` para cerrar un bypass final detectado en la revisión del tracker.

## Qué Incluye
- Migración aditiva que obliga a callers no `service_role` a usar `p_auth_id = auth.uid()`.
- Error explícito `auth_id_required` para entrada nula.
- Tests estáticos y harness SQL para spoof denial, NULL denial y visibilidad autorizada.
- Addendum en reportes archive/verify.

## Motivación / Por Qué
`puede_ver_casa_anfitriona` delega visibilidad a este RPC legacy. Sin binding a `auth.uid()`, un usuario autenticado podría invocarlo con otro `auth_id` y enumerar casas visibles.

## Evidencia Visual (si aplica)
No aplica.

## Migraciones / Base de Datos
- [ ] No aplica
- [x] Sí (orden exacto):
```
20260617214453_harden_obtener_casas_visibles_ids_rpc.sql
```
Notas: migración correctiva; no toca datos existentes.

## Impacto y Riesgos
- Cierra spoofing directo del RPC de visibilidad.
- Mantiene ejecución para `authenticated`/`service_role` con reglas seguras.
- Release caution: ejecutar harness SQL en local/staging antes de producción.

## Checklist Autor
- [x] Código formateado (Prettier/ESLint)
- [x] Sin `console.log` / debugger
- [x] Validaciones con zod para entradas nuevas
- [x] Estados loading/error/empty cubiertos
- [x] Tipos TypeScript correctos
- [x] Migraciones probadas local
- [x] Documentación actualizada (`docs/` o README)
- [x] Variables de entorno documentadas
- [x] Rebase con `main` limpio

## Checklist Revisor
- [x] Propósito claro
- [x] Nombres descriptivos
- [x] Sin lógica duplicada evidente
- [x] Manejo adecuado de errores
- [x] Cambios acotados al alcance
- [x] Sin secretos / datos sensibles

## Pruebas Manuales Realizadas
- [x] Focused Jest: 14/14
- [x] Focused Casas suites: 43/43
- [x] Full Jest: 251 tests
- [x] `pnpm lint:migrations`
- [x] `pnpm test:no-only`
- [x] `git diff --check`
- [x] Fresh security review: pass
- [x] Fresh reliability review: pass after NULL contract evidence

## Pendientes / Follow-up (opcional)
- Mergear este PR al tracker y volver a validar #180.
- Antes de producción: ejecutar harness SQL contra local/staging con esta migración aplicada.

## Notas Adicionales
No se usó Supabase producción. `docs/support-agent-integration-spec.md` sigue fuera de este cambio.