### PR TITLE
feat(casas): mejorar selector de propietarios anfitrionas

### DIFF
--- a/__tests__/app/api/casas-anfitrionas-propietarios-route.test.ts
+++ b/__tests__/app/api/casas-anfitrionas-propietarios-route.test.ts
@@ -1,0 +1,140 @@
+import type { NextRequest } from 'next/server'
+import { GET } from '@/app/api/casas-anfitrionas/propietarios/buscar/route'
+
+const createSupabaseServerClient = jest.fn()
+const createSupabaseAdminClient = jest.fn()
+const obtenerUsuariosAsignablesCasaAnfitriona = jest.fn()
+
+jest.mock('@/lib/supabase/server', () => ({ createSupabaseServerClient: () => createSupabaseServerClient() }))
+jest.mock('@/lib/supabase/admin', () => ({ createSupabaseAdminClient: () => createSupabaseAdminClient() }))
+jest.mock('@/lib/casas-anfitrionas/assignable-users', () => ({
+  obtenerUsuariosAsignablesCasaAnfitriona: (...args: unknown[]) => obtenerUsuariosAsignablesCasaAnfitriona(...args),
+}))
+jest.mock('next/server', () => ({
+  NextResponse: {
+    json: (body: unknown, init?: { status?: number }) => ({
+      status: init?.status ?? 200,
+      json: () => Promise.resolve(body),
+    }),
+  },
+}))
+
+const authId = '11111111-1111-1111-1111-111111111111'
+const casaId = '22222222-2222-2222-2222-222222222222'
+
+describe('GET /api/casas-anfitrionas/propietarios/buscar', () => {
+  let consoleErrorSpy: jest.SpyInstance
+
+  beforeEach(() => {
+    jest.clearAllMocks()
+    consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation(() => undefined)
+    createSupabaseAdminClient.mockReturnValue({ admin: true })
+    obtenerUsuariosAsignablesCasaAnfitriona.mockResolvedValue([{ value: 'user-1', label: 'Ana Pérez' }])
+  })
+
+  afterEach(() => {
+    consoleErrorSpy.mockRestore()
+  })
+
+  it('searches by the provided field term and normalizes invalid limits', async () => {
+    const supabase = createServerClient()
+    createSupabaseServerClient.mockResolvedValue(supabase)
+
+    const response = await GET(request('/api/casas-anfitrionas/propietarios/buscar?q=ana%40example.com&limit=abc'))
+
+    await expect(response.json()).resolves.toEqual({ usuarios: [{ value: 'user-1', label: 'Ana Pérez' }] })
+    expect(response.status).toBe(200)
+    expect(obtenerUsuariosAsignablesCasaAnfitriona).toHaveBeenCalledWith(expect.objectContaining({
+      authId,
+      busqueda: 'ana@example.com',
+      limit: 30,
+    }))
+  })
+
+  it('passes quotes and SQL metacharacters as search text without rejecting the request', async () => {
+    const supabase = createServerClient()
+    createSupabaseServerClient.mockResolvedValue(supabase)
+
+    const response = await GET(request("/api/casas-anfitrionas/propietarios/buscar?q=O%27Connor%25_%3B--&limit=10"))
+
+    await expect(response.json()).resolves.toEqual({ usuarios: [{ value: 'user-1', label: 'Ana Pérez' }] })
+    expect(response.status).toBe(200)
+    expect(obtenerUsuariosAsignablesCasaAnfitriona).toHaveBeenCalledWith(expect.objectContaining({
+      authId,
+      busqueda: "O'Connor%_;--",
+      limit: 10,
+    }))
+  })
+
+  it('rejects unauthenticated requests before searching', async () => {
+    createSupabaseServerClient.mockResolvedValue(createServerClient({ user: null }))
+
+    const response = await GET(request('/api/casas-anfitrionas/propietarios/buscar?q=Ana'))
+
+    await expect(response.json()).resolves.toEqual({ error: 'No autenticado' })
+    expect(response.status).toBe(401)
+    expect(obtenerUsuariosAsignablesCasaAnfitriona).not.toHaveBeenCalled()
+  })
+
+  it('rejects current house searches when the requester cannot edit that house', async () => {
+    const supabase = createServerClient({ canEdit: false })
+    createSupabaseServerClient.mockResolvedValue(supabase)
+
+    const response = await GET(request(`/api/casas-anfitrionas/propietarios/buscar?q=Ana&casaId=${casaId}`))
+
+    await expect(response.json()).resolves.toEqual({ error: 'No tienes permisos para editar esta casa' })
+    expect(response.status).toBe(403)
+    expect(supabase.rpc).toHaveBeenCalledWith('puede_editar_casa_anfitriona', { p_auth_id: authId, p_casa_id: casaId })
+    expect(obtenerUsuariosAsignablesCasaAnfitriona).not.toHaveBeenCalled()
+  })
+
+  it('rejects search when server-side owner assignment permissions are missing', async () => {
+    createSupabaseServerClient.mockResolvedValue(createServerClient({ canAssignOwners: false }))
+
+    const response = await GET(request('/api/casas-anfitrionas/propietarios/buscar?q=Ana'))
+
+    await expect(response.json()).resolves.toEqual({ error: 'No tienes permisos para asignar propietarios' })
+    expect(response.status).toBe(403)
+    expect(obtenerUsuariosAsignablesCasaAnfitriona).not.toHaveBeenCalled()
+  })
+
+  it('logs internal failures and returns a generic client error', async () => {
+    createSupabaseServerClient.mockResolvedValue(createServerClient())
+    obtenerUsuariosAsignablesCasaAnfitriona.mockRejectedValue(new Error('raw database failure with PII'))
+
+    const response = await GET(request('/api/casas-anfitrionas/propietarios/buscar?q=Ana'))
+
+    await expect(response.json()).resolves.toEqual({ error: 'Error al buscar propietarios' })
+    expect(response.status).toBe(500)
+    expect(consoleErrorSpy).toHaveBeenCalledWith(
+      '[casas-anfitrionas/propietarios/buscar] Error:',
+      expect.any(Error),
+    )
+  })
+})
+
+function request(path: string): NextRequest {
+  return { url: `http://localhost${path}` } as NextRequest
+}
+
+function createServerClient({
+  canAssignOwners = true,
+  canEdit = true,
+  user = { id: authId },
+}: {
+  canAssignOwners?: boolean
+  canEdit?: boolean
+  user?: { id: string } | null
+} = {}) {
+  return {
+    auth: { getUser: jest.fn().mockResolvedValue({ data: { user }, error: null }) },
+    rpc: jest.fn((name: string) => {
+      if (name === 'puede_editar_casa_anfitriona') return Promise.resolve({ data: canEdit, error: null })
+      if (name === 'obtener_permisos_casa_anfitriona') {
+        return Promise.resolve({ data: { puede_crear_para_otros: canAssignOwners }, error: null })
+      }
+
+      throw new Error(`Unexpected RPC ${name}`)
+    }),
+  }
+}

--- a/__tests__/app/casas-anfitrionas-pages.test.tsx
+++ b/__tests__/app/casas-anfitrionas-pages.test.tsx
@@ -140,19 +140,11 @@ describe('casas anfitrionas App Router permission wiring', () => {
     expect(screen.queryByRole('button', { name: 'Rechazar' })).not.toBeInTheDocument()
   })
 
