### PR TITLE
feat(platform): agregar PlatformSession base

### DIFF
--- a/__tests__/lib/platform/session.test.ts
+++ b/__tests__/lib/platform/session.test.ts
@@ -1,0 +1,151 @@
+import { buildPlatformSession } from '@/lib/platform/session/build'
+import type { PlatformSessionPersona } from '@/lib/platform/session/types'
+
+const linkedPersona: PlatformSessionPersona = {
+  id: 'persona-auth-1',
+  authId: 'auth-1',
+}
+
+describe('PlatformSession builder', () => {
+  it('derives authenticated persona from the backend auth subject', async () => {
+    const personaLookup = {
+      findByAuthId: jest.fn().mockResolvedValue(linkedPersona),
+    }
+
+    const result = await buildPlatformSession({
+      subjectAuthId: 'auth-1',
+      personaLookup,
+    })
+
+    expect(personaLookup.findByAuthId).toHaveBeenCalledWith('auth-1')
+    expect(result).toEqual({
+      ok: true,
+      session: {
+        personaId: 'persona-auth-1',
+        subjectAuthId: 'auth-1',
+        globalRoles: [],
+        contexts: [],
+        capabilities: [],
+      },
+      warnings: [],
+    })
+  })
+
+  it('fails closed for blank backend auth without calling persona lookup', async () => {
+    const personaLookup = {
+      findByAuthId: jest.fn(),
+    }
+
+    const result = await buildPlatformSession({
+      subjectAuthId: '   ',
+      personaLookup,
+    })
+
+    expect(personaLookup.findByAuthId).not.toHaveBeenCalled()
+    expect(result).toEqual({ ok: false, reason: 'unauthenticated', warnings: [] })
+  })
+
+  it('fails closed for missing backend auth without calling persona lookup', async () => {
+    const personaLookup = {
+      findByAuthId: jest.fn(),
+    }
+
+    const result = await buildPlatformSession({
+      subjectAuthId: null,
+      clientPersonaId: 'forged-persona',
+      personaLookup,
+    })
+
+    expect(personaLookup.findByAuthId).not.toHaveBeenCalled()
+    expect(result).toEqual({
+      ok: false,
+      reason: 'unauthenticated',
+      warnings: [{ code: 'client_persona_id_ignored', clientPersonaId: 'forged-persona' }],
+    })
+  })
+
+  it('ignores a client-provided personaId when it differs from the backend subject', async () => {
+    const personaLookup = {
+      findByAuthId: jest.fn().mockResolvedValue(linkedPersona),
+    }
+
+    const result = await buildPlatformSession({
+      subjectAuthId: 'auth-1',
+      clientPersonaId: 'forged-persona',
+      personaLookup,
+    })
+
+    expect(result).toMatchObject({
+      ok: true,
+      session: { personaId: 'persona-auth-1', subjectAuthId: 'auth-1' },
+      warnings: [{ code: 'client_persona_id_ignored', clientPersonaId: 'forged-persona' }],
+    })
+  })
+
+  it('denies direct PlatformSession access for a persona without linked auth', async () => {
+    const personaWithoutAuth: PlatformSessionPersona = {
+      ...linkedPersona,
+      id: 'visitor-persona',
+      authId: null,
+    }
+    const personaLookup = {
+      findByAuthId: jest.fn().mockResolvedValue(personaWithoutAuth),
+    }
+
+    const result = await buildPlatformSession({
+      subjectAuthId: 'auth-visitor',
+      clientPersonaId: 'visitor-persona',
+      personaLookup,
+    })
+
+    expect(result).toEqual({
+      ok: false,
+      reason: 'persona_not_linked_to_backend_auth',
+      warnings: [{ code: 'client_persona_id_ignored', clientPersonaId: 'visitor-persona' }],
+    })
+  })
+
+  it('denies a Persona linked to a different backend auth subject', async () => {
+    const personaLookup = {
+      findByAuthId: jest.fn().mockResolvedValue({
+        id: 'persona-other-auth',
+        authId: 'auth-other',
+      }),
+    }
+
+    const result = await buildPlatformSession({
+      subjectAuthId: 'auth-1',
+      personaLookup,
+    })
+
+    expect(result).toEqual({ ok: false, reason: 'persona_not_linked_to_backend_auth', warnings: [] })
+  })
+
+  it('fails closed when backend auth has no linked Persona row', async () => {
+    const personaLookup = {
+      findByAuthId: jest.fn().mockResolvedValue(null),
+    }
+
+    const result = await buildPlatformSession({
+      subjectAuthId: 'auth-missing-persona',
+      personaLookup,
+    })
+
+    expect(result).toEqual({ ok: false, reason: 'persona_not_linked_to_backend_auth', warnings: [] })
+  })
+
+  it('fails closed when persona lookup rejects', async () => {
+    const personaLookup = {
+      findByAuthId: jest.fn().mockRejectedValue(new Error('lookup timeout')),
+    }
+
+    await expect(buildPlatformSession({
+      subjectAuthId: 'auth-1',
+      personaLookup,
+    })).resolves.toEqual({
+      ok: false,
+      reason: 'persona_lookup_failed',
+      warnings: [],
+    })
+  })
+})

