### PR TITLE
docs(roadmap): agregar roadmap maestro

### DIFF
--- a/docs/roadmap/globalconnect-roadmap-maestro-v1.md
+++ b/docs/roadmap/globalconnect-roadmap-maestro-v1.md
@@ -1,0 +1,355 @@
+# Roadmap Maestro v1 — GlobalConnect
+
+Este documento es una guía estratégica **pre-SDD**. No es una especificación de implementación. Su propósito es mantener el panorama completo para que futuros agentes/orquestadores creen SDDs específicos por fase, ejecuten en orden y reporten contra este plan.
+
+## Principios no negociables
+
+- **Una persona, muchos contextos**: una misma persona puede ser padre, líder, servidor, director, participante de taller, miembro de grupo, etc.
+- **Dream Team = toda persona que sirve** en cualquier experiencia.
+- **Experiencias** es la capa organizacional: Grupos de Vida, DPS, Niños, Estudiantes, The Living Room, Talleres de Crecimiento y futuras experiencias.
+- **Grupos de Vida no se rediseña** en este roadmap inicial; se integra con extremo cuidado porque tiene uso fuerte en producción.
+- **Roles globales pocos + responsabilidades/capabilities scoped**. Evitar explosión de roles.
+- **Cada experiencia tiene su operación propia**, pero comparte identidad, participación, permisos, notificaciones e historial.
+- **Hardware no bloquea MVP**: QR, tablets, kioscos e impresoras son optimizaciones posteriores.
+- **Historial longitudinal se captura temprano**, aunque los dashboards avanzados lleguen después.
+
+## Taxonomía base
+
+```text
+Experiencias
+├── Grupos de Vida
+├── Niños
+│   ├── Waumbaland
+│   └── Upstreet
+├── Estudiantes
+│   ├── Transit
+│   └── InsideOut
+├── The Living Room
+│   └── Etapa universitaria
+├── DPS
+├── Talleres de Crecimiento
+└── futuras experiencias
+
+Dream Team
+└── toda persona que sirve en cualquier experiencia
+
+Operating Core
+└── servicios, eventos, inscripciones, asistencia, capacidad, formularios, recursos y notificaciones
+
+Ruta Espiritual
+└── progreso/journey espiritual de la persona
+```
+
+## Fases
+
+### Fase 1 — Platform Foundation
+
+**Objetivo:** crear el cimiento común de identidad, relaciones, acceso y experiencias.
+
+Incluye:
+
+- persona única;
+- familias, padres/tutores y relaciones;
+- menores preparados desde el modelo, aunque NextGen opere después;
+- Experiencias como capa organizacional;
+- Access Foundation;
+- responsabilidades y capabilities scoped;
+- dashboard/menu contextual por responsabilidades activas;
+- deduplicación de personas;
+- historial longitudinal base;
+- integración segura con Grupos de Vida existente;
+- revisión de drift relacionado con `uno_a_uno` antes de usarlo.
+
+**No incluye:** rediseño de Grupos de Vida.
+
+**Validación:** una persona puede tener múltiples contextos sin duplicarse ni recibir permisos indebidos.
+
+### Fase 2 — Dream Team Global Base
+
+**Objetivo:** modelar a toda persona que sirve.
+
+Incluye:
+
+- servicio por experiencia/equipo/rol;
+- jerarquías flexibles y configurables;
+- director/coordinador/voluntario opcional según área;
+- estado de servicio;
+- requisitos configurables por área/rol;
+- conexión con Grupos de Vida, DPS, Talleres, Niños, Estudiantes y otras experiencias.
+
+**No incluye todavía:** onboarding completo, cursos, flujos avanzados de capacitación ni firmas digitales.
+
+### Fase 3 — Operating Core
+
+**Objetivo:** construir la tubería operativa común.
+
+Incluye:
+
+- servicios configurables;
+- eventos, actividades y talleres;
+- inscripciones asistidas o por link público;
+- búsqueda de persona existente antes de crear una nueva;
+- attendance/participation ledger común;
+- experiencias de captura específicas por dominio;
+- capacidad base y capacidad operativa por instancia;
+- formularios simples;
+- biblioteca simple de recursos;
+- notificaciones en sistema y por email;
+- dashboards operativos básicos.
+
+**No incluye todavía:** portal self-service completo, mensajería interna, integración profunda con WhatsApp ni analytics avanzados.
+
+### Fase 4 — Seguimiento Pastoral: 1:1 + Triada
+
+**Objetivo:** ofrecer seguimiento simple, seguro y transversal.
+
+Incluye:
+
+- 1:1 para Grupos de Vida;
+- 1:1 para The Living Room;
+- soporte para 1:1 individual o de pareja;
+- reportes generales, no detalles pastorales sensibles profundos;
+- visibilidad para líder creador, director inmediato y pastor/admin con permiso;
+- Triada como relación de seguimiento/servicio.
+
+**Regla:** mantenerlo simple, sin workflows pesados.
+
+### Fase 5 — Talleres de Crecimiento Base
+
+**Objetivo:** operar talleres formativos que alimentan la Ruta Espiritual.
+
+Incluye:
+
+- catálogo de talleres;
+- fechas/cohortes;
+- inscripción;
+- asistencia;
+- completación;
+- líderes, co-líderes y servidores;
+- conexión con Dream Team para quienes sirven;
+- historial de participación para quienes asisten.
+
+**Importante:** asistir a un taller no convierte a una persona en Dream Team; servir en el taller sí.
+
+### Fase 6 — The Living Room Operativo
+
+**Objetivo:** operar la etapa universitaria entre Estudiantes y Adultos.
+
+Incluye:
+
+- grupos universitarios propios;
+- asistencia a grupos/eventos;
+- uso del 1:1;
+- servicio y conexión con Dream Team;
+- mentoría;
+- transición hacia Adultos / Grupos de Vida;
+- métricas de salud comunitaria.
+
+**Importante:** The Living Room no es NextGen ni Grupos de Vida.
+
+### Fase 7 — DPS Operations
+
+**Objetivo:** construir herramientas específicas de DPS sobre Dream Team y Operating Core.
+
+Incluye:
+
+- estructura multiárea de DPS;
+- dashboards DPS;
+- evaluaciones vía formularios;
+- recursos;
+- repertorio;
+- media/comunicaciones;
+- atención al invitado;
+- herramientas específicas por subárea según prioridad.
+
+**Reglas:** DPS no es solo música. GlobalConnect complementa Planning Center Services; no lo reemplaza. No hay integración técnica con PCO en la primera etapa.
+
+### Fase 8 — NextGen Foundation
+
+**Objetivo:** preparar la base común de Niños + Estudiantes.
+
+Incluye:
+
+- Niños: Waumbaland + Upstreet;
+- Estudiantes: Transit + InsideOut;
+- menores/adolescentes;
+- padres/tutores;
+- datos sensibles con permisos estrictos;
+- comunicación base;
+- transiciones asistidas por director;
+- permisos por edad/contexto.
+
+### Fase 9 — Niños Operativo
+
+**Objetivo:** operar Waumbaland + Upstreet.
+
+Incluye:
+
+- ambientes y salones como unidad operativa;
+- check-in/check-out manual/asistido;
+- capacidad por servicio/salón;
+- necesidades especiales;
+- autorizados para recoger;
+- alertas;
+- reportes básicos.
+
+**Posterior:** QR, etiquetas, impresoras, kioscos y self check-in.
+
+### Fase 10 — Estudiantes Operativo
+
+**Objetivo:** operar Transit + InsideOut.
+
+Incluye:
+
+- registro de adolescentes;
+- visitantes;
+- grupos propios de Estudiantes;
+- asistencia nominal;
+- líderes de grupo;
+- comunicación con estudiantes/padres;
+- métrica Foyer → Living Room → Kitchen;
+- liderazgo estudiantil básico;
+- transición hacia The Living Room.
+
+**No incluye temprano:** campamentos completos, pagos, becas, lista de espera ni consentimientos digitales avanzados.
+
+### Fase 11 — Ruta Espiritual Completa
+
+**Objetivo:** construir el journey espiritual longitudinal.
+
+Incluye:
+
+- pasos de ruta;
+- progreso;
+- hitos;
+- talleres/retiros completados;
+- recomendaciones;
+- dashboards de crecimiento;
+- próximos pasos personalizados.
+
+### Fase 12 — Portal / Self-service
+
+**Objetivo:** habilitar acceso para miembros normales, padres y voluntarios.
+
+Incluye:
+
+- cuenta de miembro;
+- inscripción autenticada;
+- historial personal;
+- actualización de datos;
+- portal de padres;
+- vincular hijos;
+- autogestión de inscripciones;
+- notificaciones personalizadas.
+
+### Fase 13 — Campamentos / Eventos Avanzados
+
+**Objetivo:** operar eventos complejos.
+
+Incluye:
+
+- campamentos;
+- pagos registrados;
+- becas;
+- lista de espera;
+- documentos/consentimientos;
+- ficha médica extendida;
+- validación legal futura.
+
+**Primera aproximación recomendada:** tracking de documentos físicos recibidos/verificados antes que firma digital legal.
+
+### Fase 14 — Logística de Voluntarios
+
+**Objetivo:** manejar refrigerio y operación semanal de servidores.
+
+Incluye:
+
+- planificación semanal de servidores;
+- apertura de registro los lunes;
+- cierre de registro miércoles 4:00 p.m.;
+- confirmación de refrigerio;
+- reporte para Cocina / Atención al Voluntario;
+- QR de validación;
+- control de entrega el domingo.
+
+**Depende de:** portal/acceso de voluntarios, notificaciones y Dream Team maduro.
+
+### Fase 15 — Hardware / Automatización
+
+**Objetivo:** optimizar procesos ya probados.
+
+Incluye:
+
+- tablets;
+- kioscos;
+- impresoras;
+- etiquetas;
+- QR scanning;
+- self check-in;
+- automatizaciones avanzadas.
+
+## Decisiones arquitectónicas clave
+
+### Persona y permisos
+
+- Una persona puede tener muchos contextos.
+- Una relación da contexto, no permisos infinitos.
+- Ser padre no permite administrar Niños.
+- Ser bajista no permite administrar DPS.
+- Asistir a un taller no permite administrarlo.
+- Ser director de etapa no permite ver todos los 1:1 de la iglesia.
+
+### Grupos y participación
+
+- Grupos de Vida se conserva como dominio existente de producción.
+- Grupos de Estudiantes son propios de Estudiantes.
+- Grupos de The Living Room son universitarios propios.
+- Niños usa ambientes/salones, no grupos pequeños.
+- Todos deben alimentar historial/participación común cuando aplique.
+
+### Asistencia
+
+- Operating Core mantiene un ledger común.
+- Cada dominio tiene experiencia de captura propia.
+- Grupos de Vida no se reemplaza de golpe; se integra/adapta con cuidado.
+
+### Capacidad
+
+- Existe capacidad base y capacidad operativa por instancia.
+- La capacidad puede cambiar por fecha, servicio, ambiente, voluntarios disponibles o contexto.
+
+### Comunicación
+
+- Primera versión: notificaciones en sistema, email, links compartibles y flujos compatibles con WhatsApp manual.
+- Futuro: mensajería interna e integración profunda con WhatsApp.
+
+## Guía para futuros agentes SDD
+
+Cada agente debe:
+
+1. Leer este roadmap antes de proponer.
+2. Investigar el código actual antes de diseñar.
+3. Revisar documentos fuente si la fase toca Niños, Estudiantes, The Living Room o DPS.
+4. No rediseñar Grupos de Vida salvo instrucción explícita.
+5. Mantener persona única y relaciones contextuales.
+6. Usar capabilities scoped, no crear roles infinitos.
+7. Separar servicio, participación, familia, liderazgo y permisos.
+8. Preservar operación sin hardware cuando aplique.
+9. Reportar al cerrar:
+   - qué investigó;
+   - qué propuso;
+   - riesgos;
+   - dependencias;
+   - qué queda fuera;
+   - validación contra este roadmap.
+
+## Documentos fuente
+
+- `/Users/isaacpaezz/Documents/#Global/SISTEMA GDV/NiÑos validacion directores 2026.docx`
+- `/Users/isaacpaezz/Documents/#Global/SISTEMA GDV/Estudiantes validación directores (1).docx`
+- `/Users/isaacpaezz/Documents/#Global/SISTEMA GDV/The Living Room validación directores (1) (1).docx`
+- `/Users/isaacpaezz/Documents/#Global/SISTEMA GDV/DPS validación directores.docx.pdf`
+
+## Próximo paso
+
+Preparar el handoff detallado de **Fase 1 — Platform Foundation** para que un agente SDD pueda investigar, proponer y diseñar sin perder el contexto del programa completo.