-  it('lets the new page render from backend create permissions and filters assignable users through backend predicates', async () => {
+  it('lets the new page render from backend create permissions without preloading assignable users', async () => {
     createSupabaseServerClient.mockResolvedValue(createServerClient({
       assignableUserIds: [allowedUserId],
       canCreateForOthers: true,
       canCreateOwn: true,
-    }))
-    createSupabaseAdminClient.mockReturnValue(createAdminClient({
-      existingCasas: [{ usuario_id: usedUserId, co_anfitrion_id: null }],
-      users: [
-        { id: allowedUserId, nombre: 'Ana', apellido: 'Permitida' },
-        { id: deniedUserId, nombre: 'Beto', apellido: 'Fuera de scope' },
-        { id: usedUserId, nombre: 'Casa', apellido: 'Existente' },
-      ],
     }))
     const { default: NuevaCasaAnfitrionaPage } = await import('@/app/(auth)/grupos-vida/casas-anfitrionas/nueva/page')
 
@@ -160,14 +152,9 @@ describe('casas anfitrionas App Router permission wiring', () => {
 
     const serverClient = await createSupabaseServerClient.mock.results[0].value
     expect(serverClient.rpc).toHaveBeenCalledWith('obtener_permisos_casa_anfitriona', { p_auth_id: authId })
-    expect(serverClient.rpc).toHaveBeenCalledWith('puede_crear_casa_anfitriona_para', {
-      p_auth_id: authId,
-      p_usuario_id: allowedUserId,
-    })
+    expect(serverClient.rpc).not.toHaveBeenCalledWith('puede_crear_casa_anfitriona_para', expect.anything())
+    expect(createSupabaseAdminClient).not.toHaveBeenCalled()
     expect(screen.getByTestId('nueva-selector-visible')).toHaveTextContent('true')
-    expect(screen.getByText('Ana Permitida')).toBeInTheDocument()
-    expect(screen.queryByText('Beto Fuera de scope')).not.toBeInTheDocument()
-    expect(screen.queryByText('Casa Existente')).not.toBeInTheDocument()
   })
 
   it('denies edit access with the granular edit predicate before enriched admin reads', async () => {
@@ -183,7 +170,7 @@ describe('casas anfitrionas App Router permission wiring', () => {
     expect(createSupabaseAdminClient).not.toHaveBeenCalled()
   })
 
-  it('renders edit owner selector from backend edit and create-for-others permissions with assignable users filtered by backend predicates', async () => {
+  it('renders edit owner selector with only the current owner preloaded', async () => {
     createSupabaseServerClient.mockResolvedValue(createServerClient({
       assignableUserIds: [allowedUserId],
       canCreateForOthers: true,
@@ -204,21 +191,10 @@ describe('casas anfitrionas App Router permission wiring', () => {
     const serverClient = await createSupabaseServerClient.mock.results[0].value
     expect(serverClient.rpc).toHaveBeenCalledWith('puede_editar_casa_anfitriona', { p_auth_id: authId, p_casa_id: casaId })
     expect(serverClient.rpc).toHaveBeenCalledWith('obtener_permisos_casa_anfitriona', { p_auth_id: authId, p_casa_id: casaId })
-    expect(serverClient.rpc).toHaveBeenCalledWith('puede_crear_casa_anfitriona_para', {
-      p_auth_id: authId,
-      p_usuario_id: allowedUserId,
-    })
-    expect(serverClient.rpc).toHaveBeenCalledWith('puede_crear_casa_anfitriona_para', {
-      p_auth_id: authId,
-      p_usuario_id: deniedUserId,
-    })
-    expect(serverClient.rpc).not.toHaveBeenCalledWith('puede_crear_casa_anfitriona_para', {
-      p_auth_id: authId,
-      p_usuario_id: usedUserId,
-    })
+    expect(serverClient.rpc).not.toHaveBeenCalledWith('puede_crear_casa_anfitriona_para', expect.anything())
     expect(screen.getByTestId('editar-selector-visible')).toHaveTextContent('true')
     expect(screen.getByText('Ana Pérez')).toBeInTheDocument()
-    expect(screen.getByText('Ana Permitida')).toBeInTheDocument()
+    expect(screen.queryByText('Ana Permitida')).not.toBeInTheDocument()
     expect(screen.queryByText('Beto Fuera de scope')).not.toBeInTheDocument()
     expect(screen.queryByText('Casa Existente')).not.toBeInTheDocument()
   })

--- a/__tests__/lib/actions/casas-anfitrionas.actions.test.ts
+++ b/__tests__/lib/actions/casas-anfitrionas.actions.test.ts
@@ -40,6 +40,37 @@ describe('casas anfitrionas server actions permissions', () => {
     expect(createSupabaseAdminClient).not.toHaveBeenCalled()
   })
 
+  it('rejects owners who only have inactive or deleted group membership', async () => {
+    const rpc = createPermissionRpcMock({ createFor: true })
+    const adminDb = createAdminClient({ activeGroupMemberIds: [] })
+    createSupabaseServerClient.mockResolvedValue(createServerClient({ rpc }))
+    createSupabaseAdminClient.mockReturnValue(adminDb)
+
+    const result = await crearCasaAnfitriona(createCasaInput({ usuario_id: targetUserId }))
+
+    expect(result).toEqual({ success: false, error: 'El propietario debe pertenecer actualmente a un grupo de vida' })
+    expect(adminDb.grupoMiembrosQuery.eq).toHaveBeenCalledWith('usuario_id', targetUserId)
+    expect(adminDb.grupoMiembrosQuery.eq).toHaveBeenCalledWith('grupos.activo', true)
+    expect(adminDb.grupoMiembrosQuery.eq).toHaveBeenCalledWith('grupos.eliminado', false)
+    expect(adminDb.insertDireccion).not.toHaveBeenCalled()
+  })
+
+  it('rejects co-hosts who only have inactive or deleted group membership', async () => {
+    const rpc = createPermissionRpcMock({ createFor: true, coHost: true })
+    const adminDb = createAdminClient({ activeGroupMemberIds: [actorUserId] })
+    createSupabaseServerClient.mockResolvedValue(createServerClient({ rpc }))
+    createSupabaseAdminClient.mockReturnValue(adminDb)
+
+    const result = await crearCasaAnfitriona(createCasaInput({ co_anfitrion_id: coHostUserId }))
+
+    expect(result).toEqual({ success: false, error: 'El co-anfitrión debe pertenecer actualmente a un grupo de vida' })
+    expect(adminDb.grupoMiembrosQuery.eq).toHaveBeenCalledWith('usuario_id', actorUserId)
+    expect(adminDb.grupoMiembrosQuery.eq).toHaveBeenCalledWith('usuario_id', coHostUserId)
+    expect(adminDb.grupoMiembrosQuery.eq).toHaveBeenCalledWith('grupos.activo', true)
+    expect(adminDb.grupoMiembrosQuery.eq).toHaveBeenCalledWith('grupos.eliminado', false)
+    expect(adminDb.insertDireccion).not.toHaveBeenCalled()
+  })
+
   it('denies approval before invoking the approval mutation RPC', async () => {
     const rpc = createPermissionRpcMock({ approve: false })
     createSupabaseServerClient.mockResolvedValue(createServerClient({ rpc }))
@@ -177,18 +208,67 @@ function createListQuery(rows: unknown[]) {
   }
 }
 
-function createAdminClient(input: { existingCasa: { usuario_id: string; direccion_id: string | null; aprobada: boolean } }) {
+function createAdminClient(input: {
+  activeGroupMemberIds?: string[]
+  existingCasa?: { usuario_id: string; direccion_id: string | null; aprobada: boolean }
+} = {}) {
   const updateCasasAnfitrionas = jest.fn().mockReturnValue({ eq: jest.fn().mockResolvedValue({ error: null }) })
+  const insertDireccion = jest.fn().mockReturnValue({
+    select: jest.fn().mockReturnValue({ single: jest.fn().mockResolvedValue({ data: { id: 'direccion-id' }, error: null }) }),
+  })
+  const grupoMiembrosQuery = createGrupoMiembrosQuery(input.activeGroupMemberIds ?? [actorUserId, targetUserId, coHostUserId])
+  const casasOcupadasQuery = createCasasOcupadasQuery([])
+
   return {
+    casasOcupadasQuery,
+    grupoMiembrosQuery,
+    insertDireccion,
     updateCasasAnfitrionas,
     from: jest.fn((table: string) => {
+      if (table === 'grupo_miembros') return grupoMiembrosQuery
+      if (table === 'direcciones') return { insert: insertDireccion }
       if (table === 'casas_anfitrionas') {
         return {
           update: updateCasasAnfitrionas,
-          select: jest.fn().mockReturnValue({ eq: jest.fn().mockReturnValue({ single: jest.fn().mockResolvedValue({ data: input.existingCasa, error: null }) }) }),
+          select: jest.fn(() => ({
+            eq: jest.fn().mockReturnValue({ single: jest.fn().mockResolvedValue({ data: input.existingCasa, error: null }) }),
+            or: jest.fn().mockReturnValue(casasOcupadasQuery),
+          })),
         }
       }
       throw new Error(`Unexpected admin table ${table}`)
     }),
   }
+}
+
+function createCasasOcupadasQuery(rows: Array<{ id: string }>) {
+  const query = {
+    neq: jest.fn().mockReturnThis(),
+    limit: jest.fn().mockResolvedValue({ data: rows, error: null }),
+  }
+
+  return query
+}
+
+function createGrupoMiembrosQuery(activeGroupMemberIds: string[]) {
+  let selectedUsuarioId = ''
+  const query: {
+    select: jest.Mock
+    eq: jest.Mock
+    is: jest.Mock
+    limit: jest.Mock
+  } = {
+    select: jest.fn().mockReturnThis(),
+    eq: jest.fn((column: string, value: string) => {
+      if (column === 'usuario_id') selectedUsuarioId = value
+      return query
+    }),
+    is: jest.fn().mockReturnThis(),
+    limit: jest.fn(() => Promise.resolve({
+      data: activeGroupMemberIds.includes(selectedUsuarioId) ? [{ id: 'membership-id' }] : [],
+      error: null,
+    })),
+  }
+
+  return query
 }

--- a/__tests__/lib/casas-anfitrionas/assignable-users.test.ts
+++ b/__tests__/lib/casas-anfitrionas/assignable-users.test.ts
@@ -1,0 +1,159 @@
+import { obtenerUsuariosAsignablesCasaAnfitriona } from '@/lib/casas-anfitrionas/assignable-users'
+
+const authId = '11111111-1111-1111-1111-111111111111'
+const allowedUserId = '22222222-2222-2222-2222-222222222222'
+const usedUserId = '33333333-3333-3333-3333-333333333333'
+const deniedUserId = '44444444-4444-4444-4444-444444444444'
+const inactiveUserId = '55555555-5555-5555-5555-555555555555'
+
+describe('obtenerUsuariosAsignablesCasaAnfitriona', () => {
+  it('returns only in-scope active-group users and disables only occupied in-scope users', async () => {
+    const supabase = createServerClient({
+      permissionByUserId: {
+        [allowedUserId]: true,
+        [usedUserId]: true,
+        [deniedUserId]: false,
+        [inactiveUserId]: true,
+      },
+      users: [
+        userRow(allowedUserId, 'Ana', 'Disponible', 'ana@example.com', '123'),
+        userRow(usedUserId, 'Beto', 'Ocupado', 'beto@example.com', '456'),
+        userRow(deniedUserId, 'Carla', 'Fuera', 'carla@example.com', '789'),
+        userRow(inactiveUserId, 'Diego', 'Inactivo', 'diego@example.com', '000'),
+      ],
+    })
+    const adminDb = createAdminClient({
+      activeMemberIds: [allowedUserId, usedUserId, deniedUserId],
+      occupiedRows: [{ id: 'casa-usada', usuario_id: usedUserId, co_anfitrion_id: null }],
+    })
+
+    const result = await obtenerUsuariosAsignablesCasaAnfitriona({
+      supabase: supabase as never,
+      adminDb: adminDb as never,
+      authId,
+      busqueda: ' ana@example.com ',
+    })
+
+    expect(result).toEqual([
+      expect.objectContaining({ value: allowedUserId, label: 'Ana Disponible', puedeSeleccionar: true }),
+      expect.objectContaining({
+        value: usedUserId,
+        label: 'Beto Ocupado',
+        puedeSeleccionar: false,
+        yaTieneCasa: true,
+        razonNoSeleccionable: 'Ya tiene casa asignada',
+      }),
+    ])
+    expect(result.map((user) => user.value)).not.toContain(deniedUserId)
+    expect(result.map((user) => user.value)).not.toContain(inactiveUserId)
+    expect(supabase.rpc).toHaveBeenCalledWith('listar_usuarios_con_permisos', expect.objectContaining({
+      p_busqueda: 'ana@example.com',
+      p_en_grupo: true,
+    }))
+    expect(adminDb.grupoMiembrosQuery.eq).toHaveBeenCalledWith('grupos.activo', true)
+    expect(adminDb.grupoMiembrosQuery.eq).toHaveBeenCalledWith('grupos.eliminado', false)
+  })
+
+  it('normalizes invalid limits before calling the search RPC', async () => {
+    const supabase = createServerClient({ users: [] })
+    const adminDb = createAdminClient({ activeMemberIds: [], occupiedRows: [] })
+
+    await obtenerUsuariosAsignablesCasaAnfitriona({
+      supabase: supabase as never,
+      adminDb: adminDb as never,
+      authId,
+      busqueda: 'Ana',
+      limit: Number.NaN,
+    })
+
+    expect(supabase.rpc).toHaveBeenCalledWith('listar_usuarios_con_permisos', expect.objectContaining({
+      p_limite: 30,
+    }))
+  })
+
+  it('does not call admin lookups when the permission search fails', async () => {
+    const supabase = createServerClient({ users: [], listError: { message: 'raw database failure' } })
+    const adminDb = createAdminClient({ activeMemberIds: [], occupiedRows: [] })
+
+    await expect(obtenerUsuariosAsignablesCasaAnfitriona({
+      supabase: supabase as never,
+      adminDb: adminDb as never,
+      authId,
+      busqueda: 'Ana',
+    })).rejects.toThrow('raw database failure')
+    expect(adminDb.from).not.toHaveBeenCalled()
+  })
+})
+
+function userRow(id: string, nombre: string, apellido: string, email: string, cedula: string) {
+  return { id, nombre, apellido, email, cedula, foto_perfil_url: null }
+}
+
+function createServerClient({
+  listError = null,
+  permissionByUserId = {},
+  users,
+}: {
+  listError?: { message: string } | null
+  permissionByUserId?: Record<string, boolean>
+  users: Array<ReturnType<typeof userRow>>
+}) {
+  return {
+    rpc: jest.fn((name: string, args: Record<string, unknown>) => {
+      if (name === 'listar_usuarios_con_permisos') {
+        return Promise.resolve({ data: listError ? null : users, error: listError })
+      }
+
+      if (name === 'puede_crear_casa_anfitriona_para') {
+        return Promise.resolve({ data: permissionByUserId[String(args.p_usuario_id)] === true, error: null })
+      }
+
+      throw new Error(`Unexpected RPC ${name}`)
+    }),
+  }
+}
+
+function createAdminClient({
+  activeMemberIds,
+  occupiedRows,
+}: {
+  activeMemberIds: string[]
+  occupiedRows: Array<{ id: string; usuario_id: string | null; co_anfitrion_id: string | null }>
+}) {
+  const grupoMiembrosQuery = createGrupoMiembrosQuery(activeMemberIds)
+  const casasQuery = createCasasQuery(occupiedRows)
+
+  return {
+    grupoMiembrosQuery,
+    casasQuery,
+    from: jest.fn((table: string) => {
+      if (table === 'grupo_miembros') return grupoMiembrosQuery
+      if (table === 'casas_anfitrionas') return casasQuery
+      throw new Error(`Unexpected table ${table}`)
+    }),
+  }
+}
+
+function createGrupoMiembrosQuery(activeMemberIds: string[]) {
+  const query = {
+    select: jest.fn().mockReturnThis(),
+    in: jest.fn().mockReturnThis(),
+    is: jest.fn().mockReturnThis(),
+    eq: jest.fn().mockReturnThis(),
+    then: (resolve: (value: { data: Array<{ usuario_id: string }>; error: null }) => void) =>
+      resolve({ data: activeMemberIds.map((usuario_id) => ({ usuario_id })), error: null }),
+  }
+
+  return query
+}
+
+function createCasasQuery(rows: Array<{ id: string; usuario_id: string | null; co_anfitrion_id: string | null }>) {
+  const query = {
+    select: jest.fn().mockReturnThis(),
+    or: jest.fn().mockReturnThis(),
+    neq: jest.fn().mockReturnThis(),
+    then: (resolve: (value: { data: typeof rows; error: null }) => void) => resolve({ data: rows, error: null }),
+  }
+
+  return query
+}

--- a/__tests__/supabase/casas-anfitrionas-permissions-migration.test.ts
+++ b/__tests__/supabase/casas-anfitrionas-permissions-migration.test.ts
@@ -68,6 +68,26 @@ function readObtenerCasasVisiblesHardeningMigration(): string {
   return readFileSync(join(migrationsDir, file), 'utf8')
 }
 
+function readPreventDuplicateAssigneesMigration(): string {
+  const file = readdirSync(migrationsDir).find((name) =>
+    name.endsWith('_prevent_duplicate_casa_assignees.sql'),
+  )
+
+  if (!file) throw new Error('Missing duplicate casa assignees protection migration')
+
+  return readFileSync(join(migrationsDir, file), 'utf8')
+}
+
+function readHardenListarUsuariosSearchMigration(): string {
+  const file = readdirSync(migrationsDir).find((name) =>
+    name.endsWith('_harden_listar_usuarios_con_permisos_search.sql'),
+  )
+
+  if (!file) throw new Error('Missing listar_usuarios_con_permisos search hardening migration')
+
+  return readFileSync(join(migrationsDir, file), 'utf8')
+}
+
 function readCasasRpcChecks(): string {
   return readFileSync(
     join(supabaseTestsDir, 'casas-anfitrionas-permissions-rpc.test.sql'),
@@ -267,5 +287,33 @@ describe('casas anfitrionas granular permissions migration', () => {
     expect(sql).toContain('direct obtener_casas_visibles_ids requires non-null p_auth_id')
     expect(sql).toContain("'auth_id_required'")
     expect(sql).toContain('direct obtener_casas_visibles_ids denies spoofed p_auth_id')
+  })
+
+  it('adds DB-level duplicate assignment protection for owners and co-hosts', () => {
+    const sql = readPreventDuplicateAssigneesMigration()
+    const compacted = compactSql(sql)
+
+    expect(sql).toContain('CREATE OR REPLACE FUNCTION public.prevent_duplicate_casa_anfitriona_assignees()')
+    expect(sql).toContain('CREATE TRIGGER ensure_unique_casa_anfitriona_assignees')
+    expect(sql).toContain('BEFORE INSERT OR UPDATE OF usuario_id, co_anfitrion_id')
+    expect(sql).toContain('pg_advisory_xact_lock')
+    expect(sql).toContain('hashtextextended')
+    expect(compacted).toContain('ca.usuario_id = ANY(v_assignee_ids) OR ca.co_anfitrion_id = ANY(v_assignee_ids)')
+    expect(sql).toContain("ERRCODE = '23505'")
+    expect(sql).toContain('CREATE INDEX IF NOT EXISTS idx_casas_co_anfitrion')
+    expect(sql).not.toMatch(/\bTRUNCATE\b|\bDELETE\s+FROM\b|\bINSERT\s+INTO\b|\bUPDATE\s+public\./i)
+  })
+
+  it('hardens listar_usuarios_con_permisos search without dynamic SQL interpolation', () => {
+    const sql = readHardenListarUsuariosSearchMigration()
+
+    expect(sql).toContain('CREATE OR REPLACE FUNCTION public.listar_usuarios_con_permisos')
+    expect(sql).toContain("SECURITY DEFINER\nSET search_path TO 'public'")
+    expect(sql).toContain('v_busqueda_like := replace(')
+    expect(sql).toContain("ESCAPE E'\\\\'")
+    expect(sql).toContain('g2.activo = true')
+    expect(sql).toContain('g2.eliminado = false')
+    expect(sql).toContain('GRANT EXECUTE ON FUNCTION public.listar_usuarios_con_permisos(uuid, text, text[], boolean, boolean, boolean, integer, integer, boolean) TO authenticated, service_role;')
+    expect(sql).not.toMatch(/format\s*\(|RETURN\s+QUERY\s+EXECUTE|EXECUTE\s+format|%%%s%%/i)
   })
 })

--- a/app/(auth)/grupos-vida/casas-anfitrionas/[id]/editar/editar-casa-client.tsx
+++ b/app/(auth)/grupos-vida/casas-anfitrionas/[id]/editar/editar-casa-client.tsx
@@ -17,6 +17,12 @@ interface UbicacionOption {
 interface UsuarioOption {
     value: string;
     label: string;
+    email?: string | null;
+    cedula?: string | null;
+    fotoPerfilUrl?: string | null;
+    yaTieneCasa?: boolean;
+    puedeSeleccionar?: boolean;
+    razonNoSeleccionable?: string;
 }
 
 /** Datos iniciales de la casa para pre-llenar el formulario */
@@ -96,6 +102,7 @@ export function EditarCasaClient({
     return (
         <FormCasaAnfitriona
             datosIniciales={datosIniciales}
+            casaId={casaId}
             estados={estados}
             municipios={municipios}
             parroquias={parroquias}

--- a/app/(auth)/grupos-vida/casas-anfitrionas/[id]/editar/page.tsx
+++ b/app/(auth)/grupos-vida/casas-anfitrionas/[id]/editar/page.tsx
@@ -40,7 +40,7 @@ export default async function EditarCasaAnfitrionaPage({ params }: PageProps) {
         .from("casas_anfitrionas")
         .select(`
       *,
-      usuarios!casas_anfitrionas_usuario_id_fkey ( id, nombre, apellido ),
+      usuarios!casas_anfitrionas_usuario_id_fkey ( id, nombre, apellido, email, cedula, foto_perfil_url ),
       direcciones!casas_anfitrionas_direccion_id_fkey (
         calle, barrio, codigo_postal, referencia, latitud, longitud,
         parroquia_id,
@@ -126,7 +126,14 @@ export default async function EditarCasaAnfitrionaPage({ params }: PageProps) {
         parentId: p.municipio_id,
     }));
 
-    const usuarioActual = extraerRelacion<{ id: string; nombre: string; apellido: string }>(casa.usuarios);
+    const usuarioActual = extraerRelacion<{
+        id: string;
+        nombre: string;
+        apellido: string;
+        email: string | null;
+        cedula: string | null;
+        foto_perfil_url: string | null;
+    }>(casa.usuarios);
     const usuariosOptions = permisosCasa.puedeCrearParaOtros
         ? await obtenerUsuariosAsignablesCasaAnfitriona({
             supabase,
@@ -134,7 +141,13 @@ export default async function EditarCasaAnfitrionaPage({ params }: PageProps) {
             authId: user.id,
             currentCasaId: id,
             currentOwner: usuarioActual
-                ? { value: usuarioActual.id, label: `${usuarioActual.nombre} ${usuarioActual.apellido}`.trim() }
+                ? {
+                    value: usuarioActual.id,
+                    label: `${usuarioActual.nombre} ${usuarioActual.apellido}`.trim(),
+                    email: usuarioActual.email,
+                    cedula: usuarioActual.cedula,
+                    fotoPerfilUrl: usuarioActual.foto_perfil_url,
+                }
                 : null,
         })
         : [];

--- a/app/(auth)/grupos-vida/casas-anfitrionas/nueva/nueva-casa-client.tsx
+++ b/app/(auth)/grupos-vida/casas-anfitrionas/nueva/nueva-casa-client.tsx
@@ -17,6 +17,12 @@ interface UbicacionOption {
 interface UsuarioOption {
     value: string;
     label: string;
+    email?: string | null;
+    cedula?: string | null;
+    fotoPerfilUrl?: string | null;
+    yaTieneCasa?: boolean;
+    puedeSeleccionar?: boolean;
+    razonNoSeleccionable?: string;
 }
 
 /** Props del componente cliente para crear casa anfitriona */

--- a/app/(auth)/grupos-vida/casas-anfitrionas/nueva/page.tsx
+++ b/app/(auth)/grupos-vida/casas-anfitrionas/nueva/page.tsx
@@ -1,10 +1,8 @@
 import { createSupabaseServerClient } from "@/lib/supabase/server";
-import { createSupabaseAdminClient } from "@/lib/supabase/admin";
 import { redirect } from "next/navigation";
 import { DashboardLayout } from "@/components/layout/dashboard-layout";
 import { ContenedorDashboard, TarjetaSistema } from "@/components/ui/sistema-diseno";
 import { NuevaCasaClient } from "./nueva-casa-client";
-import { obtenerUsuariosAsignablesCasaAnfitriona } from "@/lib/casas-anfitrionas/assignable-users";
 import {
     obtenerPermisosCasaAnfitrionaUI,
     puedeMostrarRegistroCasa,
@@ -15,7 +13,7 @@ import {
  *
  * - Verifica autenticación y permisos backend de creación.
  * - Carga catálogos de estados, municipios y parroquias para cascading.
- * - Si el backend permite crear para otros, carga usuarios asignables ya filtrados.
+ * - Si el backend permite crear para otros, habilita búsqueda bajo demanda de propietario.
  */
 export default async function NuevaCasaAnfitrionaPage() {
     const supabase = await createSupabaseServerClient();
@@ -33,17 +31,8 @@ export default async function NuevaCasaAnfitrionaPage() {
         supabase.from("parroquias").select("id, nombre, municipio_id").order("nombre"),
     ]);
 
-    // Cargar usuarios elegibles solo cuando el backend permite asignar propietario.
-    let usuariosOptions: { value: string; label: string }[] = [];
-
-    if (permisosCasa.puedeCrearParaOtros) {
-        const adminDb = createSupabaseAdminClient();
-        usuariosOptions = await obtenerUsuariosAsignablesCasaAnfitriona({
-            supabase,
-            adminDb,
-            authId: user.id,
-        });
-    }
+    // El selector de propietario busca bajo demanda para evitar cargar todos los miembros upfront.
+    const usuariosOptions: { value: string; label: string }[] = [];
 
     const estadosOptions = (estados ?? []).map((e) => ({
         value: e.id,

--- a/app/api/casas-anfitrionas/propietarios/buscar/route.ts
+++ b/app/api/casas-anfitrionas/propietarios/buscar/route.ts
@@ -1,0 +1,80 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { createSupabaseAdminClient } from '@/lib/supabase/admin'
+import { createSupabaseServerClient } from '@/lib/supabase/server'
+import { obtenerUsuariosAsignablesCasaAnfitriona } from '@/lib/casas-anfitrionas/assignable-users'
+
+const DEFAULT_LIMIT = 30
+
+function puedeAsignarPropietarios(permisos: unknown): boolean {
+  return Boolean(
+    permisos &&
+      typeof permisos === 'object' &&
+      !Array.isArray(permisos) &&
+      'puede_crear_para_otros' in permisos &&
+      permisos.puede_crear_para_otros === true
+  )
+}
+
+function parseLimit(value: string | null): number {
+  if (!value) return DEFAULT_LIMIT
+
+  const parsed = Number.parseInt(value, 10)
+  return Number.isFinite(parsed) ? parsed : DEFAULT_LIMIT
+}
+
+export async function GET(req: NextRequest) {
+  try {
+    const { searchParams } = new URL(req.url)
+    const q = (searchParams.get('q') ?? '').trim()
+    const currentCasaId = searchParams.get('casaId') ?? undefined
+    const limit = parseLimit(searchParams.get('limit'))
+
+    const supabase = await createSupabaseServerClient()
+    const { data: { user }, error: authError } = await supabase.auth.getUser()
+
+    if (authError || !user) {
+      return NextResponse.json({ error: 'No autenticado' }, { status: 401 })
+    }
+
+    if (currentCasaId) {
+      const { data: puedeEditar, error: permissionError } = await supabase.rpc('puede_editar_casa_anfitriona', {
+        p_auth_id: user.id,
+        p_casa_id: currentCasaId,
+      })
+
+      if (permissionError || puedeEditar !== true) {
+        return NextResponse.json({ error: 'No tienes permisos para editar esta casa' }, { status: 403 })
+      }
+    }
+
+    const { data: permisosCasa, error: permisosError } = await supabase.rpc(
+      'obtener_permisos_casa_anfitriona',
+      currentCasaId
+        ? { p_auth_id: user.id, p_casa_id: currentCasaId }
+        : { p_auth_id: user.id }
+    )
+
+    if (permisosError || !puedeAsignarPropietarios(permisosCasa)) {
+      return NextResponse.json({ error: 'No tienes permisos para asignar propietarios' }, { status: 403 })
+    }
+
+    const adminDb = createSupabaseAdminClient()
+    const usuarios = await obtenerUsuariosAsignablesCasaAnfitriona({
+      supabase,
+      adminDb,
+      authId: user.id,
+      currentCasaId,
+      busqueda: q,
+      limit,
+    })
+
+    return NextResponse.json({ usuarios })
+  } catch (error) {
+    console.error('[casas-anfitrionas/propietarios/buscar] Error:', error)
+
+    return NextResponse.json(
+      { error: 'Error al buscar propietarios' },
+      { status: 500 }
+    )
+  }
+}

--- a/components/grupos-vida/form-casa-anfitriona.tsx
+++ b/components/grupos-vida/form-casa-anfitriona.tsx
@@ -16,6 +16,7 @@ import {
 import { Home, MapPin, Hash, Save, Loader2, User, Users, Check, X } from "lucide-react";
 import { Label } from "@/components/ui/label";
 import LocationPicker from "@/components/maps/LocationPicker.client";
+import { SelectorPropietarioCasa } from "@/components/grupos-vida/selector-propietario-casa";
 
 const schemaCasaAnfitriona = z.object({
     nombre_lugar: z.string().min(2, "Nombre del lugar es requerido"),
@@ -57,6 +58,12 @@ interface UbicacionOption {
 interface UsuarioOption {
     value: string;
     label: string;
+    email?: string | null;
+    cedula?: string | null;
+    fotoPerfilUrl?: string | null;
+    yaTieneCasa?: boolean;
+    puedeSeleccionar?: boolean;
+    razonNoSeleccionable?: string;
 }
 
 interface FormCasaAnfitrionaProps {
@@ -71,6 +78,7 @@ interface FormCasaAnfitrionaProps {
     usuarios?: UsuarioOption[];
     /** Si true, muestra selector de usuario (admin/líder) */
     mostrarSelectorUsuario?: boolean;
+    casaId?: string;
     cargando?: boolean;
     onSubmit: (datos: FormCasaData) => Promise<void>;
     onCancelar: () => void;
@@ -102,6 +110,7 @@ export function FormCasaAnfitriona({
     parroquias,
     usuarios = [],
     mostrarSelectorUsuario = false,
+    casaId,
     cargando = false,
     onSubmit,
     onCancelar,
@@ -350,25 +359,22 @@ export function FormCasaAnfitriona({
     return (
         <form onSubmit={handleSubmit(processSubmit)} className="space-y-6">
             {/* Selector de usuario (solo admin/líder) */}
-            {mostrarSelectorUsuario && usuarios.length > 0 && (
+            {mostrarSelectorUsuario && (
                 <div className="space-y-4">
                     <TituloSistema nivel={4}>Propietario de la casa</TituloSistema>
                     <Controller
                         name="usuario_id"
                         control={control}
                         render={({ field }) => (
-                            <SelectSistema
-                                label="¿A quién pertenece esta casa?"
-                                placeholder="Seleccionar miembro..."
-                                onValueChange={(val) => {
+                            <SelectorPropietarioCasa
+                                value={field.value}
+                                usuariosIniciales={usuarios}
+                                casaId={casaId}
+                                disabled={cargando}
+                                onChange={(val) => {
                                     field.onChange(val);
                                     handleUsuarioChange(val);
                                 }}
-                                value={field.value}
-                                opciones={usuarios.map((u) => ({
-                                    valor: u.value,
-                                    etiqueta: u.label,
-                                }))}
                             />
                         )}
                     />

--- a/components/grupos-vida/selector-propietario-casa.tsx
+++ b/components/grupos-vida/selector-propietario-casa.tsx
@@ -1,0 +1,286 @@
+"use client";
+
+import { useEffect, useMemo, useRef, useState } from "react";
+import { Check, Home, Loader2, Search, User, X, type LucideIcon } from "lucide-react";
+import { BadgeSistema, BotonSistema, InputSistema } from "@/components/ui/sistema-diseno";
+import { Dialog, DialogContent, DialogDescription, DialogHeader, DialogTitle } from "@/components/ui/dialog";
+import { UserAvatar } from "@/components/ui/UserAvatar";
+
+export interface UsuarioCasaOption {
+    value: string;
+    label: string;
+    email?: string | null;
+    cedula?: string | null;
+    fotoPerfilUrl?: string | null;
+    yaTieneCasa?: boolean;
+    puedeSeleccionar?: boolean;
+    razonNoSeleccionable?: string;
+}
+
+interface SelectorPropietarioCasaProps {
+    value?: string;
+    usuariosIniciales?: UsuarioCasaOption[];
+    casaId?: string;
+    disabled?: boolean;
+    onChange: (usuarioId: string) => void;
+}
+
+function getNombrePartes(usuario: UsuarioCasaOption) {
+    const [nombre = usuario.label, ...resto] = usuario.label.split(" ");
+    return { nombre, apellido: resto.join(" ") };
+}
+
+export function SelectorPropietarioCasa({
+    value,
+    usuariosIniciales = [],
+    casaId,
+    disabled = false,
+    onChange,
+}: SelectorPropietarioCasaProps) {
+    const [open, setOpen] = useState(false);
+    const [query, setQuery] = useState("");
+    const [loading, setLoading] = useState(false);
+    const [error, setError] = useState<string | null>(null);
+    const [resultados, setResultados] = useState<UsuarioCasaOption[]>([]);
+    const timeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+    const abortRef = useRef<AbortController | null>(null);
+    const requestSeqRef = useRef(0);
+
+    const selectedUser = useMemo(
+        () => [...usuariosIniciales, ...resultados].find((usuario) => usuario.value === value) ?? null,
+        [resultados, usuariosIniciales, value]
+    );
+
+    useEffect(() => {
+        if (!open) return;
+
+        if (timeoutRef.current) clearTimeout(timeoutRef.current);
+
+        const trimmedQuery = query.trim();
+        if (trimmedQuery.length < 2) {
+            requestSeqRef.current += 1;
+            abortRef.current?.abort();
+            setResultados([]);
+            setError(null);
+            setLoading(false);
+            return;
+        }
+
+        timeoutRef.current = setTimeout(async () => {
+            abortRef.current?.abort();
+            const controller = new AbortController();
+            const requestSeq = requestSeqRef.current + 1;
+            requestSeqRef.current = requestSeq;
+            abortRef.current = controller;
+            setLoading(true);
+            setError(null);
+
+            const isCurrentRequest = () =>
+                requestSeqRef.current === requestSeq &&
+                abortRef.current === controller &&
+                !controller.signal.aborted;
+
+            try {
+                const params = new URLSearchParams({ q: trimmedQuery, limit: "30" });
+                if (casaId) params.set("casaId", casaId);
+
+                const response = await fetch(`/api/casas-anfitrionas/propietarios/buscar?${params.toString()}`, {
+                    cache: "no-store",
+                    signal: controller.signal,
+                });
+
+                if (!response.ok) {
+                    const payload = await response.json().catch(() => null);
+                    throw new Error(payload?.error ?? "No se pudo buscar propietarios");
+                }
+
+                const payload = await response.json();
+                if (!isCurrentRequest()) return;
+                setResultados(Array.isArray(payload.usuarios) ? payload.usuarios : []);
+            } catch (err) {
+                if (err instanceof Error && err.name === "AbortError") return;
+                if (!isCurrentRequest()) return;
+                setResultados([]);
+                setError(err instanceof Error ? err.message : "Error al buscar propietarios");
+            } finally {
+                if (isCurrentRequest()) setLoading(false);
+            }
+        }, 300);
+
+        return () => {
+            requestSeqRef.current += 1;
+            if (timeoutRef.current) clearTimeout(timeoutRef.current);
+            abortRef.current?.abort();
+        };
+    }, [casaId, open, query]);
+
+    const handleSelect = (usuario: UsuarioCasaOption) => {
+        if (usuario.puedeSeleccionar === false) return;
+        onChange(usuario.value);
+        setOpen(false);
+        setQuery("");
+        setResultados([]);
+    };
+
+    return (
+        <div className="space-y-2">
+            <label className="block text-sm font-medium text-foreground">¿A quién pertenece esta casa?</label>
+            <div className="rounded-2xl border border-border bg-card/50 p-4">
+                {selectedUser ? (
+                    <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+                        <div className="flex items-center gap-3 min-w-0">
+                            <AvatarUsuario usuario={selectedUser} />
+                            <div className="min-w-0">
+                                <p className="font-medium text-foreground truncate">{selectedUser.label}</p>
+                                <p className="text-sm text-muted-foreground truncate">
+                                    {selectedUser.email || "Sin correo"} · C.I. {selectedUser.cedula || "sin cédula"}
+                                </p>
+                            </div>
+                        </div>
+                        <BotonSistema type="button" variante="outline" onClick={() => setOpen(true)} disabled={disabled}>
+                            Cambiar propietario
+                        </BotonSistema>
+                    </div>
+                ) : (
+                    <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+                        <div className="flex items-center gap-3 text-muted-foreground">
+                            <div className="flex h-10 w-10 items-center justify-center rounded-full bg-muted">
+                                <Home className="h-5 w-5" />
+                            </div>
+                            <div>
+                                <p className="text-sm font-medium text-foreground">Sin propietario seleccionado</p>
+                                <p className="text-xs">Busca por nombre, apellido, cédula o correo.</p>
+                            </div>
+                        </div>
+                        <BotonSistema type="button" variante="primario" onClick={() => setOpen(true)} disabled={disabled}>
+                            Buscar propietario
+                        </BotonSistema>
+                    </div>
+                )}
+            </div>
+
+            <Dialog open={open} onOpenChange={setOpen}>
+                <DialogContent className="max-w-2xl max-h-[90vh] overflow-hidden">
+                    <DialogHeader>
+                        <DialogTitle>Seleccionar propietario</DialogTitle>
+                        <DialogDescription>
+                            Solo aparecen personas activas en un grupo de vida y dentro de tu alcance de permisos.
+                        </DialogDescription>
+                    </DialogHeader>
+
+                    <div className="space-y-4">
+                        <InputSistema
+                            autoFocus
+                            icono={Search}
+                            label="Buscar persona"
+                            placeholder="Nombre, apellido, cédula o correo..."
+                            value={query}
+                            onChange={(event) => setQuery(event.target.value)}
+                        />
+
+                        <div className="rounded-2xl border border-border bg-card/50 overflow-hidden">
+                            <div className="max-h-80 overflow-y-auto">
+                                {query.trim().length < 2 && (
+                                    <EstadoVacio icono={Search} texto="Escribe al menos 2 caracteres para buscar." />
+                                )}
+
+                                {query.trim().length >= 2 && loading && (
+                                    <EstadoVacio icono={Loader2} texto="Buscando personas..." animado />
+                                )}
+
+                                {query.trim().length >= 2 && !loading && error && (
+                                    <EstadoVacio icono={X} texto={error} variante="error" />
+                                )}
+
+                                {query.trim().length >= 2 && !loading && !error && resultados.length === 0 && (
+                                    <EstadoVacio icono={User} texto="No se encontraron personas disponibles con ese criterio." />
+                                )}
+
+                                {resultados.map((usuario) => (
+                                    <button
+                                        key={usuario.value}
+                                        type="button"
+                                        disabled={usuario.puedeSeleccionar === false}
+                                        onClick={() => handleSelect(usuario)}
+                                        className={`w-full border-b border-border last:border-b-0 p-3 text-left transition-colors ${
+                                            usuario.puedeSeleccionar === false
+                                                ? "cursor-not-allowed bg-muted/60 opacity-70"
+                                                : value === usuario.value
+                                                    ? "bg-accent"
+                                                    : "hover:bg-accent/50"
+                                        }`}
+                                    >
+                                        <div className="flex items-center gap-3">
+                                            <AvatarUsuario usuario={usuario} />
+                                            <div className="min-w-0 flex-1">
+                                                <div className="flex flex-wrap items-center gap-2">
+                                                    <span className="font-medium text-foreground truncate">{usuario.label}</span>
+                                                    {usuario.yaTieneCasa ? (
+                                                        <BadgeSistema variante="warning" tamaño="sm">Ya tiene casa</BadgeSistema>
+                                                    ) : (
+                                                        <BadgeSistema variante="success" tamaño="sm">Disponible</BadgeSistema>
+                                                    )}
+                                                </div>
+                                                <p className="text-sm text-muted-foreground truncate">
+                                                    {usuario.email || "Sin correo"} · C.I. {usuario.cedula || "sin cédula"}
+                                                </p>
+                                                {usuario.razonNoSeleccionable && (
+                                                    <p className="mt-1 text-xs text-amber-700 dark:text-amber-400">
+                                                        {usuario.razonNoSeleccionable}
+                                                    </p>
+                                                )}
+                                            </div>
+                                            {value === usuario.value && (
+                                                <div className="flex h-7 w-7 items-center justify-center rounded-full bg-[var(--brand-primary)] text-white">
+                                                    <Check className="h-4 w-4" />
+                                                </div>
+                                            )}
+                                        </div>
+                                    </button>
+                                ))}
+                            </div>
+                        </div>
+
+                        <div className="flex justify-end">
+                            <BotonSistema type="button" variante="outline" onClick={() => setOpen(false)}>
+                                Cancelar
+                            </BotonSistema>
+                        </div>
+                    </div>
+                </DialogContent>
+            </Dialog>
+        </div>
+    );
+}
+
+function AvatarUsuario({ usuario }: { usuario: UsuarioCasaOption }) {
+    const { nombre, apellido } = getNombrePartes(usuario);
+
+    return (
+        <UserAvatar
+            photoUrl={usuario.fotoPerfilUrl ?? null}
+            nombre={nombre}
+            apellido={apellido}
+            size="md"
+        />
+    );
+}
+
+function EstadoVacio({
+    icono: Icono,
+    texto,
+    animado = false,
+    variante = "default",
+}: {
+    icono: LucideIcon;
+    texto: string;
+    animado?: boolean;
+    variante?: "default" | "error";
+}) {
+    return (
+        <div className={`flex items-center gap-2 p-4 text-sm ${variante === "error" ? "text-red-600 dark:text-red-400" : "text-muted-foreground"}`}>
+            <Icono className={`h-4 w-4 ${animado ? "animate-spin" : ""}`} />
+            {texto}
+        </div>
+    );
+}

--- a/lib/actions/casas-anfitrionas.actions.ts
+++ b/lib/actions/casas-anfitrionas.actions.ts
@@ -178,6 +178,72 @@ async function verificarUsuarioEnScope(
   return puede ? null : error;
 }
 
+async function verificarUsuarioEnGrupoActivo(
+  adminDb: ReturnType<typeof createSupabaseAdminClient>,
+  usuarioId: string,
+  error: string
+): Promise<string | null> {
+  const { data, error: queryError } = await adminDb
+    .from("grupo_miembros")
+    .select("id, grupos!inner(id)")
+    .eq("usuario_id", usuarioId)
+    .is("fecha_salida", null)
+    .eq("grupos.activo", true)
+    .eq("grupos.eliminado", false)
+    .limit(1);
+
+  if (queryError) return queryError.message;
+  return data && data.length > 0 ? null : error;
+}
+
+async function verificarUsuarioSinCasaAsignada(
+  adminDb: ReturnType<typeof createSupabaseAdminClient>,
+  usuarioId: string,
+  currentCasaId: string | undefined,
+  error: string
+): Promise<string | null> {
+  let query = adminDb
+    .from("casas_anfitrionas")
+    .select("id")
+    .or(`usuario_id.eq.${usuarioId},co_anfitrion_id.eq.${usuarioId}`);
+
+  if (currentCasaId) {
+    query = query.neq("id", currentCasaId);
+  }
+
+  const { data, error: queryError } = await query.limit(1);
+  if (queryError) return queryError.message;
+  return data && data.length > 0 ? error : null;
+}
+
+async function validarUsuarioAsignableACasa({
+  adminDb,
+  usuarioId,
+  currentCasaId,
+  etiqueta,
+}: {
+  adminDb: ReturnType<typeof createSupabaseAdminClient>;
+  usuarioId: string;
+  currentCasaId?: string;
+  etiqueta: "propietario" | "co-anfitrión";
+}): Promise<string | null> {
+  const groupError = await verificarUsuarioEnGrupoActivo(
+    adminDb,
+    usuarioId,
+    `El ${etiqueta} debe pertenecer actualmente a un grupo de vida`
+  );
+  if (groupError) return groupError;
+
+  return verificarUsuarioSinCasaAsignada(
+    adminDb,
+    usuarioId,
+    currentCasaId,
+    etiqueta === "propietario"
+      ? "Este usuario ya tiene una casa anfitriona asignada"
+      : "Este co-anfitrión ya tiene una casa anfitriona asignada"
+  );
+}
+
 async function validarUsuarioConsultable(usuarioId: string): Promise<string | null> {
   const { supabase, authId, error } = await validarAuthYPermisos();
   if (error) return error;
@@ -394,6 +460,22 @@ export async function crearCasaAnfitriona(
 
     const adminDb = createSupabaseAdminClient();
 
+    const ownerAssignmentError = await validarUsuarioAsignableACasa({
+      adminDb,
+      usuarioId: propietarioId,
+      etiqueta: "propietario",
+    });
+    if (ownerAssignmentError) return { success: false, error: ownerAssignmentError };
+
+    if (parsed.co_anfitrion_id) {
+      const coHostAssignmentError = await validarUsuarioAsignableACasa({
+        adminDb,
+        usuarioId: parsed.co_anfitrion_id,
+        etiqueta: "co-anfitrión",
+      });
+      if (coHostAssignmentError) return { success: false, error: coHostAssignmentError };
+    }
+
     // 1. Crear dirección con lat/lng
     const { data: direccion, error: dirError } = await adminDb
       .from("direcciones")
@@ -498,6 +580,26 @@ export async function actualizarCasaAnfitriona(
       .single();
 
     if (!casa) return { success: false, error: "Casa no encontrada" };
+
+    if (parsed.usuario_id) {
+      const ownerAssignmentError = await validarUsuarioAsignableACasa({
+        adminDb,
+        usuarioId: parsed.usuario_id,
+        currentCasaId: casaId,
+        etiqueta: "propietario",
+      });
+      if (ownerAssignmentError) return { success: false, error: ownerAssignmentError };
+    }
+
+    if (parsed.co_anfitrion_id) {
+      const coHostAssignmentError = await validarUsuarioAsignableACasa({
+        adminDb,
+        usuarioId: parsed.co_anfitrion_id,
+        currentCasaId: casaId,
+        etiqueta: "co-anfitrión",
+      });
+      if (coHostAssignmentError) return { success: false, error: coHostAssignmentError };
+    }
 
     // Actualizar dirección si hay cambios
     if (casa.direccion_id && (parsed.calle || parsed.barrio || parsed.codigo_postal || parsed.referencia || parsed.parroquia_id || parsed.lat !== undefined || parsed.lng !== undefined)) {

--- a/lib/casas-anfitrionas/assignable-users.ts
+++ b/lib/casas-anfitrionas/assignable-users.ts
@@ -7,10 +7,134 @@ type AdminClient = ReturnType<typeof createSupabaseAdminClient>
 export interface UsuarioAsignableCasaOption {
   value: string
   label: string
+  email?: string | null
+  cedula?: string | null
+  fotoPerfilUrl?: string | null
+  yaTieneCasa?: boolean
+  puedeSeleccionar?: boolean
+  razonNoSeleccionable?: string
 }
 
-type UsuarioRow = { id: string; nombre: string | null; apellido: string | null }
+type UsuarioRow = {
+  id: string
+  nombre: string | null
+  apellido: string | null
+  email?: string | null
+  cedula?: string | null
+  foto_perfil_url?: string | null
+}
 type CasaOcupacionRow = { id?: string | null; usuario_id: string | null; co_anfitrion_id: string | null }
+type UsuarioPermisosRow = UsuarioRow & { puede_ver?: boolean | null }
+
+const MIN_SEARCH_LENGTH = 2
+const MAX_SEARCH_RESULTS = 50
+const DEFAULT_SEARCH_RESULTS = 30
+
+function normalizarLimiteBusqueda(limit: number): number {
+  if (!Number.isFinite(limit)) return DEFAULT_SEARCH_RESULTS
+
+  return Math.min(Math.max(Math.trunc(limit), 1), MAX_SEARCH_RESULTS)
+}
+
+function crearUsuarioOption(
+  usuario: UsuarioRow,
+  idsOcupados: Set<string>,
+  puedeSeleccionar = true
+): UsuarioAsignableCasaOption {
+  const yaTieneCasa = idsOcupados.has(usuario.id)
+  const noTienePermiso = !puedeSeleccionar
+
+  return {
+    value: usuario.id,
+    label: `${usuario.nombre ?? ''} ${usuario.apellido ?? ''}`.trim(),
+    email: usuario.email ?? null,
+    cedula: usuario.cedula ?? null,
+    fotoPerfilUrl: usuario.foto_perfil_url ?? null,
+    yaTieneCasa,
+    puedeSeleccionar: puedeSeleccionar && !yaTieneCasa,
+    razonNoSeleccionable: yaTieneCasa
+      ? 'Ya tiene casa asignada'
+      : noTienePermiso
+        ? 'No tienes permisos para asignar esta persona'
+        : undefined,
+  }
+}
+
+function normalizarCurrentOwner(
+  currentOwner: UsuarioAsignableCasaOption | null | undefined
+): UsuarioAsignableCasaOption | null {
+  if (!currentOwner) return null
+
+  return {
+    ...currentOwner,
+    yaTieneCasa: currentOwner.yaTieneCasa ?? false,
+    puedeSeleccionar: currentOwner.puedeSeleccionar ?? true,
+  }
+}
+
+async function obtenerIdsConCasaAsignada({
+  adminDb,
+  usuarioIds,
+  currentCasaId,
+}: {
+  adminDb: AdminClient
+  usuarioIds: string[]
+  currentCasaId?: string
+}) {
+  if (usuarioIds.length === 0) return new Set<string>()
+
+  let query = adminDb
+    .from('casas_anfitrionas')
+    .select('id, usuario_id, co_anfitrion_id')
+    .or(`usuario_id.in.(${usuarioIds.join(',')}),co_anfitrion_id.in.(${usuarioIds.join(',')})`)
+
+  if (currentCasaId) {
+    query = query.neq('id', currentCasaId)
+  }
+
+  const { data, error } = await query
+  if (error) throw new Error(error.message)
+
+  return new Set(
+    ((data ?? []) as CasaOcupacionRow[])
+      .flatMap((casa) => [casa.usuario_id, casa.co_anfitrion_id])
+      .filter((id): id is string => Boolean(id))
+  )
+}
+
+async function obtenerIdsEnGrupoActivo(adminDb: AdminClient, usuarioIds: string[]) {
+  if (usuarioIds.length === 0) return new Set<string>()
+
+  const { data, error } = await adminDb
+    .from('grupo_miembros')
+    .select('usuario_id, grupos!inner(id)')
+    .in('usuario_id', usuarioIds)
+    .is('fecha_salida', null)
+    .eq('grupos.activo', true)
+    .eq('grupos.eliminado', false)
+
+  if (error) throw new Error(error.message)
+
+  return new Set((data ?? []).map((m) => m.usuario_id).filter(Boolean))
+}
+
+async function puedeAsignarUsuario({
+  supabase,
+  authId,
+  usuarioId,
+}: {
+  supabase: ServerClient
+  authId: string
+  usuarioId: string
+}) {
+  const { data, error } = await supabase.rpc('puede_crear_casa_anfitriona_para', {
+    p_auth_id: authId,
+    p_usuario_id: usuarioId,
+  })
+
+  if (error) return false
+  return data === true
+}
 
 export async function obtenerUsuariosAsignablesCasaAnfitriona({
   supabase,
@@ -18,39 +142,66 @@ export async function obtenerUsuariosAsignablesCasaAnfitriona({
   authId,
   currentCasaId,
   currentOwner,
+  busqueda = '',
+  limit = 30,
 }: {
   supabase: ServerClient
   adminDb: AdminClient
   authId: string
   currentCasaId?: string
   currentOwner?: UsuarioAsignableCasaOption | null
+  busqueda?: string
+  limit?: number
 }): Promise<UsuarioAsignableCasaOption[]> {
-  const [{ data: usuarios }, { data: casasExistentes }] = await Promise.all([
-    adminDb.from('usuarios').select('id, nombre, apellido').order('nombre'),
-    adminDb.from('casas_anfitrionas').select('id, usuario_id, co_anfitrion_id'),
+  const termino = busqueda.trim()
+  const limite = normalizarLimiteBusqueda(limit)
+  const currentOwnerNormalizado = normalizarCurrentOwner(currentOwner)
+  const currentOwnerId = currentOwnerNormalizado?.value
+
+  if (termino.length < MIN_SEARCH_LENGTH) {
+    return [currentOwnerNormalizado].filter((usuario): usuario is UsuarioAsignableCasaOption => Boolean(usuario))
+  }
+
+  const { data: usuariosPermitidos, error: usuariosError } = await supabase.rpc('listar_usuarios_con_permisos', {
+    p_auth_id: authId,
+    p_busqueda: termino,
+    p_roles_filtro: [],
+    p_con_email: undefined,
+    p_con_telefono: undefined,
+    p_en_grupo: true,
+    p_limite: limite,
+    p_offset: 0,
+    p_contexto_relacion: true,
+  })
+
+  if (usuariosError) {
+    throw new Error(usuariosError.message)
+  }
+
+  const idsVisibles = ((usuariosPermitidos ?? []) as UsuarioPermisosRow[])
+    .filter((usuario) => usuario.id && usuario.id !== currentOwnerId)
+    .map((usuario) => usuario.id)
+
+  if (idsVisibles.length === 0) {
+    return [currentOwnerNormalizado].filter((usuario): usuario is UsuarioAsignableCasaOption => Boolean(usuario))
+  }
+
+  const [idsEnGrupoActivo, idsOcupados] = await Promise.all([
+    obtenerIdsEnGrupoActivo(adminDb, idsVisibles),
+    obtenerIdsConCasaAsignada({ adminDb, usuarioIds: idsVisibles, currentCasaId }),
   ])
 
-  const idsOcupados = new Set(
-    ((casasExistentes ?? []) as CasaOcupacionRow[])
-      .filter((casa) => !currentCasaId || casa.id !== currentCasaId)
-      .flatMap((casa) => [casa.usuario_id, casa.co_anfitrion_id])
-      .filter((id): id is string => Boolean(id))
-  )
-  const currentOwnerId = currentOwner?.value
-  const candidatos = ((usuarios ?? []) as UsuarioRow[])
-    .filter((usuario: UsuarioRow) => usuario.id !== currentOwnerId && !idsOcupados.has(usuario.id))
-    .map((usuario) => ({ value: usuario.id, label: `${usuario.nombre ?? ''} ${usuario.apellido ?? ''}`.trim() }))
+  const candidatos = ((usuariosPermitidos ?? []) as UsuarioPermisosRow[])
+    .filter((usuario) => usuario.id !== currentOwnerId && idsEnGrupoActivo.has(usuario.id))
 
   const permisos = await Promise.all(
     candidatos.map(async (usuario) => {
-      const { data, error } = await supabase.rpc('puede_crear_casa_anfitriona_para', {
-        p_auth_id: authId,
-        p_usuario_id: usuario.value,
-      })
+      const puedeSeleccionarPorScope = await puedeAsignarUsuario({ supabase, authId, usuarioId: usuario.id })
+      if (!puedeSeleccionarPorScope) return null
 
-      return !error && data === true ? usuario : null
+      return crearUsuarioOption(usuario, idsOcupados)
     })
   )
 
-  return [currentOwner, ...permisos].filter((usuario): usuario is UsuarioAsignableCasaOption => Boolean(usuario))
+  return [currentOwnerNormalizado, ...permisos].filter((usuario): usuario is UsuarioAsignableCasaOption => Boolean(usuario))
 }

--- a/supabase/migrations/20260618180543_prevent_duplicate_casa_assignees.sql
+++ b/supabase/migrations/20260618180543_prevent_duplicate_casa_assignees.sql
@@ -1,0 +1,69 @@
+-- Prevent concurrent duplicate Casas Anfitrionas assignments.
+-- This migration adds DB-level protection for both owner and co-host assignments
+-- without repairing, deleting, or rewriting existing production data.
+
+CREATE INDEX IF NOT EXISTS idx_casas_co_anfitrion
+ON public.casas_anfitrionas(co_anfitrion_id)
+WHERE co_anfitrion_id IS NOT NULL;
+
+CREATE OR REPLACE FUNCTION public.prevent_duplicate_casa_anfitriona_assignees()
+RETURNS trigger
+LANGUAGE plpgsql
+SET search_path TO 'public'
+AS $$
+DECLARE
+  v_assignee_ids uuid[];
+  v_assignee_id uuid;
+  v_conflict_id uuid;
+BEGIN
+  IF NEW.usuario_id IS NULL THEN
+    RETURN NEW;
+  END IF;
+
+  IF NEW.co_anfitrion_id IS NOT NULL AND NEW.co_anfitrion_id = NEW.usuario_id THEN
+    RAISE EXCEPTION USING
+      ERRCODE = '23514',
+      MESSAGE = 'El propietario y co-anfitrión deben ser usuarios distintos';
+  END IF;
+
+  SELECT array_agg(id ORDER BY id::text)
+  INTO v_assignee_ids
+  FROM (
+    SELECT NEW.usuario_id AS id
+    UNION
+    SELECT NEW.co_anfitrion_id AS id WHERE NEW.co_anfitrion_id IS NOT NULL
+  ) assignees;
+
+  FOREACH v_assignee_id IN ARRAY v_assignee_ids LOOP
+    PERFORM pg_advisory_xact_lock(
+      hashtextextended('casas_anfitrionas_assignee:' || v_assignee_id::text, 0)
+    );
+  END LOOP;
+
+  SELECT ca.id
+  INTO v_conflict_id
+  FROM public.casas_anfitrionas ca
+  WHERE ca.id IS DISTINCT FROM NEW.id
+    AND (
+      ca.usuario_id = ANY(v_assignee_ids)
+      OR ca.co_anfitrion_id = ANY(v_assignee_ids)
+    )
+  LIMIT 1;
+
+  IF v_conflict_id IS NOT NULL THEN
+    RAISE EXCEPTION USING
+      ERRCODE = '23505',
+      MESSAGE = 'El propietario o co-anfitrión ya tiene una casa anfitriona asignada';
+  END IF;
+
+  RETURN NEW;
+END;
+$$;
+
+DROP TRIGGER IF EXISTS ensure_unique_casa_anfitriona_assignees ON public.casas_anfitrionas;
+
+CREATE TRIGGER ensure_unique_casa_anfitriona_assignees
+BEFORE INSERT OR UPDATE OF usuario_id, co_anfitrion_id
+ON public.casas_anfitrionas
+FOR EACH ROW
+EXECUTE FUNCTION public.prevent_duplicate_casa_anfitriona_assignees();

--- a/supabase/migrations/20260618181650_harden_listar_usuarios_con_permisos_search.sql
+++ b/supabase/migrations/20260618181650_harden_listar_usuarios_con_permisos_search.sql
@@ -1,0 +1,205 @@
+-- Harden listar_usuarios_con_permisos search by removing dynamic SQL interpolation.
+-- Search input is treated as literal text, including quotes and LIKE metacharacters.
+
+CREATE OR REPLACE FUNCTION public.listar_usuarios_con_permisos(
+  p_auth_id uuid,
+  p_busqueda text DEFAULT '',
+  p_roles_filtro text[] DEFAULT '{}',
+  p_con_email boolean DEFAULT NULL,
+  p_con_telefono boolean DEFAULT NULL,
+  p_en_grupo boolean DEFAULT NULL,
+  p_limite integer DEFAULT 20,
+  p_offset integer DEFAULT 0,
+  p_contexto_relacion boolean DEFAULT false
+)
+RETURNS TABLE (
+  id uuid,
+  nombre text,
+  apellido text,
+  email text,
+  telefono text,
+  cedula text,
+  fecha_registro timestamptz,
+  rol_nombre_interno text,
+  rol_nombre_visible text,
+  foto_perfil_url text,
+  total_count bigint,
+  puede_ver boolean
+)
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path TO 'public'
+AS $$
+DECLARE
+  usuario_rol text;
+  usuario_interno_id uuid;
+  v_busqueda_like text;
+  v_limite integer := greatest(coalesce(p_limite, 20), 0);
+  v_offset integer := greatest(coalesce(p_offset, 0), 0);
+BEGIN
+  SELECT u.id, rs.nombre_interno
+  INTO usuario_interno_id, usuario_rol
+  FROM public.usuarios u
+  JOIN public.usuario_roles ur ON u.id = ur.usuario_id
+  JOIN public.roles_sistema rs ON ur.rol_id = rs.id
+  WHERE u.auth_id = p_auth_id
+  LIMIT 1;
+
+  IF usuario_interno_id IS NULL THEN
+    RETURN;
+  END IF;
+
+  v_busqueda_like := replace(
+    replace(
+      replace(trim(coalesce(p_busqueda, '')), E'\\', E'\\\\'),
+      '%',
+      E'\\%'
+    ),
+    '_',
+    E'\\_'
+  );
+
+  RETURN QUERY
+  WITH usuarios_visibles AS MATERIALIZED (
+    SELECT DISTINCT
+      u.id,
+      u.nombre,
+      u.apellido,
+      u.email,
+      u.telefono,
+      u.cedula,
+      u.fecha_registro,
+      rs.nombre_interno AS rol_nombre_interno,
+      rs.nombre_visible AS rol_nombre_visible,
+      u.foto_perfil_url,
+      true AS puede_ver
+    FROM public.usuarios u
+    LEFT JOIN public.usuario_roles ur ON u.id = ur.usuario_id
+    LEFT JOIN public.roles_sistema rs ON ur.rol_id = rs.id
+    WHERE (
+      usuario_rol IN ('admin', 'pastor', 'director-general')
+      OR (usuario_rol = 'director-etapa' AND p_contexto_relacion IS TRUE)
+      OR (
+        usuario_rol = 'director-etapa'
+        AND p_contexto_relacion IS NOT TRUE
+        AND EXISTS (
+          SELECT 1
+          FROM public.director_etapa_grupos deg
+          JOIN public.segmento_lideres sl
+            ON deg.director_etapa_id = sl.id
+            AND sl.usuario_id = usuario_interno_id
+            AND sl.tipo_lider = 'director_etapa'
+          JOIN public.grupo_miembros gm
+            ON gm.grupo_id = deg.grupo_id
+            AND gm.fecha_salida IS NULL
+          WHERE gm.usuario_id = u.id
+        )
+      )
+      OR (usuario_rol = 'lider' AND p_contexto_relacion IS TRUE)
+      OR (
+        usuario_rol = 'lider'
+        AND p_contexto_relacion IS NOT TRUE
+        AND EXISTS (
+          SELECT 1
+          FROM public.grupo_miembros gm
+          JOIN public.grupo_miembros gm_lider
+            ON gm.grupo_id = gm_lider.grupo_id
+          WHERE gm.usuario_id = u.id
+            AND gm.fecha_salida IS NULL
+            AND gm_lider.usuario_id = usuario_interno_id
+            AND gm_lider.rol = 'Líder'
+            AND gm_lider.fecha_salida IS NULL
+        )
+      )
+      OR (
+        usuario_rol = 'miembro'
+        AND (
+          u.familia_id = (SELECT u2.familia_id FROM public.usuarios u2 WHERE u2.id = usuario_interno_id)
+          OR u.id IN (
+            SELECT CASE
+              WHEN ru.usuario1_id = usuario_interno_id THEN ru.usuario2_id
+              ELSE ru.usuario1_id
+            END
+            FROM public.relaciones_usuarios ru
+            WHERE ru.usuario1_id = usuario_interno_id OR ru.usuario2_id = usuario_interno_id
+          )
+          OR u.id = usuario_interno_id
+        )
+      )
+    )
+      AND (
+        v_busqueda_like = ''
+        OR u.nombre ILIKE '%' || v_busqueda_like || '%' ESCAPE E'\\'
+        OR u.apellido ILIKE '%' || v_busqueda_like || '%' ESCAPE E'\\'
+        OR u.email ILIKE '%' || v_busqueda_like || '%' ESCAPE E'\\'
+        OR u.cedula ILIKE '%' || v_busqueda_like || '%' ESCAPE E'\\'
+      )
+      AND (
+        p_roles_filtro IS NULL
+        OR cardinality(p_roles_filtro) = 0
+        OR rs.nombre_interno = ANY(p_roles_filtro)
+      )
+      AND (
+        p_con_email IS NULL
+        OR (p_con_email IS TRUE AND nullif(u.email, '') IS NOT NULL)
+        OR (p_con_email IS FALSE AND nullif(u.email, '') IS NULL)
+      )
+      AND (
+        p_con_telefono IS NULL
+        OR (p_con_telefono IS TRUE AND nullif(u.telefono, '') IS NOT NULL)
+        OR (p_con_telefono IS FALSE AND nullif(u.telefono, '') IS NULL)
+      )
+      AND (
+        p_en_grupo IS NULL
+        OR (
+          p_en_grupo IS TRUE
+          AND EXISTS (
+            SELECT 1
+            FROM public.grupo_miembros gm2
+            JOIN public.grupos g2 ON g2.id = gm2.grupo_id
+            WHERE gm2.usuario_id = u.id
+              AND gm2.fecha_salida IS NULL
+              AND g2.activo = true
+              AND g2.eliminado = false
+          )
+        )
+        OR (
+          p_en_grupo IS FALSE
+          AND NOT EXISTS (
+            SELECT 1
+            FROM public.grupo_miembros gm2
+            JOIN public.grupos g2 ON g2.id = gm2.grupo_id
+            WHERE gm2.usuario_id = u.id
+              AND gm2.fecha_salida IS NULL
+              AND g2.activo = true
+              AND g2.eliminado = false
+          )
+        )
+      )
+  ), total AS (
+    SELECT count(DISTINCT uv.id)::bigint AS total_count
+    FROM usuarios_visibles uv
+  )
+  SELECT
+    uv.id,
+    uv.nombre,
+    uv.apellido,
+    uv.email,
+    uv.telefono,
+    uv.cedula,
+    uv.fecha_registro,
+    uv.rol_nombre_interno,
+    uv.rol_nombre_visible,
+    uv.foto_perfil_url,
+    total.total_count,
+    uv.puede_ver
+  FROM usuarios_visibles uv
+  CROSS JOIN total
+  ORDER BY uv.nombre, uv.apellido
+  LIMIT v_limite OFFSET v_offset;
+END;
+$$;
+
+REVOKE ALL ON FUNCTION public.listar_usuarios_con_permisos(uuid, text, text[], boolean, boolean, boolean, integer, integer, boolean) FROM PUBLIC;
+REVOKE ALL ON FUNCTION public.listar_usuarios_con_permisos(uuid, text, text[], boolean, boolean, boolean, integer, integer, boolean) FROM anon;
+GRANT EXECUTE ON FUNCTION public.listar_usuarios_con_permisos(uuid, text, text[], boolean, boolean, boolean, integer, integer, boolean) TO authenticated, service_role;


### PR DESCRIPTION
Closes #190

## Resumen
Mejora la selección de propietario en Casas Anfitrionas con una búsqueda modal, alcance por permisos y protecciones backend para evitar asignaciones inválidas.

## Qué Incluye
- Selector/modal buscable para propietarios de casas anfitrionas.
- Endpoint de búsqueda por nombre, apellido, cédula y correo.
- Filtrado server-side por grupo de vida activo y permisos de asignación.
- Usuarios con casa existente se muestran deshabilitados y no seleccionables.
- Validaciones server-side para crear/editar y protección DB contra duplicados.
- Tests para endpoint, helper, acciones y migraciones.

## Motivación / Por Qué
El selector anterior mostraba una lista extensa de miembros del sistema, hacía difícil encontrar propietarios válidos y no comunicaba quién ya tenía casa asignada. Este cambio reduce ruido, protege datos y evita bypasses desde cliente.

## Evidencia Visual (si aplica)
| Antes | Después |
|-------|---------|
| Selector largo con todos los miembros | Selector buscable con estados y usuarios no seleccionables |

## Migraciones / Base de Datos
- [ ] No aplica
- [x] Sí (orden exacto):
```
supabase/migrations/20260618180543_prevent_duplicate_casa_assignees.sql
supabase/migrations/20260618181650_harden_listar_usuarios_con_permisos_search.sql
```
Notas: migraciones locales agregadas; no aplicadas a producción desde este PR.

## Impacto y Riesgos
- No rompe compatibilidad esperada del formulario.
- Requiere aplicar migraciones antes de depender de la protección DB en entornos desplegados.
- Mejora seguridad al filtrar PII fuera de alcance y endurecer búsqueda SQL.

## Checklist Autor
- [x] Código formateado (Prettier/ESLint)
- [x] Sin `console.log` / debugger
- [x] Validaciones con zod para entradas nuevas
- [x] Estados loading/error/empty cubiertos
- [x] Tipos TypeScript correctos
- [ ] Migraciones probadas local
- [x] Documentación actualizada (`docs/` o README) — no aplica
- [x] Variables de entorno documentadas — no aplica
- [x] Rebase con `main` limpio

## Checklist Revisor
- [ ] Propósito claro
- [ ] Nombres descriptivos
- [ ] Sin lógica duplicada evidente
- [ ] Manejo adecuado de errores
- [ ] Cambios acotados al alcance
- [ ] Sin secretos / datos sensibles

## Pruebas Manuales Realizadas
- [x] `pnpm exec jest ...Casas/actions/endpoint/migration... --runInBand`
- [x] `pnpm exec tsc --noEmit`
- [x] `pnpm exec eslint <subset touched>`
- [x] `pnpm lint:migrations`
- [x] `git diff --check`
- [x] Fresh risk review: PASS
- [x] Fresh reliability review: PASS

## Pendientes / Follow-up (opcional)
- Probar visualmente el flujo en navegador antes de merge.
- Ejecutar pruebas de Supabase local si el servicio local está levantado.

## Notas Adicionales
La prueba local de DB no se ejecutó porque Supabase local estaba apagado (`127.0.0.1:54322 connection refused`).
