### PR TITLE
fix(security): harden grupos users dashboard scope

### DIFF
--- a/app/api/grupos/bulk-update-status/route.ts
+++ b/app/api/grupos/bulk-update-status/route.ts
@@ -1,6 +1,5 @@
 import { NextResponse, type NextRequest } from 'next/server';
 import { z } from 'zod';
-import { createSupabaseAdminClient } from '@/lib/supabase/admin';
 import { createSupabaseServerClient } from '@/lib/supabase/server';
 
 // 1. Definir el esquema de validación con Zod
@@ -53,9 +52,25 @@ export async function POST(req: NextRequest) {
   const { groupIds, status } = validation.data;
 
   try {
-    // 4. Ejecutar la actualización con cliente de admin
-    const supabaseAdmin = createSupabaseAdminClient();
-    const { data, error } = await supabaseAdmin
+    const { data: visibleGroups, error: visibilityError } = await supabase
+      .from('grupos')
+      .select('id')
+      .in('id', groupIds);
+
+    if (visibilityError) {
+      console.error('Error al validar alcance de grupos:', visibilityError);
+      return NextResponse.json({ error: 'Error al validar permisos sobre los grupos.' }, { status: 500 });
+    }
+
+    const visibleGroupIds = new Set((visibleGroups ?? []).map((group) => group.id));
+    const allGroupsAreVisible = groupIds.every((groupId) => visibleGroupIds.has(groupId));
+
+    if (!allGroupsAreVisible || visibleGroupIds.size !== groupIds.length) {
+      return NextResponse.json({ error: 'No tienes permiso para actualizar uno o más grupos.' }, { status: 403 });
+    }
+
+    // 4. Ejecutar la actualización con el cliente del usuario para que RLS valide cada grupo.
+    const { data, error } = await supabase
       .from('grupos')
       .update({ activo: status })
       .in('id', groupIds)
@@ -67,12 +82,16 @@ export async function POST(req: NextRequest) {
       return NextResponse.json({ error: 'Error al actualizar los grupos en la base de datos.' }, { status: 500 });
     }
 
+    if ((data?.length ?? 0) !== groupIds.length) {
+      return NextResponse.json({ error: 'No se actualizaron todos los grupos solicitados.' }, { status: 403 });
+    }
+
     return NextResponse.json({
       message: 'Grupos actualizados correctamente.',
       count: data?.length ?? 0,
     }, { status: 200 });
 
-  } catch (e: any) {
+  } catch (e: unknown) {
     console.error('Excepción en el handler:', e);
     return NextResponse.json({ error: 'Ocurrió un error inesperado en el servidor.' }, { status: 500 });
   }

--- a/app/api/usuarios/buscar-para-relacion/route.ts
+++ b/app/api/usuarios/buscar-para-relacion/route.ts
@@ -1,56 +1,54 @@
 import { NextRequest, NextResponse } from "next/server";
 import { createSupabaseServerClient } from "@/lib/supabase/server";
 
-// Endpoint de búsqueda unificada para relaciones familiares.
-// Replica la lógica de permisos de listar_usuarios_con_permisos y filtra:
-//  - Usuario actual (siempre). Anteriormente se excluían familiares existentes, ahora se incluyen para mostrar badge.
+type RelationSearchUser = {
+  id: string
+  nombre: string
+  apellido: string
+  foto_perfil_url: string | null
+}
+
+// Endpoint de búsqueda mínima para relaciones familiares.
 // Parámetros:
-//  - q: término de búsqueda
+//  - q: término de búsqueda por nombre/apellido
 //  - limit: opcional (default 10)
-//  - excluir: lista separada por comas de ids a excluir
+//  - excluir: id del usuario base al que se agregará la relación
 export async function GET(req: NextRequest) {
   try {
     const { searchParams } = new URL(req.url);
     const q = searchParams.get('q') || '';
     const limit = parseInt(searchParams.get('limit') || '10', 10);
-  // Ya no usamos lista de excluir salvo casos especiales futuros
+    const usuarioBaseId = searchParams.get('excluir');
+
+    if (!usuarioBaseId) {
+      return NextResponse.json({ error: 'Usuario base requerido' }, { status: 400 });
+    }
 
     const supabase = await createSupabaseServerClient();
     const { data: { user } } = await supabase.auth.getUser();
     if (!user) return NextResponse.json({ error: 'No autenticado' }, { status: 401 });
 
-    // Usamos la función robusta de permisos existente.
-    const { data, error } = await supabase.rpc('listar_usuarios_con_permisos', {
+    const { data, error } = await supabase.rpc('buscar_usuarios_para_relacion_familiar', {
       p_auth_id: user.id,
+      p_usuario_base_id: usuarioBaseId,
       p_busqueda: q,
-      p_roles_filtro: [],
-      p_con_email: undefined,
-      p_con_telefono: undefined,
-      p_en_grupo: undefined,
       p_limite: limit,
-      p_offset: 0,
-      p_contexto_relacion: true
     });
+
     if (error) {
       return NextResponse.json({ error: error.message }, { status: 400 });
     }
 
-    const filtrados = (data || [])
-      .filter((u: any) => u.id !== user.id); // excluir solo al usuario actual
-
-    // Normalizar al shape que espera el modal (Usuario)
-    const respuesta = filtrados.map((u: any) => ({
+    const respuesta: RelationSearchUser[] = (data || []).map((u) => ({
       id: u.id,
       nombre: u.nombre,
       apellido: u.apellido,
-      email: u.email || '',
-      genero: 'Otro',
-      cedula: u.cedula || '',
       foto_perfil_url: u.foto_perfil_url || null
     }));
 
     return NextResponse.json(respuesta);
-  } catch (e: any) {
-    return NextResponse.json({ error: e?.message || 'Error' }, { status: 500 });
+  } catch (e: unknown) {
+    const message = e instanceof Error ? e.message : 'Error';
+    return NextResponse.json({ error: message }, { status: 500 });
   }
 }

--- a/components/modals/AgregarFamiliarModal.tsx
+++ b/components/modals/AgregarFamiliarModal.tsx
@@ -17,9 +17,9 @@ export type Usuario = {
   id: string
   nombre: string
   apellido: string
-  email: string
-  genero: string
-  cedula: string
+  email?: string
+  genero?: string
+  cedula?: string
   foto_perfil_url: string | null
 }
 
@@ -177,7 +177,7 @@ export function AgregarFamiliarModal({
                 <Search className="absolute left-3 top-1/2 transform -translate-y-1/2 w-5 h-5 text-muted-foreground z-10" />
                 <InputSistema
                   label="Buscar Usuario"
-                  placeholder="Buscar por nombre, apellido, cédula o correo..."
+                  placeholder="Buscar por nombre o apellido..."
                   value={terminoBusqueda}
                   onChange={(e) => setTerminoBusqueda(e.target.value)}
                   className="pl-10"
@@ -224,9 +224,7 @@ export function AgregarFamiliarModal({
                           <p className="font-medium text-foreground">
                             {usuario.nombre} {usuario.apellido}
                           </p>
-                          <p className="text-sm text-muted-foreground">
-                            {usuario.email} • {usuario.cedula}
-                          </p>
+                          <p className="text-sm text-muted-foreground">Usuario disponible para relación familiar</p>
                         </div>
                         {yaEsFamiliar && (
                           <span

--- a/lib/actions/user.actions.ts
+++ b/lib/actions/user.actions.ts
@@ -7,22 +7,34 @@ import { createSupabaseAdminClient } from "@/lib/supabase/admin"
 import { requireAuth } from "@/lib/auth/requireAuth"
 import type { Database } from "@/lib/supabase/database.types"
 
+type FamilyRelationshipResponse = {
+  error?: string
+  message?: string
+}
+
+type FamilyRelationshipType = Database["public"]["Enums"]["enum_tipo_relacion"]
+
 // Elimina una relacion familiar usando la funcion RPC y revalida la pagina de detalle
 export async function deleteFamilyRelation(relationId: string, userId: string) {
-  await requireAuth()
-  const supabase = createSupabaseAdminClient();
+  const { authId } = await requireAuth()
+  const supabase = await createSupabaseServerClient()
   try {
-    const { data, error } = await supabase.rpc('eliminar_relacion_familiar', { p_relacion_id: relationId });
+    const { data, error } = await supabase.rpc('eliminar_relacion_familiar_segura', {
+      p_auth_id: authId,
+      p_relacion_id: relationId,
+    });
     if (error) {
       return { success: false, error: error.message };
     }
-    if ((data as any) && (data as any).error) {
-      return { success: false, error: (data as any).error };
+    const response = data as FamilyRelationshipResponse | null
+    if (response?.error) {
+      return { success: false, error: response.error };
     }
     revalidatePath(`/users/${userId}`);
     return { success: true };
-  } catch (err: any) {
-    return { success: false, error: err?.message || 'Error inesperado' };
+  } catch (err: unknown) {
+    const message = err instanceof Error ? err.message : 'Error inesperado'
+    return { success: false, error: message };
   }
 }
 
@@ -247,48 +259,34 @@ export async function addFamilyRelation({
   usuario2_id: string
   tipo_relacion: string
 }) {
-  await requireAuth()
-  const supabase = createSupabaseAdminClient()
+  const { authId } = await requireAuth()
+  const supabase = await createSupabaseServerClient()
   try {
-
-    // Validar duplicados: solo una relación entre los mismos usuarios (en cualquier orden, sin importar tipo)
-    const { data: existing, error: errorExisting } = await supabase
-      .from('relaciones_usuarios')
-      .select('id')
-      .or(
-        `and(usuario1_id.eq.${usuario1_id},usuario2_id.eq.${usuario2_id})` +
-        `,and(usuario1_id.eq.${usuario2_id},usuario2_id.eq.${usuario1_id})`
-      )
-      .limit(1)
-
-    if (errorExisting) {
-      return { success: false, message: errorExisting.message }
+    if (usuario1_id === usuario2_id) {
+      return { success: false, message: 'A user cannot be related to themselves' }
     }
 
-    if (existing && existing.length > 0) {
-      return { success: false, message: 'Ya existe una relación entre estos usuarios' }
-    }
-
-    // Insertar una sola fila representando la relación desde la perspectiva de usuario1
-    const { data: inserted, error: errorInsert } = await supabase
-      .from('relaciones_usuarios')
-      .insert({
-        usuario1_id,
-        usuario2_id,
-        tipo_relacion: tipo_relacion as any,
-        es_principal: false,
+    const { data, error } = await supabase.rpc('agregar_relacion_familiar_segura', {
+        p_auth_id: authId,
+        p_usuario1_id: usuario1_id,
+        p_usuario2_id: usuario2_id,
+        p_tipo_relacion: tipo_relacion as FamilyRelationshipType,
       })
-      .select()
-      .maybeSingle()
 
-    if (errorInsert) {
-      return { success: false, message: errorInsert.message }
+    if (error) {
+      return { success: false, message: error.message }
+    }
+
+    const response = data as FamilyRelationshipResponse | null
+    if (response?.error || response?.message) {
+      return { success: false, message: response.error ?? response.message }
     }
 
     revalidatePath(`/users/${usuario1_id}`)
     return { success: true }
-  } catch (err: any) {
-    return { success: false, message: err?.message || "Error inesperado" }
+  } catch (err: unknown) {
+    const message = err instanceof Error ? err.message : "Error inesperado"
+    return { success: false, message }
   }
 }
 

--- a/lib/supabase/database.types.ts
+++ b/lib/supabase/database.types.ts
@@ -3956,14 +3956,6 @@ export type Database = {
         }
         Returns: Json
       }
-      agregar_relacion_familiar: {
-        Args: {
-          p_tipo_relacion: string
-          p_usuario1_id: string
-          p_usuario2_id: string
-        }
-        Returns: undefined
-      }
       asignar_director_etapa_a_ubicacion: {
         Args: {
           p_accion: string
@@ -4004,6 +3996,21 @@ export type Database = {
           nombre: string
           telefono: string
           ya_es_miembro: boolean
+        }[]
+      }
+      buscar_usuarios_para_relacion_familiar: {
+        Args: {
+          p_auth_id: string
+          p_busqueda?: string
+          p_limite?: number
+          p_usuario_base_id: string
+        }
+        Returns: {
+          apellido: string
+          foto_perfil_url: string | null
+          id: string
+          nombre: string
+          total_count: number
         }[]
       }
       claim_support_event_outbox_batch: {
@@ -4208,6 +4215,19 @@ export type Database = {
       obtener_casas_visibles_ids: {
         Args: { p_auth_id: string }
         Returns: string[]
+      }
+      agregar_relacion_familiar_segura: {
+        Args: {
+          p_auth_id: string
+          p_tipo_relacion: Database["public"]["Enums"]["enum_tipo_relacion"]
+          p_usuario1_id: string
+          p_usuario2_id: string
+        }
+        Returns: Json
+      }
+      eliminar_relacion_familiar_segura: {
+        Args: { p_auth_id: string; p_relacion_id: string }
+        Returns: Json
       }
       obtener_conyugue: {
         Args: { p_usuario_id: string }
@@ -4463,6 +4483,10 @@ export type Database = {
       puede_ver_debug_toolbar: { Args: { p_auth_id: string }; Returns: boolean }
       puede_ver_grupo: {
         Args: { p_grupo_id: string; p_user_id: string }
+        Returns: boolean
+      }
+      puede_ver_grupo_reporte_asistencia: {
+        Args: { p_auth_id: string; p_grupo_id: string }
         Returns: boolean
       }
       puede_ver_usuario: {

--- a/pages/api/addFamilyRelation.ts
+++ b/pages/api/addFamilyRelation.ts
@@ -1,53 +1,12 @@
 import type { NextApiRequest, NextApiResponse } from 'next';
-import { createSupabaseServerClient } from '@/lib/supabase/server';
 
 export default async function handler(req: NextApiRequest, res: NextApiResponse) {
   if (req.method !== 'POST') {
     return res.status(405).json({ success: false, message: 'Método no permitido' });
   }
 
-  const { usuario1_id, usuario2_id, tipo_relacion } = req.body;
-  if (!usuario1_id || !usuario2_id || !tipo_relacion) {
-    return res.status(400).json({ success: false, message: 'Faltan datos requeridos' });
-  }
-
-  const supabase = await createSupabaseServerClient();
-  try {
-    // Validar duplicados
-    const { data: existing, error: errorExisting } = await supabase
-      .from('relaciones_usuarios')
-      .select('id')
-      .or(
-        `and(usuario1_id.eq.${usuario1_id},usuario2_id.eq.${usuario2_id})` +
-        `,and(usuario1_id.eq.${usuario2_id},usuario2_id.eq.${usuario1_id})`
-      )
-      .limit(1);
-
-    if (errorExisting) {
-      return res.status(500).json({ success: false, message: errorExisting.message });
-    }
-    if (existing && existing.length > 0) {
-      return res.status(409).json({ success: false, message: 'Ya existe una relación entre estos usuarios' });
-    }
-
-    // Insertar relación
-    const { data: inserted, error: errorInsert } = await supabase
-      .from('relaciones_usuarios')
-      .insert({
-        usuario1_id,
-        usuario2_id,
-        tipo_relacion,
-        es_principal: false,
-      })
-      .select()
-      .maybeSingle();
-
-    if (errorInsert) {
-      return res.status(500).json({ success: false, message: errorInsert.message });
-    }
-
-    return res.status(200).json({ success: true, data: inserted });
-  } catch (err: any) {
-    return res.status(500).json({ success: false, message: err?.message || 'Error inesperado' });
-  }
+  return res.status(410).json({
+    success: false,
+    message: 'This endpoint is disabled. Use the safe addFamilyRelation server action.',
+  });
 }

--- a/supabase/migrations/20260618203000_harden_judgment_day_critical_security.sql
+++ b/supabase/migrations/20260618203000_harden_judgment_day_critical_security.sql
@@ -1,0 +1,1148 @@
+-- Harden Judgment Day Round 1 critical security findings.
+-- Scope: usuario detail RPC, grupos RLS/edit scope, DG dashboard scope,
+-- bulk-safe group updates, and family relationship access/mutations.
+
+-- -----------------------------------------------------------------------------
+-- Shared authorization helpers
+-- -----------------------------------------------------------------------------
+
+CREATE OR REPLACE FUNCTION public.es_admin_o_pastor(p_auth_id uuid)
+RETURNS boolean
+LANGUAGE sql
+STABLE
+SECURITY DEFINER
+SET search_path TO 'public'
+AS $$
+  SELECT EXISTS (
+    SELECT 1
+    FROM public.usuarios u
+    JOIN public.usuario_roles ur ON ur.usuario_id = u.id
+    JOIN public.roles_sistema rs ON rs.id = ur.rol_id
+    WHERE u.auth_id = p_auth_id
+      AND rs.nombre_interno IN ('admin', 'pastor')
+  );
+$$;
+
+REVOKE ALL ON FUNCTION public.es_admin_o_pastor(uuid) FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION public.es_admin_o_pastor(uuid) TO authenticated, service_role;
+
+CREATE OR REPLACE FUNCTION public.puede_gestionar_relacion_familiar(
+  p_auth_id uuid,
+  p_usuario1_id uuid,
+  p_usuario2_id uuid
+)
+RETURNS boolean
+LANGUAGE plpgsql
+STABLE
+SECURITY DEFINER
+SET search_path TO 'public'
+AS $$
+DECLARE
+  v_actor_id uuid;
+BEGIN
+  IF p_auth_id IS NULL OR p_auth_id IS DISTINCT FROM auth.uid() THEN
+    RETURN FALSE;
+  END IF;
+
+  IF p_usuario1_id IS NULL OR p_usuario2_id IS NULL OR p_usuario1_id = p_usuario2_id THEN
+    RETURN FALSE;
+  END IF;
+
+  SELECT u.id INTO v_actor_id
+  FROM public.usuarios u
+  WHERE u.auth_id = p_auth_id;
+
+  IF v_actor_id IS NULL THEN
+    RETURN FALSE;
+  END IF;
+
+  IF public.es_admin_o_pastor(p_auth_id) THEN
+    RETURN TRUE;
+  END IF;
+
+  RETURN public.puede_editar_usuario(p_auth_id, p_usuario1_id)
+     AND public.puede_editar_usuario(p_auth_id, p_usuario2_id);
+END;
+$$;
+
+REVOKE ALL ON FUNCTION public.puede_gestionar_relacion_familiar(uuid, uuid, uuid) FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION public.puede_gestionar_relacion_familiar(uuid, uuid, uuid) TO authenticated, service_role;
+
+CREATE OR REPLACE FUNCTION public.puede_ver_relacion_familiar(
+  p_auth_id uuid,
+  p_usuario1_id uuid,
+  p_usuario2_id uuid
+)
+RETURNS boolean
+LANGUAGE plpgsql
+STABLE
+SECURITY DEFINER
+SET search_path TO 'public'
+AS $$
+DECLARE
+  v_actor_id uuid;
+BEGIN
+  IF p_auth_id IS NULL OR p_auth_id IS DISTINCT FROM auth.uid() THEN
+    RETURN FALSE;
+  END IF;
+
+  SELECT u.id INTO v_actor_id
+  FROM public.usuarios u
+  WHERE u.auth_id = p_auth_id;
+
+  IF v_actor_id IS NULL THEN
+    RETURN FALSE;
+  END IF;
+
+  IF p_usuario1_id = v_actor_id OR p_usuario2_id = v_actor_id THEN
+    RETURN TRUE;
+  END IF;
+
+  RETURN public.puede_gestionar_relacion_familiar(p_auth_id, p_usuario1_id, p_usuario2_id);
+END;
+$$;
+
+REVOKE ALL ON FUNCTION public.puede_ver_relacion_familiar(uuid, uuid, uuid) FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION public.puede_ver_relacion_familiar(uuid, uuid, uuid) TO authenticated, service_role;
+
+-- -----------------------------------------------------------------------------
+-- grupos RLS and edit scope
+-- -----------------------------------------------------------------------------
+
+CREATE OR REPLACE FUNCTION public.puede_editar_grupo(p_auth_id uuid, p_grupo_id uuid)
+RETURNS boolean
+LANGUAGE plpgsql
+STABLE
+SECURITY DEFINER
+SET search_path TO 'public'
+AS $$
+DECLARE
+  v_user_id uuid;
+BEGIN
+  IF p_auth_id IS NULL OR p_grupo_id IS NULL OR p_auth_id IS DISTINCT FROM auth.uid() THEN
+    RETURN FALSE;
+  END IF;
+
+  SELECT u.id INTO v_user_id
+  FROM public.usuarios u
+  WHERE u.auth_id = p_auth_id;
+
+  IF v_user_id IS NULL THEN
+    RETURN FALSE;
+  END IF;
+
+  IF public.es_admin_o_pastor(p_auth_id) THEN
+    RETURN TRUE;
+  END IF;
+
+  IF EXISTS (
+    SELECT 1
+    FROM public.usuario_roles ur
+    JOIN public.roles_sistema rs ON rs.id = ur.rol_id
+    JOIN public.grupos g ON g.id = p_grupo_id
+    JOIN public.director_general_segmentos dgs
+      ON dgs.segmento_id = g.segmento_id
+     AND dgs.usuario_id = v_user_id
+    WHERE ur.usuario_id = v_user_id
+      AND rs.nombre_interno = 'director-general'
+  ) THEN
+    RETURN TRUE;
+  END IF;
+
+  IF EXISTS (
+    SELECT 1
+    FROM public.director_etapa_grupos deg
+    JOIN public.segmento_lideres sl ON sl.id = deg.director_etapa_id
+    WHERE deg.grupo_id = p_grupo_id
+      AND sl.usuario_id = v_user_id
+      AND sl.tipo_lider = 'director_etapa'
+  ) THEN
+    RETURN TRUE;
+  END IF;
+
+  RETURN EXISTS (
+    SELECT 1
+    FROM public.grupo_miembros gm
+    WHERE gm.grupo_id = p_grupo_id
+      AND gm.usuario_id = v_user_id
+      AND gm.rol = 'Líder'
+      AND COALESCE(gm.estado, 'activo') = 'activo'
+      AND gm.fecha_salida IS NULL
+  );
+END;
+$$;
+
+REVOKE ALL ON FUNCTION public.puede_editar_grupo(uuid, uuid) FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION public.puede_editar_grupo(uuid, uuid) TO authenticated, service_role;
+
+ALTER TABLE public.grupos ENABLE ROW LEVEL SECURITY;
+
+DO $$
+DECLARE
+  v_policy record;
+BEGIN
+  FOR v_policy IN
+    SELECT policyname
+    FROM pg_policies
+    WHERE schemaname = 'public'
+      AND tablename = 'grupos'
+      AND cmd IN ('SELECT', 'UPDATE', 'ALL')
+  LOOP
+    EXECUTE format('DROP POLICY IF EXISTS %I ON public.grupos', v_policy.policyname);
+  END LOOP;
+END $$;
+
+CREATE POLICY grupos_select_scoped_authenticated
+ON public.grupos
+FOR SELECT
+TO authenticated
+USING (
+  EXISTS (
+    SELECT 1
+    FROM public.usuarios actor
+    WHERE actor.auth_id = auth.uid()
+      AND public.puede_ver_grupo(actor.id, grupos.id)
+  )
+);
+
+CREATE POLICY grupos_update_scoped_authenticated
+ON public.grupos
+FOR UPDATE
+TO authenticated
+USING (public.puede_editar_grupo(auth.uid(), id))
+WITH CHECK (public.puede_editar_grupo(auth.uid(), id));
+
+-- -----------------------------------------------------------------------------
+-- obtener_detalle_usuario: actor-scoped privileged RPC
+-- -----------------------------------------------------------------------------
+
+CREATE OR REPLACE FUNCTION public.obtener_detalle_usuario(p_user_id uuid)
+RETURNS jsonb
+LANGUAGE plpgsql
+STABLE
+SECURITY DEFINER
+SET search_path TO 'public'
+AS $$
+DECLARE
+  v_actor_auth_id uuid := auth.uid();
+  v_actor_id uuid;
+  v_can_view_sensitive boolean := false;
+  v_payload jsonb;
+BEGIN
+  IF v_actor_auth_id IS NULL THEN
+    RAISE EXCEPTION 'Authentication required' USING ERRCODE = '28000';
+  END IF;
+
+  SELECT u.id INTO v_actor_id
+  FROM public.usuarios u
+  WHERE u.auth_id = v_actor_auth_id;
+
+  IF v_actor_id IS NULL THEN
+    RAISE EXCEPTION 'Actor user not found' USING ERRCODE = '28000';
+  END IF;
+
+  IF p_user_id = v_actor_id OR public.puede_editar_usuario(v_actor_auth_id, p_user_id) THEN
+    v_can_view_sensitive := true;
+  END IF;
+
+  IF NOT v_can_view_sensitive THEN
+    RAISE EXCEPTION 'Not authorized to view this user' USING ERRCODE = '42501';
+  END IF;
+
+  SELECT jsonb_build_object(
+    'id', u.id,
+    'nombre', u.nombre,
+    'apellido', u.apellido,
+    'cedula', u.cedula,
+    'email', u.email,
+    'telefono', u.telefono,
+    'fecha_nacimiento', u.fecha_nacimiento,
+    'fecha_registro', u.fecha_registro,
+    'estado_civil', u.estado_civil,
+    'genero', u.genero,
+    'foto_perfil_url', u.foto_perfil_url,
+    'familia_id', u.familia_id,
+    'direccion_id', u.direccion_id,
+    'ocupacion_id', u.ocupacion_id,
+    'profesion_id', u.profesion_id,
+    'roles', COALESCE((
+      SELECT jsonb_agg(rs.nombre_interno ORDER BY rs.nombre_interno)
+      FROM public.usuario_roles ur
+      JOIN public.roles_sistema rs ON rs.id = ur.rol_id
+      WHERE ur.usuario_id = u.id
+    ), '[]'::jsonb),
+    'ocupacion', CASE WHEN o.id IS NULL THEN NULL ELSE jsonb_build_object('id', o.id, 'nombre', o.nombre) END,
+    'profesion', CASE WHEN p.id IS NULL THEN NULL ELSE jsonb_build_object('id', p.id, 'nombre', p.nombre) END,
+    'direccion', CASE WHEN d.id IS NULL THEN NULL ELSE jsonb_build_object(
+      'id', d.id,
+      'calle', d.calle,
+      'barrio', d.barrio,
+      'codigo_postal', d.codigo_postal,
+      'referencia', d.referencia,
+      'latitud', d.latitud,
+      'longitud', d.longitud,
+      'parroquia', CASE WHEN par.id IS NULL THEN NULL ELSE jsonb_build_object(
+        'id', par.id,
+        'nombre', par.nombre,
+        'municipio', CASE WHEN mun.id IS NULL THEN NULL ELSE jsonb_build_object(
+          'id', mun.id,
+          'nombre', mun.nombre,
+          'estado', CASE WHEN est.id IS NULL THEN NULL ELSE jsonb_build_object(
+            'id', est.id,
+            'nombre', est.nombre,
+            'pais', CASE WHEN pais.id IS NULL THEN NULL ELSE jsonb_build_object('id', pais.id, 'nombre', pais.nombre) END
+          ) END
+        ) END
+      ) END
+    ) END,
+    'relaciones', COALESCE((
+      SELECT jsonb_agg(jsonb_build_object(
+        'id', ru.id,
+        'tipo_relacion', ru.tipo_relacion,
+        'es_principal', ru.es_principal,
+        'usuario1_id', ru.usuario1_id,
+        'usuario2_id', ru.usuario2_id,
+        'familiar', jsonb_build_object(
+          'id', familiar.id,
+          'nombre', familiar.nombre,
+          'apellido', familiar.apellido,
+          'email', familiar.email,
+          'telefono', familiar.telefono,
+          'genero', familiar.genero,
+          'foto_perfil_url', familiar.foto_perfil_url
+        )
+      ) ORDER BY familiar.apellido, familiar.nombre)
+      FROM public.relaciones_usuarios ru
+      JOIN public.usuarios familiar
+        ON familiar.id = CASE WHEN ru.usuario1_id = u.id THEN ru.usuario2_id ELSE ru.usuario1_id END
+      WHERE (ru.usuario1_id = u.id OR ru.usuario2_id = u.id)
+        AND public.puede_ver_relacion_familiar(v_actor_auth_id, ru.usuario1_id, ru.usuario2_id)
+    ), '[]'::jsonb)
+  )
+  INTO v_payload
+  FROM public.usuarios u
+  LEFT JOIN public.ocupaciones o ON o.id = u.ocupacion_id
+  LEFT JOIN public.profesiones p ON p.id = u.profesion_id
+  LEFT JOIN public.direcciones d ON d.id = u.direccion_id
+  LEFT JOIN public.parroquias par ON par.id = d.parroquia_id
+  LEFT JOIN public.municipios mun ON mun.id = par.municipio_id
+  LEFT JOIN public.estados est ON est.id = mun.estado_id
+  LEFT JOIN public.paises pais ON pais.id = est.pais_id
+  WHERE u.id = p_user_id;
+
+  IF v_payload IS NULL THEN
+    RAISE EXCEPTION 'User not found' USING ERRCODE = '02000';
+  END IF;
+
+  RETURN v_payload;
+END;
+$$;
+
+REVOKE ALL ON FUNCTION public.obtener_detalle_usuario(uuid) FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION public.obtener_detalle_usuario(uuid) TO authenticated;
+
+-- -----------------------------------------------------------------------------
+-- obtener_datos_dashboard: DG scope is assigned segments, admin/pastor global
+-- -----------------------------------------------------------------------------
+
+CREATE OR REPLACE FUNCTION public.obtener_datos_dashboard(p_auth_id uuid)
+RETURNS jsonb
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path TO 'public'
+AS $$
+DECLARE
+  v_user_id uuid;
+  v_rol_nombre text;
+  v_is_admin_pastor boolean := false;
+  v_is_dg boolean := false;
+  v_total_miembros int := 0;
+  v_total_miembros_hace_30 int := 0;
+  v_variacion_miembros numeric := 0;
+  v_asistencia_semanal numeric := 0;
+  v_grupos_activos int := 0;
+  v_nuevos_miembros_mes int := 0;
+  v_actividad jsonb := '[]'::jsonb;
+  v_cumpleanos jsonb := '[]'::jsonb;
+  v_riesgo jsonb := '[]'::jsonb;
+  v_tendencia jsonb := '[]'::jsonb;
+  v_distribucion jsonb := '[]'::jsonb;
+  v_rep jsonb;
+  v_grupos_asignados_ids uuid[];
+  v_total_miembros_alcance int := 0;
+  v_asistencia_semanal_alcance numeric := 0;
+  v_grupos_activos_alcance int := 0;
+  v_nuevos_miembros_mes_alcance int := 0;
+  v_actividad_alcance jsonb := '[]'::jsonb;
+  v_cumpleanos_alcance jsonb := '[]'::jsonb;
+  v_riesgo_alcance jsonb := '[]'::jsonb;
+  v_lideres_sin_reporte jsonb := '[]'::jsonb;
+  v_semana_inicio date;
+  v_semana_fin date;
+  v_grupos_lider_ids uuid[];
+  v_accion_requerida jsonb := NULL;
+  v_kpis_grupo jsonb := '{}'::jsonb;
+  v_proximos_cumpleanos_grupo jsonb := '[]'::jsonb;
+  v_miembros_ausentes_recientemente jsonb := '[]'::jsonb;
+  v_nuevos_miembros_grupo jsonb := '[]'::jsonb;
+  v_evento_ultimo uuid;
+  v_evento_ultimo_grupo uuid;
+BEGIN
+  IF p_auth_id IS NULL OR p_auth_id IS DISTINCT FROM auth.uid() THEN
+    RAISE EXCEPTION 'Authentication required' USING ERRCODE = '28000';
+  END IF;
+
+  SELECT u.id INTO v_user_id FROM public.usuarios u WHERE u.auth_id = p_auth_id;
+  IF v_user_id IS NULL THEN RAISE EXCEPTION 'Usuario no encontrado'; END IF;
+
+  SELECT rs.nombre_interno INTO v_rol_nombre
+  FROM public.usuario_roles ur
+  JOIN public.roles_sistema rs ON rs.id = ur.rol_id
+  WHERE ur.usuario_id = v_user_id
+  ORDER BY CASE rs.nombre_interno
+    WHEN 'admin' THEN 1 WHEN 'pastor' THEN 2 WHEN 'director-general' THEN 3
+    WHEN 'director-etapa' THEN 4 WHEN 'lider' THEN 5 ELSE 6 END
+  LIMIT 1;
+
+  v_is_admin_pastor := v_rol_nombre IN ('admin', 'pastor');
+  v_is_dg := v_rol_nombre = 'director-general';
+
+  IF v_is_admin_pastor OR v_is_dg THEN
+    WITH scoped_groups AS (
+      SELECT g.id, g.nombre, g.fecha_creacion, g.segmento_id
+      FROM public.grupos g
+      WHERE g.activo = true
+        AND COALESCE(g.eliminado, false) = false
+        AND (
+          v_is_admin_pastor
+          OR EXISTS (
+            SELECT 1
+            FROM public.director_general_segmentos dgs
+            WHERE dgs.usuario_id = v_user_id
+              AND dgs.segmento_id = g.segmento_id
+          )
+        )
+    ), scoped_members AS (
+      SELECT DISTINCT gm.usuario_id
+      FROM public.grupo_miembros gm
+      JOIN scoped_groups sg ON sg.id = gm.grupo_id
+      WHERE gm.fecha_salida IS NULL
+        AND COALESCE(gm.estado, 'activo') = 'activo'
+    )
+    SELECT COUNT(*) INTO v_total_miembros FROM scoped_members;
+
+    WITH scoped_groups AS (
+      SELECT g.id
+      FROM public.grupos g
+      WHERE g.activo = true AND COALESCE(g.eliminado, false) = false
+        AND (v_is_admin_pastor OR EXISTS (
+          SELECT 1 FROM public.director_general_segmentos dgs
+          WHERE dgs.usuario_id = v_user_id AND dgs.segmento_id = g.segmento_id
+        ))
+    ), scoped_members AS (
+      SELECT DISTINCT gm.usuario_id
+      FROM public.grupo_miembros gm
+      JOIN scoped_groups sg ON sg.id = gm.grupo_id
+      JOIN public.usuarios u ON u.id = gm.usuario_id
+      WHERE gm.fecha_salida IS NULL
+        AND COALESCE(gm.estado, 'activo') = 'activo'
+        AND u.fecha_registro <= (CURRENT_DATE - INTERVAL '30 days')
+    )
+    SELECT COUNT(*) INTO v_total_miembros_hace_30 FROM scoped_members;
+
+    v_variacion_miembros := CASE WHEN v_total_miembros_hace_30 > 0 THEN ROUND(((v_total_miembros - v_total_miembros_hace_30)::numeric / v_total_miembros_hace_30::numeric) * 100, 1) ELSE 0 END;
+
+    SELECT COUNT(*) INTO v_grupos_activos
+    FROM public.grupos g
+    WHERE g.activo = true AND COALESCE(g.eliminado, false) = false
+      AND (v_is_admin_pastor OR EXISTS (
+        SELECT 1 FROM public.director_general_segmentos dgs
+        WHERE dgs.usuario_id = v_user_id AND dgs.segmento_id = g.segmento_id
+      ));
+
+    SELECT COUNT(DISTINCT gm.usuario_id) INTO v_nuevos_miembros_mes
+    FROM public.grupo_miembros gm
+    JOIN public.grupos g ON g.id = gm.grupo_id
+    JOIN public.usuarios u ON u.id = gm.usuario_id
+    WHERE u.fecha_registro >= (CURRENT_DATE - INTERVAL '30 days')
+      AND gm.fecha_salida IS NULL
+      AND COALESCE(gm.estado, 'activo') = 'activo'
+      AND g.activo = true AND COALESCE(g.eliminado, false) = false
+      AND (v_is_admin_pastor OR EXISTS (
+        SELECT 1 FROM public.director_general_segmentos dgs
+        WHERE dgs.usuario_id = v_user_id AND dgs.segmento_id = g.segmento_id
+      ));
+
+    v_semana_inicio := CURRENT_DATE - (((EXTRACT(ISODOW FROM CURRENT_DATE)::int + 6) % 7));
+    v_semana_fin := v_semana_inicio + INTERVAL '6 days';
+
+    IF v_is_admin_pastor THEN
+      BEGIN
+        v_rep := public.obtener_reporte_semanal_asistencia(p_auth_id, NULL, true);
+        v_asistencia_semanal := COALESCE((v_rep->'kpis_globales'->>'porcentaje_asistencia_global')::numeric, 0);
+      EXCEPTION WHEN OTHERS THEN
+        v_asistencia_semanal := 0;
+      END;
+    ELSE
+      WITH scoped_groups AS (
+        SELECT g.id
+        FROM public.grupos g
+        WHERE g.activo = true
+          AND COALESCE(g.eliminado, false) = false
+          AND EXISTS (
+            SELECT 1
+            FROM public.director_general_segmentos dgs
+            WHERE dgs.usuario_id = v_user_id
+              AND dgs.segmento_id = g.segmento_id
+          )
+      ), eventos_por_grupo AS (
+        SELECT eg.grupo_id,
+               COUNT(a.id) AS total_registros,
+               COUNT(a.id) FILTER (WHERE a.presente = true) AS total_presentes
+        FROM public.eventos_grupo eg
+        JOIN scoped_groups sg ON sg.id = eg.grupo_id
+        LEFT JOIN public.asistencia a ON a.evento_grupo_id = eg.id
+        WHERE eg.fecha >= v_semana_inicio
+          AND eg.fecha <= v_semana_fin
+        GROUP BY eg.grupo_id
+      )
+      SELECT COALESCE(ROUND(AVG(CASE WHEN COALESCE(epg.total_registros, 0) > 0 THEN (epg.total_presentes::numeric / epg.total_registros::numeric) * 100 ELSE 0 END), 1), 0)
+      INTO v_asistencia_semanal
+      FROM scoped_groups sg
+      LEFT JOIN eventos_por_grupo epg ON epg.grupo_id = sg.id;
+
+      v_tendencia := (
+        WITH semanas AS (
+          SELECT v_semana_inicio - (n * INTERVAL '7 days') AS semana_inicio,
+                 v_semana_fin - (n * INTERVAL '7 days') AS semana_fin
+          FROM generate_series(0, 7) AS n
+        ), trend AS (
+          SELECT s.semana_inicio,
+                 (
+                   WITH scoped_groups AS (
+                     SELECT g.id
+                     FROM public.grupos g
+                     WHERE g.activo = true
+                       AND COALESCE(g.eliminado, false) = false
+                       AND EXISTS (
+                         SELECT 1
+                         FROM public.director_general_segmentos dgs
+                         WHERE dgs.usuario_id = v_user_id
+                           AND dgs.segmento_id = g.segmento_id
+                       )
+                   ), eventos_por_grupo AS (
+                     SELECT eg.grupo_id,
+                            COUNT(a.id) AS total_registros,
+                            COUNT(a.id) FILTER (WHERE a.presente = true) AS total_presentes
+                     FROM public.eventos_grupo eg
+                     JOIN scoped_groups sg ON sg.id = eg.grupo_id
+                     LEFT JOIN public.asistencia a ON a.evento_grupo_id = eg.id
+                     WHERE eg.fecha >= s.semana_inicio
+                       AND eg.fecha <= s.semana_fin
+                     GROUP BY eg.grupo_id
+                   )
+                   SELECT COALESCE(ROUND(AVG(CASE WHEN COALESCE(epg.total_registros, 0) > 0 THEN (epg.total_presentes::numeric / epg.total_registros::numeric) * 100 ELSE 0 END), 1), 0)
+                   FROM scoped_groups sg
+                   LEFT JOIN eventos_por_grupo epg ON epg.grupo_id = sg.id
+                 ) AS porcentaje
+          FROM semanas s
+          ORDER BY s.semana_inicio
+        )
+        SELECT COALESCE(jsonb_agg(jsonb_build_object('semana_inicio', semana_inicio, 'porcentaje', porcentaje) ORDER BY semana_inicio), '[]'::jsonb)
+        FROM trend
+      );
+    END IF;
+
+    v_actividad := (
+      SELECT COALESCE(jsonb_agg(jsonb_build_object('tipo', e.tipo, 'texto', e.texto, 'fecha', e.fecha) ORDER BY e.fecha DESC), '[]'::jsonb)
+      FROM (
+        SELECT * FROM (
+          SELECT u.fecha_registro AS fecha, 'NUEVO_MIEMBRO'::text AS tipo,
+                 (u.nombre || ' ' || u.apellido || ' se ha unido a la comunidad.') AS texto
+          FROM public.usuarios u
+          WHERE u.fecha_registro IS NOT NULL
+            AND (v_is_admin_pastor OR EXISTS (
+              SELECT 1 FROM public.grupo_miembros gm
+              JOIN public.grupos g ON g.id = gm.grupo_id
+              JOIN public.director_general_segmentos dgs ON dgs.segmento_id = g.segmento_id
+              WHERE gm.usuario_id = u.id AND dgs.usuario_id = v_user_id
+            ))
+          UNION ALL
+          SELECT g.fecha_creacion, 'NUEVO_GRUPO'::text, ('Se creó el grupo "' || g.nombre || '".')
+          FROM public.grupos g
+          WHERE g.fecha_creacion IS NOT NULL
+            AND (v_is_admin_pastor OR EXISTS (SELECT 1 FROM public.director_general_segmentos dgs WHERE dgs.usuario_id = v_user_id AND dgs.segmento_id = g.segmento_id))
+          UNION ALL
+          SELECT gm.fecha_asignacion, 'USUARIO_A_GRUPO'::text,
+                 (COALESCE(u.nombre,'') || ' ' || COALESCE(u.apellido,'') || ' añadido a ' || COALESCE(g.nombre,''))
+          FROM public.grupo_miembros gm
+          JOIN public.grupos g ON g.id = gm.grupo_id
+          LEFT JOIN public.usuarios u ON u.id = gm.usuario_id
+          WHERE gm.fecha_asignacion IS NOT NULL
+            AND (v_is_admin_pastor OR EXISTS (SELECT 1 FROM public.director_general_segmentos dgs WHERE dgs.usuario_id = v_user_id AND dgs.segmento_id = g.segmento_id))
+          UNION ALL
+          SELECT eg.fecha, 'REPORTE_ASISTENCIA'::text,
+                 ('El grupo "' || COALESCE(g.nombre,'') || '" ha reportado su asistencia.')
+          FROM public.eventos_grupo eg
+          JOIN public.grupos g ON g.id = eg.grupo_id
+          WHERE (v_is_admin_pastor OR EXISTS (SELECT 1 FROM public.director_general_segmentos dgs WHERE dgs.usuario_id = v_user_id AND dgs.segmento_id = g.segmento_id))
+        ) eventos
+        ORDER BY fecha DESC
+        LIMIT 5
+      ) e
+    );
+
+    v_cumpleanos := (
+      WITH miembros AS (
+        SELECT DISTINCT u.id, u.nombre, u.apellido, u.foto_perfil_url, u.fecha_nacimiento
+        FROM public.usuarios u
+        WHERE u.fecha_nacimiento IS NOT NULL
+          AND (v_is_admin_pastor OR EXISTS (
+            SELECT 1 FROM public.grupo_miembros gm
+            JOIN public.grupos g ON g.id = gm.grupo_id
+            JOIN public.director_general_segmentos dgs ON dgs.segmento_id = g.segmento_id
+            WHERE gm.usuario_id = u.id AND dgs.usuario_id = v_user_id
+          ))
+      ), norm AS (
+        SELECT id, nombre, apellido, foto_perfil_url, fecha_nacimiento,
+               CASE WHEN make_date(EXTRACT(YEAR FROM CURRENT_DATE)::int, EXTRACT(MONTH FROM fecha_nacimiento)::int, EXTRACT(DAY FROM fecha_nacimiento)::int) < CURRENT_DATE
+                    THEN (make_date(EXTRACT(YEAR FROM CURRENT_DATE)::int, EXTRACT(MONTH FROM fecha_nacimiento)::int, EXTRACT(DAY FROM fecha_nacimiento)::int) + INTERVAL '1 year')::date
+                    ELSE make_date(EXTRACT(YEAR FROM CURRENT_DATE)::int, EXTRACT(MONTH FROM fecha_nacimiento)::int, EXTRACT(DAY FROM fecha_nacimiento)::int)::date END AS proximo
+        FROM miembros
+      )
+      SELECT COALESCE(jsonb_agg(jsonb_build_object('id', id, 'nombre_completo', nombre || ' ' || apellido, 'foto_url', foto_perfil_url, 'fecha_nacimiento', fecha_nacimiento, 'proximo', proximo) ORDER BY proximo ASC), '[]'::jsonb)
+      FROM norm
+      WHERE proximo BETWEEN CURRENT_DATE AND (CURRENT_DATE + INTERVAL '14 days')
+      LIMIT 7
+    );
+
+    IF v_is_admin_pastor THEN
+      v_riesgo := (
+        SELECT COALESCE(jsonb_agg(item), '[]'::jsonb)
+        FROM (
+          SELECT risk.item AS item
+          FROM jsonb_array_elements(COALESCE(v_rep->'top_5_grupos_en_riesgo', '[]'::jsonb)) AS risk(item)
+          LIMIT 5
+        ) scoped_risk
+      );
+      v_tendencia := COALESCE(v_rep->'tendencia_asistencia_global', '[]'::jsonb);
+    ELSE
+      v_riesgo := (
+        WITH scoped_groups AS (
+          SELECT g.id, g.nombre
+          FROM public.grupos g
+          WHERE g.activo = true
+            AND COALESCE(g.eliminado, false) = false
+            AND EXISTS (
+              SELECT 1
+              FROM public.director_general_segmentos dgs
+              WHERE dgs.usuario_id = v_user_id
+                AND dgs.segmento_id = g.segmento_id
+            )
+        ), eventos_agreg AS (
+          SELECT eg.grupo_id,
+                 COUNT(a.id) AS total_registros,
+                 COUNT(a.id) FILTER (WHERE a.presente = true) AS total_presentes
+          FROM public.eventos_grupo eg
+          JOIN scoped_groups sg ON sg.id = eg.grupo_id
+          LEFT JOIN public.asistencia a ON a.evento_grupo_id = eg.id
+          WHERE eg.fecha >= v_semana_inicio
+            AND eg.fecha <= v_semana_fin
+          GROUP BY eg.grupo_id
+        ), pct AS (
+          SELECT sg.id AS grupo_id,
+                 COALESCE(ROUND((CASE WHEN COALESCE(e.total_registros, 0) > 0 THEN (COALESCE(e.total_presentes, 0)::numeric / COALESCE(e.total_registros, 0)::numeric) * 100 ELSE 0 END), 1), 0) AS porcentaje,
+                 COALESCE(e.total_registros, 0) AS total_registros
+          FROM scoped_groups sg
+          LEFT JOIN eventos_agreg e ON e.grupo_id = sg.id
+        ), lideres AS (
+          SELECT gm.grupo_id,
+                 STRING_AGG(DISTINCT u.nombre || ' ' || u.apellido, ', ' ORDER BY u.nombre || ' ' || u.apellido) AS nombres
+          FROM public.grupo_miembros gm
+          JOIN public.usuarios u ON u.id = gm.usuario_id
+          WHERE gm.rol = 'Líder'
+          GROUP BY gm.grupo_id
+        )
+        SELECT COALESCE(jsonb_agg(jsonb_build_object('id', o.grupo_id, 'nombre', sg.nombre, 'porcentaje_asistencia', o.porcentaje, 'lideres', COALESCE(l.nombres, 'Sin líderes asignados')) ORDER BY o.porcentaje ASC, o.grupo_id), '[]'::jsonb)
+        FROM (
+          SELECT grupo_id, porcentaje
+          FROM pct
+          WHERE total_registros > 0
+            AND porcentaje > 0
+            AND porcentaje < 70
+          ORDER BY porcentaje ASC, grupo_id
+          LIMIT 5
+        ) o
+        JOIN scoped_groups sg ON sg.id = o.grupo_id
+        LEFT JOIN lideres l ON l.grupo_id = o.grupo_id
+      );
+    END IF;
+
+    v_distribucion := (
+      SELECT COALESCE(jsonb_agg(jsonb_build_object('id', x.id, 'nombre', x.nombre, 'total_miembros', x.total_miembros) ORDER BY x.total_miembros DESC), '[]'::jsonb)
+      FROM (
+        SELECT s.id, COALESCE(s.nombre, 'Sin segmento') AS nombre, COUNT(DISTINCT gm.usuario_id) AS total_miembros
+        FROM public.segmentos s
+        JOIN public.grupos g ON g.segmento_id = s.id AND g.activo = true AND COALESCE(g.eliminado,false) = false
+        LEFT JOIN public.grupo_miembros gm ON gm.grupo_id = g.id AND gm.fecha_salida IS NULL AND COALESCE(gm.estado, 'activo') = 'activo'
+        WHERE v_is_admin_pastor OR EXISTS (
+          SELECT 1 FROM public.director_general_segmentos dgs
+          WHERE dgs.usuario_id = v_user_id AND dgs.segmento_id = s.id
+        )
+        GROUP BY s.id, s.nombre
+      ) x
+    );
+
+    RETURN jsonb_build_object(
+      'rol', v_rol_nombre,
+      'widgets', jsonb_build_object(
+        'kpis_globales', jsonb_build_object(
+          'total_miembros', jsonb_build_object('valor', v_total_miembros, 'variacion', v_variacion_miembros),
+          'asistencia_semanal', jsonb_build_object('valor', v_asistencia_semanal),
+          'grupos_activos', jsonb_build_object('valor', v_grupos_activos),
+          'nuevos_miembros_mes', jsonb_build_object('valor', v_nuevos_miembros_mes)
+        ),
+        'actividad_reciente', v_actividad,
+        'proximos_cumpleanos', v_cumpleanos,
+        'grupos_en_riesgo', v_riesgo,
+        'tendencia_asistencia', v_tendencia,
+        'distribucion_segmentos', v_distribucion
+      )
+    );
+  ELSIF v_rol_nombre = 'director-etapa' THEN
+    SELECT array_agg(deg.grupo_id)
+    INTO v_grupos_asignados_ids
+    FROM public.director_etapa_grupos deg
+    JOIN public.segmento_lideres sl ON sl.id = deg.director_etapa_id
+    WHERE sl.usuario_id = v_user_id AND sl.tipo_lider = 'director_etapa';
+
+    v_semana_inicio := CURRENT_DATE - (((EXTRACT(ISODOW FROM CURRENT_DATE)::int + 6) % 7));
+    v_semana_fin := v_semana_inicio + INTERVAL '6 days';
+
+    SELECT COUNT(DISTINCT gm.usuario_id) INTO v_total_miembros_alcance
+    FROM public.grupo_miembros gm
+    WHERE v_grupos_asignados_ids IS NOT NULL AND gm.grupo_id = ANY(v_grupos_asignados_ids);
+
+    BEGIN
+      v_rep := public.obtener_reporte_semanal_asistencia(p_auth_id, NULL, true);
+      v_asistencia_semanal_alcance := COALESCE((v_rep->'kpis_globales'->>'porcentaje_asistencia_global')::numeric, 0);
+    EXCEPTION WHEN OTHERS THEN
+      v_asistencia_semanal_alcance := 0;
+    END;
+
+    SELECT COUNT(*) INTO v_grupos_activos_alcance
+    FROM public.grupos g
+    WHERE v_grupos_asignados_ids IS NOT NULL AND g.id = ANY(v_grupos_asignados_ids) AND g.activo = true AND COALESCE(g.eliminado,false)=false;
+
+    SELECT COUNT(*) INTO v_nuevos_miembros_mes_alcance
+    FROM public.grupo_miembros gm
+    WHERE v_grupos_asignados_ids IS NOT NULL AND gm.grupo_id = ANY(v_grupos_asignados_ids)
+      AND gm.fecha_asignacion >= (CURRENT_DATE - INTERVAL '30 days');
+
+    v_actividad_alcance := (
+      SELECT COALESCE(
+        jsonb_agg(jsonb_build_object('tipo', e.tipo, 'texto', e.texto, 'fecha', e.fecha) ORDER BY e.fecha DESC),
+        '[]'::jsonb
+      )
+      FROM (
+        SELECT * FROM (
+          SELECT gm.fecha_asignacion AS fecha, 'USUARIO_A_GRUPO'::text AS tipo,
+                 (COALESCE(u.nombre,'') || ' ' || COALESCE(u.apellido,'') || ' añadido a ' || COALESCE(g.nombre,'')) AS texto
+          FROM public.grupo_miembros gm
+          JOIN public.grupos g ON g.id = gm.grupo_id
+          LEFT JOIN public.usuarios u ON u.id = gm.usuario_id
+          WHERE (v_grupos_asignados_ids IS NOT NULL) AND gm.grupo_id = ANY(v_grupos_asignados_ids)
+          UNION ALL
+          SELECT g.fecha_creacion AS fecha, 'NUEVO_GRUPO'::text AS tipo,
+                 ('Se creó el grupo ' || '"' || g.nombre || '".') AS texto
+          FROM public.grupos g
+          WHERE (v_grupos_asignados_ids IS NOT NULL) AND g.id = ANY(v_grupos_asignados_ids)
+          UNION ALL
+          SELECT eg.fecha AS fecha, 'REPORTE_ASISTENCIA'::text AS tipo,
+                 ('El grupo "' || COALESCE(g.nombre,'') || '" ha reportado su asistencia.') AS texto
+          FROM public.eventos_grupo eg
+          JOIN public.grupos g ON g.id = eg.grupo_id
+          WHERE (v_grupos_asignados_ids IS NOT NULL) AND eg.grupo_id = ANY(v_grupos_asignados_ids)
+        ) eventos
+        ORDER BY fecha DESC
+        LIMIT 5
+      ) e
+    );
+
+    v_cumpleanos_alcance := (
+      WITH miembros AS (
+        SELECT DISTINCT u.id, u.nombre, u.apellido, u.foto_perfil_url, u.fecha_nacimiento
+        FROM public.usuarios u
+        JOIN public.grupo_miembros gm ON gm.usuario_id = u.id
+        WHERE (v_grupos_asignados_ids IS NOT NULL) AND gm.grupo_id = ANY(v_grupos_asignados_ids)
+          AND u.fecha_nacimiento IS NOT NULL
+      ), norm AS (
+        SELECT id, nombre, apellido, foto_perfil_url, fecha_nacimiento,
+               CASE WHEN fecha_nacimiento IS NULL THEN NULL
+                    WHEN make_date(EXTRACT(YEAR FROM CURRENT_DATE)::int, EXTRACT(MONTH FROM fecha_nacimiento)::int, EXTRACT(DAY FROM fecha_nacimiento)::int) < CURRENT_DATE
+                      THEN (make_date(EXTRACT(YEAR FROM CURRENT_DATE)::int, EXTRACT(MONTH FROM fecha_nacimiento)::int, EXTRACT(DAY FROM fecha_nacimiento)::int) + INTERVAL '1 year')::date
+                    ELSE make_date(EXTRACT(YEAR FROM CURRENT_DATE)::int, EXTRACT(MONTH FROM fecha_nacimiento)::int, EXTRACT(DAY FROM fecha_nacimiento)::int)::date
+               END AS proximo
+        FROM miembros
+      )
+      SELECT COALESCE(jsonb_agg(jsonb_build_object(
+        'id', id,
+        'nombre_completo', nombre || ' ' || apellido,
+        'foto_url', foto_perfil_url,
+        'fecha_nacimiento', fecha_nacimiento,
+        'proximo', proximo
+      ) ORDER BY proximo ASC), '[]'::jsonb)
+      FROM norm
+      WHERE proximo BETWEEN CURRENT_DATE AND (CURRENT_DATE + INTERVAL '14 days')
+      LIMIT 7
+    );
+
+    IF v_rep IS NULL THEN v_rep := public.obtener_reporte_semanal_asistencia(p_auth_id, NULL, true); END IF;
+    v_riesgo_alcance := COALESCE(v_rep->'top_5_grupos_en_riesgo', '[]'::jsonb);
+
+    v_lideres_sin_reporte := (
+      WITH asignados AS (
+        SELECT g.id, g.nombre
+        FROM public.grupos g
+        WHERE (v_grupos_asignados_ids IS NOT NULL) AND g.id = ANY(v_grupos_asignados_ids)
+          AND g.activo = true AND COALESCE(g.eliminado,false)=false
+      ), eventos_semana AS (
+        SELECT DISTINCT eg.grupo_id
+        FROM public.eventos_grupo eg
+        WHERE eg.fecha >= v_semana_inicio AND eg.fecha <= v_semana_fin
+          AND (v_grupos_asignados_ids IS NOT NULL) AND eg.grupo_id = ANY(v_grupos_asignados_ids)
+      ), faltantes AS (
+        SELECT a.id AS grupo_id, a.nombre
+        FROM asignados a
+        LEFT JOIN eventos_semana es ON es.grupo_id = a.id
+        WHERE es.grupo_id IS NULL
+      ), lideres AS (
+        SELECT gm.grupo_id, STRING_AGG(DISTINCT u.nombre || ' ' || u.apellido, ', ' ORDER BY u.nombre||' '||u.apellido) AS nombres
+        FROM public.grupo_miembros gm
+        JOIN public.usuarios u ON u.id = gm.usuario_id
+        WHERE gm.rol = 'Líder'
+        GROUP BY gm.grupo_id
+      )
+      SELECT COALESCE(jsonb_agg(jsonb_build_object(
+        'grupo_id', f.grupo_id,
+        'grupo_nombre', f.nombre,
+        'lideres', COALESCE(l.nombres,'Sin líderes asignados')
+      ) ORDER BY f.nombre), '[]'::jsonb)
+      FROM faltantes f
+      LEFT JOIN lideres l ON l.grupo_id = f.grupo_id
+    );
+
+    RETURN jsonb_build_object(
+      'rol', v_rol_nombre,
+      'widgets', jsonb_build_object(
+        'kpis_alcance', jsonb_build_object(
+          'total_miembros', jsonb_build_object('valor', v_total_miembros_alcance),
+          'asistencia_semanal', jsonb_build_object('valor', v_asistencia_semanal_alcance),
+          'grupos_activos', jsonb_build_object('valor', v_grupos_activos_alcance),
+          'nuevos_miembros_mes', jsonb_build_object('valor', v_nuevos_miembros_mes_alcance)
+        ),
+        'actividad_reciente_alcance', v_actividad_alcance,
+        'proximos_cumpleanos_alcance', v_cumpleanos_alcance,
+        'grupos_en_riesgo_alcance', v_riesgo_alcance,
+        'lideres_sin_reporte', v_lideres_sin_reporte
+      )
+    );
+  ELSIF v_rol_nombre = 'lider' THEN
+    SELECT array_agg(gm.grupo_id) INTO v_grupos_lider_ids
+    FROM public.grupo_miembros gm
+    WHERE gm.usuario_id = v_user_id AND gm.rol = 'Líder';
+
+    v_semana_inicio := CURRENT_DATE - (((EXTRACT(ISODOW FROM CURRENT_DATE)::int + 6) % 7));
+    v_semana_fin := v_semana_inicio + INTERVAL '6 days';
+
+    SELECT jsonb_build_object(
+      'tipo','REGISTRAR_ASISTENCIA',
+      'mensaje','No has registrado la asistencia de esta semana para el grupo ' || '"' || a.nombre || '"' || '.',
+      'grupo_id', a.id,
+      'grupo_nombre', a.nombre
+    ) INTO v_accion_requerida
+    FROM (
+      WITH asignados AS (
+        SELECT g.id, g.nombre
+        FROM public.grupos g
+        WHERE (v_grupos_lider_ids IS NOT NULL) AND g.id = ANY(v_grupos_lider_ids)
+          AND g.activo = true AND COALESCE(g.eliminado,false)=false
+      ), eventos_semana AS (
+        SELECT DISTINCT eg.grupo_id
+        FROM public.eventos_grupo eg
+        WHERE eg.fecha >= v_semana_inicio AND eg.fecha <= v_semana_fin
+          AND (v_grupos_lider_ids IS NOT NULL) AND eg.grupo_id = ANY(v_grupos_lider_ids)
+      )
+      SELECT a.*
+      FROM asignados a
+      LEFT JOIN eventos_semana es ON es.grupo_id = a.id
+      WHERE es.grupo_id IS NULL
+      ORDER BY a.nombre
+      LIMIT 1
+    ) a;
+
+    IF NOT EXISTS (
+      SELECT 1 FROM (
+        WITH asignados AS (
+          SELECT g.id FROM public.grupos g
+          WHERE (v_grupos_lider_ids IS NOT NULL) AND g.id = ANY(v_grupos_lider_ids)
+            AND g.activo = true AND COALESCE(g.eliminado,false)=false
+        ), eventos_semana AS (
+          SELECT DISTINCT eg.grupo_id FROM public.eventos_grupo eg
+          WHERE eg.fecha >= v_semana_inicio AND eg.fecha <= v_semana_fin
+            AND (v_grupos_lider_ids IS NOT NULL) AND eg.grupo_id = ANY(v_grupos_lider_ids)
+        )
+        SELECT a.id FROM asignados a
+        LEFT JOIN eventos_semana es ON es.grupo_id = a.id
+        WHERE es.grupo_id IS NULL
+      ) x
+    ) THEN
+      v_accion_requerida := NULL;
+    END IF;
+
+    SELECT eg.id, eg.grupo_id INTO v_evento_ultimo, v_evento_ultimo_grupo
+    FROM public.eventos_grupo eg
+    WHERE v_grupos_lider_ids IS NOT NULL AND eg.grupo_id = ANY(v_grupos_lider_ids)
+    ORDER BY eg.fecha DESC
+    LIMIT 1;
+
+    v_kpis_grupo := jsonb_build_object(
+      'asistencia_ultima_reunion', (SELECT COALESCE(ROUND((COUNT(a.id) FILTER (WHERE a.presente = true))::numeric / NULLIF(COUNT(a.id), 0)::numeric * 100, 1), 0) FROM public.asistencia a WHERE v_evento_ultimo IS NOT NULL AND a.evento_grupo_id = v_evento_ultimo),
+      'total_miembros', (SELECT COALESCE(COUNT(DISTINCT gm.usuario_id), 0) FROM public.grupo_miembros gm WHERE v_evento_ultimo_grupo IS NOT NULL AND gm.grupo_id = v_evento_ultimo_grupo AND gm.fecha_salida IS NULL)
+    );
+
+    v_proximos_cumpleanos_grupo := (
+      WITH miembros AS (
+        SELECT DISTINCT u.id, u.nombre, u.apellido, u.foto_perfil_url, u.fecha_nacimiento
+        FROM public.usuarios u
+        JOIN public.grupo_miembros gm ON gm.usuario_id = u.id
+        WHERE (v_grupos_lider_ids IS NOT NULL) AND gm.grupo_id = ANY(v_grupos_lider_ids)
+          AND u.fecha_nacimiento IS NOT NULL
+      ), norm AS (
+        SELECT id, nombre, apellido, foto_perfil_url, fecha_nacimiento,
+               CASE WHEN fecha_nacimiento IS NULL THEN NULL
+                    WHEN make_date(EXTRACT(YEAR FROM CURRENT_DATE)::int, EXTRACT(MONTH FROM fecha_nacimiento)::int, EXTRACT(DAY FROM fecha_nacimiento)::int) < CURRENT_DATE
+                      THEN (make_date(EXTRACT(YEAR FROM CURRENT_DATE)::int, EXTRACT(MONTH FROM fecha_nacimiento)::int, EXTRACT(DAY FROM fecha_nacimiento)::int) + INTERVAL '1 year')::date
+                    ELSE make_date(EXTRACT(YEAR FROM CURRENT_DATE)::int, EXTRACT(MONTH FROM fecha_nacimiento)::int, EXTRACT(DAY FROM fecha_nacimiento)::int)::date
+               END AS proximo
+        FROM miembros
+      )
+      SELECT COALESCE(jsonb_agg(jsonb_build_object(
+        'id', id,
+        'nombre_completo', nombre || ' ' || apellido,
+        'foto_url', foto_perfil_url,
+        'fecha_nacimiento', fecha_nacimiento,
+        'proximo', proximo
+      ) ORDER BY proximo ASC), '[]'::jsonb)
+      FROM norm
+      WHERE proximo BETWEEN CURRENT_DATE AND (CURRENT_DATE + INTERVAL '14 days')
+      LIMIT 7
+    );
+
+    v_miembros_ausentes_recientemente := (
+      WITH ultimos_eventos AS (
+        SELECT eg.id AS evento_id, eg.grupo_id, eg.fecha
+        FROM public.eventos_grupo eg
+        WHERE (v_grupos_lider_ids IS NOT NULL) AND eg.grupo_id = ANY(v_grupos_lider_ids)
+        ORDER BY eg.fecha DESC
+        LIMIT 2
+      ), ausentes AS (
+        SELECT a.usuario_id, MAX(COALESCE(a.fecha_registro::date, ue.fecha)) AS ultima_ausencia
+        FROM public.asistencia a
+        JOIN ultimos_eventos ue ON ue.evento_id = a.evento_grupo_id
+        WHERE a.presente = false
+        GROUP BY a.usuario_id
+      )
+      SELECT COALESCE(jsonb_agg(jsonb_build_object(
+        'id', u.id,
+        'nombre_completo', u.nombre || ' ' || u.apellido,
+        'foto_url', u.foto_perfil_url,
+        'ultima_ausencia', aus.ultima_ausencia
+      ) ORDER BY aus.ultima_ausencia DESC), '[]'::jsonb)
+      FROM ausentes aus
+      JOIN public.usuarios u ON u.id = aus.usuario_id
+    );
+
+    v_nuevos_miembros_grupo := (
+      SELECT COALESCE(jsonb_agg(jsonb_build_object(
+        'id', u.id,
+        'nombre_completo', u.nombre || ' ' || u.apellido,
+        'foto_url', u.foto_perfil_url,
+        'fecha_ingreso', gm.fecha_asignacion
+      ) ORDER BY gm.fecha_asignacion DESC), '[]'::jsonb)
+      FROM public.grupo_miembros gm
+      JOIN public.usuarios u ON u.id = gm.usuario_id
+      WHERE (v_grupos_lider_ids IS NOT NULL) AND gm.grupo_id = ANY(v_grupos_lider_ids)
+        AND gm.fecha_asignacion >= (CURRENT_DATE - INTERVAL '30 days')
+    );
+
+    RETURN jsonb_build_object(
+      'rol', v_rol_nombre,
+      'widgets', jsonb_build_object(
+        'accion_requerida', v_accion_requerida,
+        'kpis_grupo', v_kpis_grupo,
+        'proximos_cumpleanos_grupo', v_proximos_cumpleanos_grupo,
+        'miembros_ausentes_recientemente', v_miembros_ausentes_recientemente,
+        'nuevos_miembros_grupo', v_nuevos_miembros_grupo
+      )
+    );
+  ELSE
+    RETURN jsonb_build_object('rol', v_rol_nombre, 'widgets', jsonb_build_object());
+  END IF;
+END;
+$$;
+
+REVOKE ALL ON FUNCTION public.obtener_datos_dashboard(uuid) FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION public.obtener_datos_dashboard(uuid) TO authenticated, service_role;
+
+-- -----------------------------------------------------------------------------
+-- relaciones_usuarios RLS, grants, and safe mutation RPCs
+-- -----------------------------------------------------------------------------
+
+ALTER TABLE public.relaciones_usuarios ENABLE ROW LEVEL SECURITY;
+
+DO $$
+DECLARE
+  v_constraint_exists boolean;
+BEGIN
+  SELECT EXISTS (
+    SELECT 1 FROM pg_constraint
+    WHERE conname = 'relaciones_usuarios_no_self_relation'
+      AND conrelid = 'public.relaciones_usuarios'::regclass
+  ) INTO v_constraint_exists;
+
+  IF NOT v_constraint_exists THEN
+    ALTER TABLE public.relaciones_usuarios
+      ADD CONSTRAINT relaciones_usuarios_no_self_relation
+      CHECK (usuario1_id <> usuario2_id) NOT VALID;
+  END IF;
+END $$;
+
+DO $$
+DECLARE
+  v_policy record;
+BEGIN
+  FOR v_policy IN
+    SELECT policyname
+    FROM pg_policies
+    WHERE schemaname = 'public'
+      AND tablename = 'relaciones_usuarios'
+      AND cmd IN ('SELECT', 'INSERT', 'UPDATE', 'DELETE', 'ALL')
+  LOOP
+    EXECUTE format('DROP POLICY IF EXISTS %I ON public.relaciones_usuarios', v_policy.policyname);
+  END LOOP;
+END $$;
+
+REVOKE ALL ON TABLE public.relaciones_usuarios FROM anon;
+REVOKE ALL ON TABLE public.relaciones_usuarios FROM authenticated;
+GRANT SELECT, INSERT, UPDATE, DELETE ON TABLE public.relaciones_usuarios TO authenticated;
+
+CREATE POLICY relaciones_usuarios_select_scoped
+ON public.relaciones_usuarios
+FOR SELECT
+TO authenticated
+USING (public.puede_ver_relacion_familiar(auth.uid(), usuario1_id, usuario2_id));
+
+CREATE POLICY relaciones_usuarios_insert_scoped
+ON public.relaciones_usuarios
+FOR INSERT
+TO authenticated
+WITH CHECK (public.puede_gestionar_relacion_familiar(auth.uid(), usuario1_id, usuario2_id));
+
+CREATE POLICY relaciones_usuarios_update_scoped
+ON public.relaciones_usuarios
+FOR UPDATE
+TO authenticated
+USING (public.puede_gestionar_relacion_familiar(auth.uid(), usuario1_id, usuario2_id))
+WITH CHECK (public.puede_gestionar_relacion_familiar(auth.uid(), usuario1_id, usuario2_id));
+
+CREATE POLICY relaciones_usuarios_delete_scoped
+ON public.relaciones_usuarios
+FOR DELETE
+TO authenticated
+USING (public.puede_gestionar_relacion_familiar(auth.uid(), usuario1_id, usuario2_id));
+
+CREATE OR REPLACE FUNCTION public.agregar_relacion_familiar_segura(
+  p_auth_id uuid,
+  p_usuario1_id uuid,
+  p_usuario2_id uuid,
+  p_tipo_relacion enum_tipo_relacion
+)
+RETURNS jsonb
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path TO 'public'
+AS $$
+DECLARE
+  v_inserted public.relaciones_usuarios%ROWTYPE;
+BEGIN
+  IF p_auth_id IS NULL OR p_auth_id IS DISTINCT FROM auth.uid() THEN
+    RAISE EXCEPTION 'Authentication required' USING ERRCODE = '28000';
+  END IF;
+
+  IF NOT public.puede_gestionar_relacion_familiar(p_auth_id, p_usuario1_id, p_usuario2_id) THEN
+    RAISE EXCEPTION 'Not authorized to create this relationship' USING ERRCODE = '42501';
+  END IF;
+
+  IF EXISTS (
+    SELECT 1 FROM public.relaciones_usuarios ru
+    WHERE LEAST(ru.usuario1_id, ru.usuario2_id) = LEAST(p_usuario1_id, p_usuario2_id)
+      AND GREATEST(ru.usuario1_id, ru.usuario2_id) = GREATEST(p_usuario1_id, p_usuario2_id)
+  ) THEN
+    RAISE EXCEPTION 'Relationship already exists' USING ERRCODE = '23505';
+  END IF;
+
+  INSERT INTO public.relaciones_usuarios (usuario1_id, usuario2_id, tipo_relacion, es_principal) -- noqa: insert-into
+  VALUES (p_usuario1_id, p_usuario2_id, p_tipo_relacion, false)
+  RETURNING * INTO v_inserted;
+
+  RETURN to_jsonb(v_inserted);
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION public.eliminar_relacion_familiar_segura(
+  p_auth_id uuid,
+  p_relacion_id uuid
+)
+RETURNS jsonb
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path TO 'public'
+AS $$
+DECLARE
+  v_relation public.relaciones_usuarios%ROWTYPE;
+BEGIN
+  IF p_auth_id IS NULL OR p_auth_id IS DISTINCT FROM auth.uid() THEN
+    RAISE EXCEPTION 'Authentication required' USING ERRCODE = '28000';
+  END IF;
+
+  SELECT * INTO v_relation
+  FROM public.relaciones_usuarios ru
+  WHERE ru.id = p_relacion_id;
+
+  IF v_relation.id IS NULL THEN
+    RAISE EXCEPTION 'Relationship not found' USING ERRCODE = '02000';
+  END IF;
+
+  IF NOT public.puede_gestionar_relacion_familiar(p_auth_id, v_relation.usuario1_id, v_relation.usuario2_id) THEN
+    RAISE EXCEPTION 'Not authorized to delete this relationship' USING ERRCODE = '42501';
+  END IF;
+
+  DELETE FROM public.relaciones_usuarios ru
+  WHERE ru.id = p_relacion_id;
+
+  RETURN jsonb_build_object('success', true);
+END;
+$$;
+
+REVOKE ALL ON FUNCTION public.agregar_relacion_familiar_segura(uuid, uuid, uuid, enum_tipo_relacion) FROM PUBLIC;
+REVOKE ALL ON FUNCTION public.eliminar_relacion_familiar_segura(uuid, uuid) FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION public.agregar_relacion_familiar_segura(uuid, uuid, uuid, enum_tipo_relacion) TO authenticated;
+GRANT EXECUTE ON FUNCTION public.eliminar_relacion_familiar_segura(uuid, uuid) TO authenticated;
+
+DO $$
+BEGIN
+  IF to_regprocedure('public.eliminar_relacion_familiar(uuid)') IS NOT NULL THEN
+    REVOKE ALL ON FUNCTION public.eliminar_relacion_familiar(uuid) FROM PUBLIC;
+  END IF;
+END $$;

--- a/supabase/migrations/20260619000353_harden_round3_remaining_blockers.sql
+++ b/supabase/migrations/20260619000353_harden_round3_remaining_blockers.sql
@@ -1,0 +1,555 @@
+-- Harden remaining Judgment Day Round 3 blockers:
+-- 1. Scope weekly attendance report for director-general by assigned segments.
+-- 2. Add minimal, authorization-checked family relation search RPC.
+-- 3. Remove legacy unsafe family relation mutation surface when present.
+
+-- -----------------------------------------------------------------------------
+-- Weekly attendance report visibility
+-- -----------------------------------------------------------------------------
+
+CREATE OR REPLACE FUNCTION public.puede_ver_grupo_reporte_asistencia(
+  p_auth_id uuid,
+  p_grupo_id uuid
+)
+RETURNS boolean
+LANGUAGE plpgsql
+STABLE
+SECURITY DEFINER
+SET search_path TO 'public'
+AS $$
+DECLARE
+  v_user_id uuid;
+  v_role text;
+BEGIN
+  IF p_auth_id IS NULL OR p_grupo_id IS NULL THEN
+    RETURN FALSE;
+  END IF;
+
+  IF auth.uid() IS NOT NULL AND p_auth_id IS DISTINCT FROM auth.uid() THEN
+    RETURN FALSE;
+  END IF;
+
+  SELECT u.id, rs.nombre_interno
+  INTO v_user_id, v_role
+  FROM public.usuarios u
+  JOIN public.usuario_roles ur ON ur.usuario_id = u.id
+  JOIN public.roles_sistema rs ON rs.id = ur.rol_id
+  WHERE u.auth_id = p_auth_id
+    AND rs.nombre_interno IN ('admin', 'pastor', 'director-general', 'director-etapa')
+  ORDER BY CASE rs.nombre_interno
+    WHEN 'admin' THEN 1
+    WHEN 'pastor' THEN 2
+    WHEN 'director-general' THEN 3
+    WHEN 'director-etapa' THEN 4
+    ELSE 99
+  END
+  LIMIT 1;
+
+  IF v_user_id IS NULL THEN
+    RETURN FALSE;
+  END IF;
+
+  IF v_role IN ('admin', 'pastor') THEN
+    RETURN TRUE;
+  END IF;
+
+  IF v_role = 'director-general' THEN
+    RETURN EXISTS (
+      SELECT 1
+      FROM public.grupos g
+      JOIN public.director_general_segmentos dgs
+        ON dgs.segmento_id = g.segmento_id
+      WHERE g.id = p_grupo_id
+        AND dgs.usuario_id = v_user_id
+    );
+  END IF;
+
+  IF v_role = 'director-etapa' THEN
+    RETURN EXISTS (
+      SELECT 1
+      FROM public.director_etapa_grupos deg
+      JOIN public.segmento_lideres sl ON sl.id = deg.director_etapa_id
+      WHERE deg.grupo_id = p_grupo_id
+        AND sl.usuario_id = v_user_id
+        AND sl.tipo_lider = 'director_etapa'
+    );
+  END IF;
+
+  RETURN FALSE;
+END;
+$$;
+
+REVOKE ALL ON FUNCTION public.puede_ver_grupo_reporte_asistencia(uuid, uuid) FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION public.puede_ver_grupo_reporte_asistencia(uuid, uuid) TO authenticated, service_role;
+
+DROP FUNCTION IF EXISTS public.obtener_reporte_semanal_asistencia(uuid, date, boolean);
+
+CREATE OR REPLACE FUNCTION public.obtener_reporte_semanal_asistencia(
+  p_auth_id uuid,
+  p_fecha_semana date DEFAULT NULL,
+  p_incluir_todos boolean DEFAULT false
+)
+RETURNS jsonb
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path TO 'public'
+AS $$
+DECLARE
+  v_user_id uuid;
+  v_rol_nombre text;
+  v_fecha_inicio date;
+  v_fecha_fin date;
+  v_numero_semana int;
+  v_fecha_inicio_anterior date;
+  v_fecha_fin_anterior date;
+  v_result jsonb;
+  v_kpis_globales jsonb;
+  v_tendencia jsonb;
+  v_por_segmento jsonb;
+  v_grupos_perfectos jsonb;
+  v_grupos_riesgo jsonb;
+  v_grupos_riesgo_todos jsonb;
+BEGIN
+  SELECT u.id, rs.nombre_interno
+  INTO v_user_id, v_rol_nombre
+  FROM public.usuarios u
+  JOIN public.usuario_roles ur ON ur.usuario_id = u.id
+  JOIN public.roles_sistema rs ON rs.id = ur.rol_id
+  WHERE u.auth_id = p_auth_id
+    AND rs.nombre_interno IN ('admin', 'pastor', 'director-general', 'director-etapa')
+  ORDER BY CASE rs.nombre_interno
+    WHEN 'admin' THEN 1
+    WHEN 'pastor' THEN 2
+    WHEN 'director-general' THEN 3
+    WHEN 'director-etapa' THEN 4
+    ELSE 99
+  END
+  LIMIT 1;
+
+  IF v_user_id IS NULL THEN
+    RAISE EXCEPTION 'No tienes permisos para ver este reporte';
+  END IF;
+
+  IF p_fecha_semana IS NULL THEN p_fecha_semana := CURRENT_DATE; END IF;
+  v_fecha_inicio := p_fecha_semana - (((EXTRACT(ISODOW FROM p_fecha_semana)::int + 6) % 7));
+  v_fecha_fin := v_fecha_inicio + INTERVAL '6 days';
+  v_numero_semana := EXTRACT(WEEK FROM v_fecha_inicio)::int;
+  v_fecha_inicio_anterior := v_fecha_inicio - INTERVAL '7 days';
+  v_fecha_fin_anterior := v_fecha_fin - INTERVAL '7 days';
+
+  WITH grupos_activos AS (
+    SELECT g.id, g.segmento_id
+    FROM public.grupos g
+    WHERE g.activo = true
+      AND public.puede_ver_grupo_reporte_asistencia(p_auth_id, g.id)
+  ),
+  eventos_semana AS (
+    SELECT eg.id AS evento_id, eg.grupo_id, ga.segmento_id,
+           COUNT(a.id) AS total_registros,
+           COUNT(a.id) FILTER (WHERE a.presente = true) AS total_presentes
+    FROM public.eventos_grupo eg
+    JOIN grupos_activos ga ON ga.id = eg.grupo_id
+    LEFT JOIN public.asistencia a ON a.evento_grupo_id = eg.id
+    WHERE eg.fecha >= v_fecha_inicio AND eg.fecha <= v_fecha_fin
+    GROUP BY eg.id, eg.grupo_id, ga.segmento_id
+  ),
+  eventos_por_grupo AS (
+    SELECT es.grupo_id, es.segmento_id,
+           SUM(es.total_registros) AS total_registros,
+           SUM(es.total_presentes) AS total_presentes,
+           COUNT(DISTINCT es.evento_id) AS total_eventos
+    FROM eventos_semana es
+    GROUP BY es.grupo_id, es.segmento_id
+  ),
+  base_grupos_semana AS (
+    SELECT ga.id AS grupo_id, ga.segmento_id,
+           COALESCE(eg.total_registros,0) AS total_registros,
+           COALESCE(eg.total_presentes,0) AS total_presentes,
+           COALESCE(eg.total_eventos,0) AS total_eventos
+    FROM grupos_activos ga
+    LEFT JOIN eventos_por_grupo eg ON eg.grupo_id = ga.id
+  ),
+  kpis AS (
+    SELECT
+      CASE WHEN p_incluir_todos = false THEN
+        COALESCE(ROUND((SUM(es.total_presentes)::numeric / NULLIF(SUM(es.total_registros),0)::numeric) * 100, 1), 0)
+      ELSE
+        COALESCE(ROUND(AVG(CASE WHEN bgs.total_registros>0 THEN (bgs.total_presentes::numeric / bgs.total_registros::numeric)*100 ELSE 0 END), 1), 0)
+      END AS porcentaje_asistencia_global,
+      SUM(CASE WHEN p_incluir_todos = false THEN es.total_eventos ELSE bgs.total_eventos END) AS total_reuniones_registradas,
+      SUM(CASE WHEN p_incluir_todos = false THEN CASE WHEN es.total_eventos>0 THEN 1 ELSE 0 END ELSE CASE WHEN bgs.total_eventos>0 THEN 1 ELSE 0 END END) AS total_grupos_con_reunion,
+      (SELECT COUNT(*) FROM grupos_activos) AS total_grupos_activos,
+      COALESCE(SUM(bgs.total_presentes), 0) AS total_miembros_asistentes,
+      (
+        SELECT COUNT(*)
+        FROM public.grupo_miembros gm
+        JOIN grupos_activos ga2 ON ga2.id = gm.grupo_id
+      ) AS total_miembros_en_grupos
+    FROM eventos_por_grupo es
+    FULL JOIN base_grupos_semana bgs ON bgs.grupo_id = es.grupo_id
+  ),
+  eventos_semana_ant AS (
+    SELECT eg.id AS evento_id, eg.grupo_id,
+           COUNT(a.id) AS total_registros,
+           COUNT(a.id) FILTER (WHERE a.presente = true) AS total_presentes
+    FROM public.eventos_grupo eg
+    JOIN grupos_activos ga ON ga.id = eg.grupo_id
+    LEFT JOIN public.asistencia a ON a.evento_grupo_id = eg.id
+    WHERE eg.fecha >= v_fecha_inicio_anterior AND eg.fecha <= v_fecha_fin_anterior
+    GROUP BY eg.id, eg.grupo_id
+  ),
+  eventos_por_grupo_ant AS (
+    SELECT es.grupo_id,
+           SUM(es.total_registros) AS total_registros,
+           SUM(es.total_presentes) AS total_presentes
+    FROM eventos_semana_ant es
+    GROUP BY es.grupo_id
+  ),
+  base_grupos_semana_ant AS (
+    SELECT ga.id AS grupo_id,
+           COALESCE(eg.total_registros,0) AS total_registros,
+           COALESCE(eg.total_presentes,0) AS total_presentes
+    FROM grupos_activos ga
+    LEFT JOIN eventos_por_grupo_ant eg ON eg.grupo_id = ga.id
+  ),
+  kpis_ant AS (
+    SELECT
+      CASE WHEN p_incluir_todos = false THEN
+        COALESCE(ROUND((SUM(es.total_presentes)::numeric / NULLIF(SUM(es.total_registros),0)::numeric) * 100, 1), 0)
+      ELSE
+        COALESCE(ROUND(AVG(CASE WHEN bga.total_registros>0 THEN (bga.total_presentes::numeric/bga.total_registros::numeric)*100 ELSE 0 END),1),0)
+      END AS porcentaje
+    FROM eventos_por_grupo_ant es
+    FULL JOIN base_grupos_semana_ant bga ON bga.grupo_id = es.grupo_id
+  )
+  SELECT jsonb_build_object(
+    'porcentaje_asistencia_global', k.porcentaje_asistencia_global,
+    'variacion_semana_anterior', ROUND(k.porcentaje_asistencia_global - ka.porcentaje, 1),
+    'total_reuniones_registradas', k.total_reuniones_registradas,
+    'total_grupos_con_reunion', k.total_grupos_con_reunion,
+    'total_grupos_activos', k.total_grupos_activos,
+    'total_miembros_asistentes', k.total_miembros_asistentes,
+    'total_miembros_en_grupos', k.total_miembros_en_grupos
+  ) INTO v_kpis_globales
+  FROM kpis k, kpis_ant ka;
+
+  v_tendencia := (
+    WITH semanas AS (
+      SELECT v_fecha_inicio - (n * INTERVAL '7 days') AS semana_inicio,
+             v_fecha_fin - (n * INTERVAL '7 days') AS semana_fin
+      FROM generate_series(0,7) AS n
+    ),
+    trend AS (
+      SELECT s.semana_inicio,
+        CASE WHEN p_incluir_todos = false THEN
+          COALESCE(ROUND((COUNT(a.id) FILTER (WHERE a.presente = true)::numeric / NULLIF(COUNT(a.id),0)::numeric) * 100, 1), 0)
+        ELSE (
+          SELECT COALESCE(ROUND(AVG(CASE WHEN epg.total_registros>0 THEN (epg.total_presentes::numeric/epg.total_registros::numeric)*100 ELSE 0 END),1),0)
+          FROM (
+            SELECT g.id AS grupo_id
+            FROM public.grupos g
+            WHERE g.activo = true
+              AND public.puede_ver_grupo_reporte_asistencia(p_auth_id, g.id)
+          ) gperm
+          LEFT JOIN (
+            SELECT eg.grupo_id,
+                   COUNT(a.id) AS total_registros,
+                   COUNT(a.id) FILTER (WHERE a.presente = true) AS total_presentes
+            FROM public.eventos_grupo eg
+            LEFT JOIN public.asistencia a ON a.evento_grupo_id = eg.id
+            WHERE eg.fecha >= s.semana_inicio AND eg.fecha <= s.semana_fin
+            GROUP BY eg.grupo_id
+          ) epg ON epg.grupo_id = gperm.grupo_id
+        ) END AS porcentaje
+      FROM semanas s
+      LEFT JOIN public.eventos_grupo eg
+        ON eg.fecha >= s.semana_inicio
+       AND eg.fecha <= s.semana_fin
+       AND public.puede_ver_grupo_reporte_asistencia(p_auth_id, eg.grupo_id)
+      LEFT JOIN public.asistencia a ON a.evento_grupo_id = eg.id
+      GROUP BY s.semana_inicio, s.semana_fin
+      ORDER BY s.semana_inicio
+    )
+    SELECT jsonb_agg(jsonb_build_object('semana_inicio', semana_inicio, 'porcentaje', porcentaje)) FROM trend
+  );
+
+  v_por_segmento := (
+    WITH grupos_perm AS (
+      SELECT g.id, g.segmento_id
+      FROM public.grupos g
+      WHERE g.activo = true
+        AND public.puede_ver_grupo_reporte_asistencia(p_auth_id, g.id)
+    ),
+    eventos_agreg AS (
+      SELECT eg.grupo_id,
+             COUNT(a.id) AS total_registros,
+             COUNT(a.id) FILTER (WHERE a.presente = true) AS total_presentes
+      FROM public.eventos_grupo eg
+      JOIN grupos_perm gp ON gp.id = eg.grupo_id
+      LEFT JOIN public.asistencia a ON a.evento_grupo_id = eg.id
+      WHERE eg.fecha >= v_fecha_inicio AND eg.fecha <= v_fecha_fin
+      GROUP BY eg.grupo_id
+    ),
+    grupo_stats AS (
+      SELECT gp.segmento_id, gp.id AS grupo_id,
+             COALESCE(e.total_registros,0) AS total_registros,
+             COALESCE(e.total_presentes,0) AS total_presentes,
+             CASE WHEN COALESCE(e.total_registros,0)>0 THEN (COALESCE(e.total_presentes,0)::numeric/COALESCE(e.total_registros,0)::numeric)*100 ELSE 0 END AS pct_grupo
+      FROM grupos_perm gp
+      LEFT JOIN eventos_agreg e ON e.grupo_id = gp.id
+    ),
+    seg AS (
+      SELECT segmento_id,
+        CASE WHEN p_incluir_todos = true THEN ROUND(AVG(pct_grupo),1)
+             ELSE COALESCE(ROUND((SUM(total_presentes)::numeric/NULLIF(SUM(total_registros),0)::numeric)*100,1),0)
+        END AS porcentaje,
+        SUM(total_registros) AS registros
+      FROM grupo_stats
+      GROUP BY segmento_id
+    ),
+    eventos_por_segmento AS (
+      SELECT gp.segmento_id, COUNT(DISTINCT eg.id) AS total_reuniones
+      FROM public.eventos_grupo eg
+      JOIN grupos_perm gp ON gp.id = eg.grupo_id
+      WHERE eg.fecha >= v_fecha_inicio AND eg.fecha <= v_fecha_fin
+      GROUP BY gp.segmento_id
+    )
+    SELECT jsonb_agg(jsonb_build_object(
+      'id', s.segmento_id,
+      'nombre', COALESCE(se.nombre,'Sin segmento'),
+      'porcentaje_asistencia', s.porcentaje,
+      'total_reuniones', COALESCE(eps.total_reuniones,0)
+    ) ORDER BY s.porcentaje DESC)
+    FROM seg s
+    LEFT JOIN public.segmentos se ON se.id = s.segmento_id
+    LEFT JOIN eventos_por_segmento eps ON eps.segmento_id = s.segmento_id
+  );
+
+  v_grupos_perfectos := (
+    WITH grupos_perm AS (
+      SELECT g.id
+      FROM public.grupos g
+      WHERE g.activo = true
+        AND public.puede_ver_grupo_reporte_asistencia(p_auth_id, g.id)
+    ),
+    eventos_agreg AS (
+      SELECT eg.grupo_id,
+             COUNT(a.id) AS total_registros,
+             COUNT(a.id) FILTER (WHERE a.presente = true) AS total_presentes
+      FROM public.eventos_grupo eg
+      JOIN grupos_perm gp ON gp.id = eg.grupo_id
+      LEFT JOIN public.asistencia a ON a.evento_grupo_id = eg.id
+      WHERE eg.fecha >= v_fecha_inicio AND eg.fecha <= v_fecha_fin
+      GROUP BY eg.grupo_id
+    )
+    SELECT jsonb_agg(jsonb_build_object('id', x.grupo_id, 'nombre', g.nombre, 'lideres', COALESCE(l.lideres,'Sin líderes asignados')))
+    FROM (
+      SELECT grupo_id
+      FROM eventos_agreg
+      GROUP BY grupo_id
+      HAVING ROUND((SUM(total_presentes)::numeric / NULLIF(SUM(total_registros),0)::numeric) * 100,1) = 100
+      ORDER BY grupo_id
+      LIMIT 5
+    ) x
+    JOIN public.grupos g ON g.id = x.grupo_id
+    LEFT JOIN (
+      SELECT gm.grupo_id, STRING_AGG(DISTINCT u.nombre || ' ' || u.apellido, ', ' ORDER BY u.nombre||' '||u.apellido) AS lideres
+      FROM public.grupo_miembros gm
+      JOIN public.usuarios u ON u.id = gm.usuario_id
+      WHERE gm.rol = 'Líder'
+      GROUP BY gm.grupo_id
+    ) l ON l.grupo_id = x.grupo_id
+  );
+
+  v_grupos_riesgo := (
+    WITH grupos_perm AS (
+      SELECT g.id
+      FROM public.grupos g
+      WHERE g.activo = true
+        AND public.puede_ver_grupo_reporte_asistencia(p_auth_id, g.id)
+    ),
+    eventos_agreg AS (
+      SELECT eg.grupo_id,
+             COUNT(a.id) AS total_registros,
+             COUNT(a.id) FILTER (WHERE a.presente = true) AS total_presentes
+      FROM public.eventos_grupo eg
+      JOIN grupos_perm gp ON gp.id = eg.grupo_id
+      LEFT JOIN public.asistencia a ON a.evento_grupo_id = eg.id
+      WHERE eg.fecha >= v_fecha_inicio AND eg.fecha <= v_fecha_fin
+      GROUP BY eg.grupo_id
+    ),
+    pct AS (
+      SELECT gp.id AS grupo_id,
+             COALESCE(ROUND((CASE WHEN COALESCE(e.total_registros,0)>0 THEN (COALESCE(e.total_presentes,0)::numeric/COALESCE(e.total_registros,0)::numeric)*100 ELSE 0 END),1),0) AS porcentaje,
+             COALESCE(e.total_registros,0) AS total_registros
+      FROM grupos_perm gp
+      LEFT JOIN eventos_agreg e ON e.grupo_id = gp.id
+    )
+    SELECT jsonb_agg(jsonb_build_object('id', o.grupo_id, 'nombre', g.nombre, 'porcentaje_asistencia', o.porcentaje, 'lideres', COALESCE(l.lideres,'Sin líderes asignados')))
+    FROM (
+      SELECT grupo_id, porcentaje
+      FROM pct
+      WHERE (p_incluir_todos = true OR total_registros > 0)
+        AND porcentaje > 0
+        AND porcentaje < 70
+      ORDER BY porcentaje ASC, grupo_id
+      LIMIT 5
+    ) o
+    JOIN public.grupos g ON g.id = o.grupo_id
+    LEFT JOIN (
+      SELECT gm.grupo_id, STRING_AGG(DISTINCT u.nombre || ' ' || u.apellido, ', ' ORDER BY u.nombre||' '||u.apellido) AS lideres
+      FROM public.grupo_miembros gm
+      JOIN public.usuarios u ON u.id = gm.usuario_id
+      WHERE gm.rol = 'Líder'
+      GROUP BY gm.grupo_id
+    ) l ON l.grupo_id = o.grupo_id
+  );
+
+  v_grupos_riesgo_todos := (
+    WITH grupos_perm AS (
+      SELECT g.id
+      FROM public.grupos g
+      WHERE g.activo = true
+        AND public.puede_ver_grupo_reporte_asistencia(p_auth_id, g.id)
+    ),
+    eventos_agreg AS (
+      SELECT eg.grupo_id,
+             COUNT(a.id) AS total_registros,
+             COUNT(a.id) FILTER (WHERE a.presente = true) AS total_presentes
+      FROM public.eventos_grupo eg
+      JOIN grupos_perm gp ON gp.id = eg.grupo_id
+      LEFT JOIN public.asistencia a ON a.evento_grupo_id = eg.id
+      WHERE eg.fecha >= v_fecha_inicio AND eg.fecha <= v_fecha_fin
+      GROUP BY eg.grupo_id
+    ),
+    pct AS (
+      SELECT gp.id AS grupo_id,
+             COALESCE(ROUND((CASE WHEN COALESCE(e.total_registros,0)>0 THEN (COALESCE(e.total_presentes,0)::numeric/COALESCE(e.total_registros,0)::numeric)*100 ELSE 0 END),1),0) AS porcentaje,
+             COALESCE(e.total_registros,0) AS total_registros
+      FROM grupos_perm gp
+      LEFT JOIN eventos_agreg e ON e.grupo_id = gp.id
+    )
+    SELECT jsonb_agg(jsonb_build_object('id', o.grupo_id, 'nombre', g.nombre, 'porcentaje_asistencia', o.porcentaje, 'lideres', COALESCE(l.lideres,'Sin líderes asignados')))
+    FROM (
+      SELECT grupo_id, porcentaje
+      FROM pct
+      WHERE (p_incluir_todos = true OR total_registros > 0)
+        AND porcentaje < 70
+      ORDER BY porcentaje ASC, grupo_id
+    ) o
+    JOIN public.grupos g ON g.id = o.grupo_id
+    LEFT JOIN (
+      SELECT gm.grupo_id, STRING_AGG(DISTINCT u.nombre || ' ' || u.apellido, ', ' ORDER BY u.nombre||' '||u.apellido) AS lideres
+      FROM public.grupo_miembros gm
+      JOIN public.usuarios u ON u.id = gm.usuario_id
+      WHERE gm.rol = 'Líder'
+      GROUP BY gm.grupo_id
+    ) l ON l.grupo_id = o.grupo_id
+  );
+
+  v_result := jsonb_build_object(
+    'semana', jsonb_build_object('inicio', v_fecha_inicio, 'fin', v_fecha_fin, 'numero', v_numero_semana),
+    'kpis_globales', v_kpis_globales,
+    'tendencia_asistencia_global', COALESCE(v_tendencia, '[]'::jsonb),
+    'asistencia_por_segmento', COALESCE(v_por_segmento, '[]'::jsonb),
+    'top_5_grupos_perfectos', COALESCE(v_grupos_perfectos, '[]'::jsonb),
+    'top_5_grupos_en_riesgo', COALESCE(v_grupos_riesgo, '[]'::jsonb),
+    'grupos_en_riesgo_todos', COALESCE(v_grupos_riesgo_todos, '[]'::jsonb)
+  );
+
+  RETURN v_result;
+END;
+$$;
+
+REVOKE ALL ON FUNCTION public.obtener_reporte_semanal_asistencia(uuid, date, boolean) FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION public.obtener_reporte_semanal_asistencia(uuid, date, boolean) TO authenticated, service_role;
+
+COMMENT ON FUNCTION public.obtener_reporte_semanal_asistencia(uuid, date, boolean)
+IS 'Reporte semanal de asistencia. Admin/pastor ven global; director-general ve segmentos asignados; director-etapa ve grupos asignados.';
+
+-- -----------------------------------------------------------------------------
+-- Minimal family relation search
+-- -----------------------------------------------------------------------------
+
+CREATE OR REPLACE FUNCTION public.buscar_usuarios_para_relacion_familiar(
+  p_auth_id uuid,
+  p_usuario_base_id uuid,
+  p_busqueda text DEFAULT '',
+  p_limite integer DEFAULT 10
+)
+RETURNS TABLE (
+  id uuid,
+  nombre text,
+  apellido text,
+  foto_perfil_url text,
+  total_count bigint
+)
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path TO 'public'
+AS $$
+DECLARE
+  v_busqueda_like text;
+  v_limite integer := least(greatest(coalesce(p_limite, 10), 0), 25);
+BEGIN
+  IF p_auth_id IS NULL OR p_usuario_base_id IS NULL THEN
+    RETURN;
+  END IF;
+
+  IF p_auth_id IS DISTINCT FROM auth.uid() THEN
+    RAISE EXCEPTION 'Authentication required' USING ERRCODE = '28000';
+  END IF;
+
+  v_busqueda_like := replace(
+    replace(
+      replace(trim(coalesce(p_busqueda, '')), E'\\', E'\\\\'),
+      '%',
+      E'\\%'
+    ),
+    '_',
+    E'\\_'
+  );
+
+  RETURN QUERY
+  WITH candidatos AS MATERIALIZED (
+    SELECT DISTINCT u.id, u.nombre, u.apellido, u.foto_perfil_url
+    FROM public.usuarios u
+    WHERE u.id <> p_usuario_base_id
+      AND public.puede_gestionar_relacion_familiar(p_auth_id, p_usuario_base_id, u.id)
+      AND (
+        v_busqueda_like = ''
+        OR u.nombre ILIKE '%' || v_busqueda_like || '%' ESCAPE E'\\'
+        OR u.apellido ILIKE '%' || v_busqueda_like || '%' ESCAPE E'\\'
+      )
+  ), total AS (
+    SELECT count(*)::bigint AS total_count FROM candidatos
+  )
+  SELECT c.id, c.nombre, c.apellido, c.foto_perfil_url, total.total_count
+  FROM candidatos c
+  CROSS JOIN total
+  ORDER BY c.nombre, c.apellido
+  LIMIT v_limite;
+END;
+$$;
+
+REVOKE ALL ON FUNCTION public.buscar_usuarios_para_relacion_familiar(uuid, uuid, text, integer) FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION public.buscar_usuarios_para_relacion_familiar(uuid, uuid, text, integer) TO authenticated;
+
+-- -----------------------------------------------------------------------------
+-- Legacy family relation mutation cleanup
+-- -----------------------------------------------------------------------------
+
+DO $$
+DECLARE
+  v_function record;
+BEGIN
+  FOR v_function IN
+    SELECT p.oid::regprocedure AS signature
+    FROM pg_proc p
+    JOIN pg_namespace n ON n.oid = p.pronamespace
+    WHERE n.nspname = 'public'
+      AND p.proname = 'agregar_relacion_familiar'
+  LOOP
+    EXECUTE format('DROP FUNCTION %s', v_function.signature);
+  END LOOP;
+END $$;


### PR DESCRIPTION
Closes #192

## Resumen
Harden Grupos de Vida, user profile detail, dashboard/report scoping, bulk group status updates, and family relationship flows after Judgment Day security review.

## Qué Incluye
- Scoped Supabase RLS/RPC hardening for users, groups, dashboard reports, and family relationships.
- Replaced unsafe family relation mutation/search paths with safe scoped RPCs and minimal response fields.
- Updated Next.js API/server actions/modal/types to align with the hardened database contract.

## Motivación / Por Qué
Removes authorization bypasses and PII exposure risks found in Judgment Day review. Directors and leaders should only see or mutate data inside their assigned role scope.

## Evidencia Visual (si aplica)
| Antes | Después |
|-------|---------|
| No aplica | No aplica |

## Migraciones / Base de Datos
- [ ] No aplica
- [x] Sí (orden exacto):
```sql
20260618203000_harden_judgment_day_critical_security.sql
20260619000353_harden_round3_remaining_blockers.sql
```
Notas: these migrations must be applied with the deploy for production enforcement.

## Impacto y Riesgos
- No intended breaking change for authorized users.
- Requires coordinated DB migration + app deploy.
- Security impact: restricts over-broad data access and mutation paths.
- Review-size exception approved because most of the diff is tightly coupled SQL migration code.

## Checklist Autor
- [x] Código formateado (Prettier/ESLint)
- [x] Sin `console.log` / debugger
- [x] Validaciones con zod para entradas nuevas
- [x] Estados loading/error/empty cubiertos
- [x] Tipos TypeScript correctos
- [ ] Migraciones probadas local
- [x] Documentación actualizada (`docs/` o README)
- [x] Variables de entorno documentadas
- [x] Rebase con `main` limpio

## Checklist Revisor
- [x] Propósito claro
- [x] Nombres descriptivos
- [x] Sin lógica duplicada evidente
- [x] Manejo adecuado de errores
- [x] Cambios acotados al alcance
- [x] Sin secretos / datos sensibles

## Pruebas Manuales Realizadas
- `pnpm lint:migrations` passed with existing warnings only.
- `pnpm exec tsc --noEmit` passed.
- Focused tests reported passing during Judgment Day re-review.
- Fresh pre-commit risk review returned PASS.
- Judgment Day Round 4: APPROVED by both blind judges.

## Pendientes / Follow-up (opcional)
- Apply migrations in disposable/staging DB before production.
- Add SQL regression tests for DG weekly report scoping and PII-free family relation search.

## Notas Adicionales
- `size:exception` requested/approved because DB hardening and app callers must ship together.
- Unrelated untracked `docs/support-agent-integration-spec.md` is intentionally excluded.