--- a/docs/roadmap/handoffs/fase-01-platform-foundation.md
+++ b/docs/roadmap/handoffs/fase-01-platform-foundation.md
@@ -1,0 +1,246 @@
+# Handoff — Fase 1: Platform Foundation
+
+Este handoff es una guía para que un agente/orquestador SDD investigue y prepare la fase **Platform Foundation**. No es una especificación final ni una instrucción para implementar directamente.
+
+## Objetivo de la fase
+
+Crear el cimiento común para que GlobalConnect pueda conectar personas, familias, experiencias, responsabilidades, permisos e historial sin duplicar identidades ni romper Grupos de Vida.
+
+## Resultado esperado del agente
+
+El agente debe producir artefactos SDD para esta fase:
+
+1. exploración técnica del estado actual;
+2. propuesta de cambio;
+3. especificación funcional;
+4. diseño técnico;
+5. plan de tareas por slices seguros.
+
+No debe implementar hasta que esos artefactos sean revisados y aprobados.
+
+## Contexto estratégico
+
+Platform Foundation desbloquea todas las fases posteriores:
+
+- Dream Team necesita saber quién sirve y en qué experiencia/equipo.
+- Operating Core necesita una persona única para inscripciones, asistencia e historial.
+- 1:1 necesita scopes claros de líder/director/pastor/admin.
+- Talleres de Crecimiento necesita participantes, líderes y completación.
+- The Living Room, Niños y Estudiantes necesitan grupos/ambientes propios sin mezclarse con Grupos de Vida.
+- Portal/Self-service futuro necesita cuentas normales y vinculación con personas existentes.
+
+## Principios no negociables
+
+- Una persona puede tener múltiples contextos simultáneos.
+- Una relación da contexto, no permisos infinitos.
+- Grupos de Vida es producción-crítico y no se rediseña en esta fase.
+- Roles globales deben seguir siendo pocos.
+- Nuevas responsabilidades deben modelarse con scopes/capabilities, no con explosión de roles.
+- Padres/tutores y menores deben estar previstos desde el modelo aunque NextGen opere más adelante.
+- El sistema debe soportar personas sin cuenta auth.
+- Todo cambio debe ser aditivo o compatible con producción.
+
+## Alcance funcional
+
+### 1. Persona única
+
+Investigar y diseñar cómo GlobalConnect debe representar una persona única que puede tener o no cuenta de usuario.
+
+Debe cubrir:
+
+- persona con cuenta auth;
+- persona sin cuenta auth;
+- miembro existente;
+- visitante/persona nueva;
+- padre/tutor;
+- menor/adolescente;
+- voluntario/servidor;
+- líder/director/coordinador según contexto.
+
+### 2. Relaciones familiares y contextuales
+
+Debe preparar el modelo para:
+
+- cónyuges;
+- padres/tutores;
+- hijos;
+- autorizados o contactos relacionados;
+- relaciones de liderazgo o cuidado;
+- relaciones futuras de transición.
+
+### 3. Experiencias
+
+Crear o diseñar la capa conceptual de experiencias:
+
+```text
+Experiencias
+├── Grupos de Vida
+├── Niños
+├── Estudiantes
+├── The Living Room
+├── DPS
+├── Talleres de Crecimiento
+└── futuras experiencias
+```
+
+Las experiencias organizan responsabilidad y alcance. No son lo mismo que Dream Team.
+
+### 4. Access Foundation
+
+Diseñar el modelo para:
+
+- roles globales pocos;
+- responsabilidades scoped por experiencia/equipo/grupo/salón;
+- capabilities scoped;
+- grants auditables;
+- helpers de sesión que devuelvan responsabilidades activas;
+- menú/dashboard contextual según responsabilidades.
+
+Referencia conceptual: el patrón de capabilities de soporte sirve como inspiración, pero no debe reutilizarse directamente como tabla genérica.
+
+### 5. Protección de Grupos de Vida
+
+Debe investigar el sistema actual de Grupos de Vida y proponer integración segura.
+
+No se permite:
+
+- reescribir asistencia de Grupos de Vida;
+- cambiar semántica de roles existentes sin migración compatible;
+- romper dashboards existentes;
+- mezclar grupos NextGen con Grupos de Vida;
+- alterar flujos de producción sin plan de compatibilidad.
+
+### 6. Historial longitudinal base
+
+Diseñar una base para capturar eventos de participación/historial desde temprano.
+
+Ejemplos futuros:
+
+- inscripción;
+- asistencia;
+- completación;
+- servicio activo;
+- transición;
+- asignación a grupo/equipo;
+- documento recibido;
+- 1:1 registrado;
+- cambios de estado relevantes.
+
+No se requiere timeline visual en esta fase.
+
+### 7. Dedupe / búsqueda de persona existente
+
+Toda inscripción o captura futura debe buscar una persona existente antes de crear una nueva.
+
+Esta fase debe investigar y proponer la base para evitar duplicados.
+
+## Fuera de alcance
+
+- Implementar Dream Team completo.
+- Implementar check-in/check-out de Niños.
+- Implementar grupos de Estudiantes o The Living Room.
+- Implementar Portal/Self-service.
+- Implementar Ruta Espiritual completa.
+- Implementar campamentos.
+- Rediseñar Grupos de Vida.
+- Crear una mensajería interna.
+- Crear hardware/QR/kioscos.
+
+## Investigación obligatoria en el repo
+
+El agente debe investigar como mínimo:
+
+- `lib/supabase/database.types.ts`;
+- `lib/getUserWithRoles.ts`;
+- `lib/auth/requireAuth.ts`;
+- `hooks/useCurrentUser.ts`;
+- `lib/dashboard/obtenerDatosDashboard.ts`;
+- `app/(auth)/dashboard/page.tsx`;
+- `components/ui/sidebar-moderna.tsx`;
+- `components/ui/header-movil.tsx`;
+- `components/ui/menu-inferior-movil.tsx`;
+- acciones y migraciones actuales de Grupos de Vida;
+- patrón de `support_user_capabilities` y helpers relacionados;
+- tablas actuales de usuarios, familias, relaciones, roles y grupos;
+- estado de tablas `uno_a_uno` y posible drift entre DB live/types/migraciones.
+
+## Preguntas que el agente debe responder
+
+1. ¿Qué parte del modelo actual ya soporta persona única y qué parte está acoplada a usuario auth?
+2. ¿Cómo se deben representar personas sin cuenta sin romper flujos existentes?
+3. ¿Qué estructura mínima de experiencias se necesita para fases futuras?
+4. ¿Cómo se modelan responsabilidades scoped sin explotar roles globales?
+5. ¿Qué debe cambiar en menú/dashboard para mostrar múltiples responsabilidades?
+6. ¿Cómo se integra Grupos de Vida sin rediseñarlo?
+7. ¿Qué historial longitudinal mínimo debe capturarse desde esta fase?
+8. ¿Qué migraciones serían aditivas y seguras?
+
+## Validación con ejemplos
+
+El diseño debe soportar este caso:
+
+```text
+Una persona es director de etapa de Grupos de Vida,
+sirve en DPS Música como bajista,
+está casada,
+tiene un hijo en Waumbaland,
+tiene otro hijo en InsideOut,
+y asiste como participante a un taller De hombre a hombre.
+```
+
+El sistema debe separar:
+
+- rol global;
+- responsabilidad en Grupos de Vida;
+- servicio en Dream Team/DPS;
+- relaciones familiares;
+- participación en taller;
+- permisos reales por scope.
+
+## Criterios de aceptación del diseño
+
+- El diseño mantiene Grupos de Vida funcionando sin rediseño.
+- El diseño permite múltiples contextos por persona.
+- El diseño evita crear roles globales por cada función.
+- El diseño prepara menores/tutores sin construir NextGen todavía.
+- El diseño prepara dashboard/menu contextual.
+- El diseño permite historial longitudinal futuro.
+- El diseño tiene una estrategia clara de deduplicación.
+- El diseño identifica riesgos de RLS, permisos y migraciones.
+
+## Riesgos principales
+
+- Romper Grupos de Vida en producción.
+- Duplicar personas por no resolver identidad primero.
+- Crear roles excesivos y difíciles de mantener.
+- Exponer información familiar, pastoral o de menores por scopes débiles.
+- Diseñar solo para adultos y luego rediseñar para NextGen.
+- Ignorar drift de `uno_a_uno`.
+
+## Reporte requerido al finalizar
+
+El agente debe reportar:
+
+```text
+status:
+resumen_ejecutivo:
+artefactos_creados:
+evidencia_investigada:
+decisiones_propuestas:
+riesgos:
+dependencias:
+fuera_de_alcance:
+validacion_contra_roadmap:
+preguntas_abiertas:
+siguiente_recomendado:
+```
+
+## Documentos que debe leer antes de trabajar
+
+- `docs/roadmap/globalconnect-roadmap-maestro-v1.md`
+- Este handoff.
+- Documentos fuente externos solo si necesita validar necesidades futuras de Niños, Estudiantes, The Living Room o DPS.
+
+## Nota para el orquestador
+
+No lanzar implementación directa desde este handoff. Primero usarlo para crear el SDD específico de Fase 1 y revisar sus artefactos antes de permitir `sdd-apply`.