--- a/__tests__/lib/platform/session.test.ts
+++ b/__tests__/lib/platform/session.test.ts
@@ -82,6 +82,32 @@ describe('PlatformSession builder', () => {
     })
   })
 
+  it('ignores a client-provided personaId even when it matches the resolved Persona', async () => {
+    const personaLookup = {
+      findByAuthId: jest.fn().mockResolvedValue(linkedPersona),
+    }
+
+    const result = await buildPlatformSession({
+      subjectAuthId: 'auth-1',
+      clientPersonaId: 'persona-auth-1',
+      personaLookup,
+    })
+
+    expect(personaLookup.findByAuthId).toHaveBeenCalledWith('auth-1')
+    expect(personaLookup.findByAuthId).not.toHaveBeenCalledWith('persona-auth-1')
+    expect(result).toEqual({
+      ok: true,
+      session: {
+        personaId: 'persona-auth-1',
+        subjectAuthId: 'auth-1',
+        globalRoles: [],
+        contexts: [],
+        capabilities: [],
+      },
+      warnings: [{ code: 'client_persona_id_ignored', clientPersonaId: 'persona-auth-1' }],
+    })
+  })
+
   it('denies direct PlatformSession access for a persona without linked auth', async () => {
     const personaWithoutAuth: PlatformSessionPersona = {
       ...linkedPersona,

--- a/lib/platform/session/build.ts
+++ b/lib/platform/session/build.ts
@@ -1,0 +1,37 @@
+import type { PlatformSessionBuildInput, PlatformSessionBuildResult, PlatformSessionWarning } from '@/lib/platform/session/types'
+
+export async function buildPlatformSession(input: PlatformSessionBuildInput): Promise<PlatformSessionBuildResult> {
+  const warnings = input.clientPersonaId ? [clientPersonaWarning(input.clientPersonaId)] : []
+
+  if (!input.subjectAuthId?.trim()) {
+    return { ok: false, reason: 'unauthenticated', warnings }
+  }
+
+  const subjectAuthId = input.subjectAuthId.trim()
+  let persona
+  try {
+    persona = await input.personaLookup.findByAuthId(subjectAuthId)
+  } catch {
+    return { ok: false, reason: 'persona_lookup_failed', warnings }
+  }
+
+  if (!persona || persona.authId !== subjectAuthId) {
+    return { ok: false, reason: 'persona_not_linked_to_backend_auth', warnings }
+  }
+
+  return {
+    ok: true,
+    session: {
+      personaId: persona.id,
+      subjectAuthId,
+      globalRoles: [],
+      contexts: [],
+      capabilities: [],
+    },
+    warnings,
+  }
+}
+
+function clientPersonaWarning(clientPersonaId: string): PlatformSessionWarning {
+  return { code: 'client_persona_id_ignored', clientPersonaId }
+}

--- a/lib/platform/session/types.ts
+++ b/lib/platform/session/types.ts
@@ -1,0 +1,34 @@
+export type PlatformSessionContext = { experience: string; scopeType: string; scopeId?: string; label: string }
+
+export type PlatformSessionCapability = { key: string; experience: string; scopeType: string; scopeId?: string; source: string }
+
+export type PlatformSession = {
+  personaId: string
+  /** Backend Supabase Auth subject; this is the session auth source of truth. */
+  subjectAuthId: string
+  /** PR1a does not derive authz grants yet; PR2+ will populate these from backend sources only. */
+  globalRoles: string[]
+  contexts: PlatformSessionContext[]
+  capabilities: PlatformSessionCapability[]
+}
+
+export type PlatformSessionPersona = {
+  id: string
+  authId: string | null
+}
+
+export type PlatformSessionWarning = { code: 'client_persona_id_ignored'; clientPersonaId: string }
+
+export type PlatformSessionBuildResult =
+  | { ok: true; session: PlatformSession; warnings: PlatformSessionWarning[] }
+  | { ok: false; reason: 'unauthenticated' | 'persona_not_linked_to_backend_auth' | 'persona_lookup_failed'; warnings: PlatformSessionWarning[] }
+
+export type PlatformPersonaLookup = {
+  findByAuthId(authId: string): Promise<PlatformSessionPersona | null>
+}
+
+export type PlatformSessionBuildInput = {
+  subjectAuthId: string | null | undefined
+  clientPersonaId?: string | null
+  personaLookup: PlatformPersonaLookup
+}

--- a/openspec/changes/fase-01-platform-foundation/tasks.md
+++ b/openspec/changes/fase-01-platform-foundation/tasks.md
@@ -1,27 +1,28 @@
 # Tareas: Fase 1 — Platform Foundation
 
-> Plan de implementación futura. No aplicar en el PR documental/SDD.
+> Plan de implementación por PRs después del planning mergeado. PR1a registra progreso de implementación; los gates de estrategia siguen aplicando antes de ampliar futuros slices.
 
 ## Review Workload Forecast
 
 | Field | Value |
 |-------|-------|
 | Estimated changed lines | 1,200–1,800 |
-| Suggested split | PR 1 → PR 2 → PR 3 → PR 4 → PR 5 → PR 6 → PR 7 |
-| Delivery strategy | ask-on-risk |
+| Suggested split | PR 1a → PR 1b → PR 2 → PR 3 → PR 4 → PR 5 → PR 6 → PR 7 |
+| Delivery strategy | stacked-to-main para PR1a; ask-on-risk para slices futuros |
 
-Decision needed before apply: Yes
+Decision needed before apply: No para PR1a aprobado; sí antes de cambiar estrategia o ampliar futuros slices
 Chained PRs recommended: Yes
-Chain strategy: pending
+Chain strategy: stacked-to-main para PR1a; confirmar por slice futuro
 400-line budget risk: High
 
-**Gate obligatorio antes de implementar:** no ejecutar `sdd-apply` ni abrir un PR de implementación hasta elegir `stacked-to-main` o `feature-branch-chain`. Un PR único para esta fase queda bloqueado salvo aprobación explícita `size:exception` del mantenedor.
+**Gate obligatorio para futuros slices:** mantener PRs encadenados y no ampliar alcance sin confirmar estrategia. Un PR único para toda la fase queda bloqueado salvo aprobación explícita `size:exception` del mantenedor.
 
 ### Suggested Work Units
 
 | Unit | Goal | Likely PR | Notes |
 |------|------|-----------|-------|
-| 1 | Auth/sesión + Persona/dedupe | PR 1 | `auth.uid()`/server session, anti-enumeración y tests del slice |
+| 1a | Auth/sesión | PR 1a | `auth.uid()`/server session y rechazo de `personaId` cliente |
+| 1b | Persona/dedupe | PR 1b | anti-enumeración, masking y boundaries base; issue #203 |
 | 2 | Capabilities/scopes fail-closed | PR 2 | Allowlist, scopes inválidos, tests de denegación |
 | 3 | Adapter GDV read-only | PR 3 | Delegar RPC/RLS actuales; tests de compatibilidad |
 | 4 | Menú/dashboard contextual | PR 4 | Feature flag, kill switch, fallback legado y tests UI/server |
@@ -31,8 +32,8 @@ Chain strategy: pending
 
 ## Fase 1: Auth, Persona y scopes
 
-- [ ] 1.1 Crear `lib/platform/session/types.ts` y builder desde `auth.uid()`/server session; rechazar `personaId` cliente como identidad; tests.
-- [ ] 1.2 Crear `lib/platform/persona.ts` para búsqueda/dedupe con minimización, masking, auditoría, boundaries y tests anti-enumeración.
+- [x] 1.1 Crear `lib/platform/session/types.ts` y builder desde `auth.uid()`/server session; rechazar `personaId` cliente como identidad; tests.
+- [ ] 1.2 Crear `lib/platform/persona.ts` para búsqueda/dedupe con minimización, masking, auditoría, boundaries base de actor/flujo/scope requerido y tests anti-enumeración.
 - [ ] 1.3 Crear `lib/platform/experiences.ts` y scopes allowlisted; scopes ausentes/malformados/desconocidos/duplicados/conflictivos fallan cerrado con tests.
 
 ## Fase 2: Adapter GDV read-only


### PR DESCRIPTION
Closes #202

## Chain Context

```text
main
└── 📍 PR1a: PlatformSession/auth base (#202)
    └── PR1b: Persona/dedupe base (#203, pending)
        └── PR2+: remaining Platform Foundation slices
```

Strategy: `stacked-to-main`. This PR targets `main`; the next slice starts only after this PR is reviewed/merged.

## PR Type
- [ ] Bug fix
- [x] New feature
- [ ] Documentation only
- [ ] Code refactoring
- [ ] Maintenance/tooling
- [ ] Breaking change

## Summary
- Adds the PlatformSession contract and builder for backend-auth-derived identity.
- Fails closed for missing, blank, mismatched, unlinked, or failed Persona lookup states.
- Splits Persona/dedupe into follow-up issue #203 to keep review size under 400 lines.

## Changes
| File | Change |
|------|--------|
| `lib/platform/session/types.ts` | Adds PlatformSession/session input/result types. |
| `lib/platform/session/build.ts` | Adds fail-closed PlatformSession builder. |
| `__tests__/lib/platform/session.test.ts` | Adds Strict TDD coverage for auth-derived session behavior. |
| `openspec/changes/fase-01-platform-foundation/tasks.md` | Marks PR1a task complete and documents PR1b split. |

## Out of Scope
- Persona/dedupe implementation (#203).
- UI, dashboard, menu/navigation.
- Experiences/scopes, Grupos de Vida adapter, family/minors, ledger/uno_a_uno, grants/rollout.
- Migrations, Supabase remote, or visible behavior changes.

## Risks
- This is a foundation contract only; production wiring happens in later PRs.
- Authorization arrays remain empty in PR1a; future PRs must derive grants from backend/RLS sources only.

## Roadmap / OpenSpec validation
- Matches Platform Foundation principles: Persona/auth separation and fail-closed session identity.
- Implements only task 1.1 from `openspec/changes/fase-01-platform-foundation/tasks.md`.
- Keeps Grupos de Vida, DB, Supabase, and UI untouched.

## Test Plan
- [x] `pnpm test -- __tests__/lib/platform/session.test.ts --runInBand`
- [x] `pnpm exec tsc --noEmit --pretty false --incremental false`
- [x] `pnpm test:ci`
- [x] Fresh pre-PR review: risk, reliability, readability, resilience.

## Contributor Checklist
- [x] Linked an approved issue.
- [x] Added exactly one `type:*` label.
- [x] Tests included with the behavior.
- [x] Conventional commit format.
- [x] No migrations, Supabase changes, or production data changes.
- [x] No `Co-Authored-By` trailers.