### PR DESCRIPTION
Closes #198

## Tipo de PR
- [ ] Bug fix
- [ ] New feature
- [x] Documentation only
- [ ] Code refactoring
- [ ] Maintenance/tooling
- [ ] Breaking change

## Resumen
- Agrega el Roadmap Maestro v1 de GlobalConnect como guía estratégica pre-SDD.
- Agrega el handoff detallado de Fase 1 — Platform Foundation para futuros agentes/orquestadores.
- Define límites clave: no rediseñar Grupos de Vida, usar persona única, Experiencias, Dream Team y capabilities scoped.

## Cambios
| File | Change |
|------|--------|
| `docs/roadmap/globalconnect-roadmap-maestro-v1.md` | Documenta fases, principios, taxonomía y guía para futuros agentes SDD. |
| `docs/roadmap/handoffs/fase-01-platform-foundation.md` | Define alcance, investigación obligatoria, riesgos y formato de reporte para Fase 1. |

## Test Plan
- [x] Revisión manual del diff de documentación.
- [x] No se ejecutaron tests: cambio solo de documentación.

## Review Workload
- Cambios: 601 líneas de documentación.
- [x] Maintainer aprobó `size:exception` para mantener roadmap + handoff en un solo PR coherente.

## Contributor Checklist
- [x] Linked an approved issue.
- [x] Added exactly one `type:*` label.
- [x] Docs updated.
- [x] Conventional commit format.
- [x] No `Co-Authored-By` trailers.
