### PR TITLE
feat(platform): implementar Persona y dedupe base

### DIFF
--- a/__tests__/lib/platform/persona.test.ts
+++ b/__tests__/lib/platform/persona.test.ts
@@ -1,0 +1,138 @@
+import { findPlatformPersonaCandidates } from '@/lib/platform/persona'
+import type { PlatformPersonaLookupActor, PlatformPersonaUsuario } from '@/lib/platform/persona'
+
+const authorizedActor: PlatformPersonaLookupActor = {
+  personaId: 'actor-persona-1',
+  allowedFlows: ['registration'],
+  allowedScopes: ['waumbaland:registration'],
+}
+const adaPersona: PlatformPersonaUsuario = {
+  id: 'persona-ada',
+  auth_id: 'auth-ada',
+  nombre: 'Ada',
+  apellido: 'Lovelace',
+  email: 'ada.lovelace@example.com',
+  telefono: '+54 9 11 1234-7890',
+  cedula: 'ABC-123456',
+  fecha_nacimiento: '1815-12-10',
+}
+const baseLookupInput = { actor: authorizedActor, flow: 'registration', requiredScope: 'waumbaland:registration' }
+
+function createLookup(candidates: PlatformPersonaUsuario[]) {
+  return { findCandidatesBySignals: jest.fn().mockResolvedValue(candidates) }
+}
+
+describe('Platform Persona lookup and dedupe base', () => {
+  it('returns only minimized and masked candidate data for authorized Persona lookup', async () => {
+    const personaLookup = createLookup([adaPersona])
+    const result = await findPlatformPersonaCandidates({
+      ...baseLookupInput,
+      query: {
+        email: ' Ada.Lovelace@Example.com ',
+        telefono: '+54 (9) 11 1234-7890',
+        cedula: 'ABC-123456',
+        nombre: 'Ada',
+        apellido: 'Lovelace',
+        fechaNacimiento: '1815-12-10',
+      },
+      personaLookup,
+    })
+
+    expect(personaLookup.findCandidatesBySignals).toHaveBeenCalledWith({
+      email: 'ada.lovelace@example.com',
+      telefono: '5491112347890',
+      cedula: 'abc123456',
+      nombre: 'ada',
+      apellido: 'lovelace',
+      fechaNacimiento: '1815-12-10',
+    })
+    expect(result).toMatchObject({
+      ok: true,
+      decision: 'single_candidate',
+      autoMerge: false,
+      reviewRequired: false,
+      candidates: [{
+        personaId: 'persona-ada',
+        displayName: 'A. L.',
+        hasAuthAccount: true,
+        matchedSignals: ['email', 'telefono', 'cedula', 'nombre', 'apellido', 'fechaNacimiento'],
+        maskedSignals: { email: 'a***@example.com', telefono: '••••7890', cedula: '••••3456' },
+      }],
+      audit: { actorPersonaId: 'actor-persona-1', decision: 'lookup_allowed', resultCount: 1 },
+    })
+    for (const hidden of ['ada.lovelace@example.com', '+54 9 11 1234-7890', 'ABC-123456', 'auth-ada']) {
+      expect(JSON.stringify(result)).not.toContain(hidden)
+    }
+  })
+
+  it('fails closed for invalid input and keeps no-match responses non-enumerable', async () => {
+    const invalidLookup = createLookup([adaPersona])
+    const invalid = await findPlatformPersonaCandidates({
+      ...baseLookupInput,
+      query: { nombre: 'A' },
+      personaLookup: invalidLookup,
+    })
+    expect(invalidLookup.findCandidatesBySignals).not.toHaveBeenCalled()
+    expect(invalid).toMatchObject({
+      ok: false,
+      reason: 'invalid_query',
+      candidates: [],
+      audit: { decision: 'lookup_denied', reason: 'invalid_query', signalNames: ['nombre'], resultCount: 0 },
+    })
+
+    const noMatch = await findPlatformPersonaCandidates({
+      ...baseLookupInput,
+      query: { email: 'missing.person@example.com' },
+      personaLookup: createLookup([]),
+    })
+    expect(noMatch).toMatchObject({
+      ok: true,
+      decision: 'no_match',
+      autoMerge: false,
+      reviewRequired: false,
+      candidates: [],
+      audit: { resultCount: 0, signalNames: ['email'] },
+    })
+    expect(JSON.stringify(noMatch)).not.toContain('missing.person@example.com')
+  })
+
+  it('marks partial duplicate candidates as ambiguous without auto-merging them', async () => {
+    const personaLookup = createLookup([
+      { ...adaPersona, id: 'persona-ada-1', email: null, telefono: null, cedula: null },
+      { ...adaPersona, id: 'persona-ada-2', auth_id: null, email: null, telefono: null, cedula: null },
+    ])
+    const result = await findPlatformPersonaCandidates({
+      ...baseLookupInput,
+      query: { nombre: 'Ada', apellido: 'Lovelace', fechaNacimiento: '1815-12-10' },
+      personaLookup,
+    })
+
+    expect(result).toMatchObject({
+      ok: true,
+      decision: 'ambiguous_candidates',
+      autoMerge: false,
+      reviewRequired: true,
+      candidates: [
+        { personaId: 'persona-ada-1', displayName: 'A. L.', hasAuthAccount: true },
+        { personaId: 'persona-ada-2', displayName: 'A. L.', hasAuthAccount: false },
+      ],
+      audit: { resultCount: 2, reviewRequired: true },
+    })
+  })
+
+  it('denies lookup outside actor, flow, or required scope boundaries', async () => {
+    const personaLookup = createLookup([adaPersona])
+    const attempts = await Promise.all([
+      findPlatformPersonaCandidates({ actor: null, flow: 'registration', requiredScope: 'waumbaland:registration', query: { email: 'ada@example.com' }, personaLookup }),
+      findPlatformPersonaCandidates({ ...baseLookupInput, flow: 'support', query: { email: 'ada@example.com' }, personaLookup }),
+      findPlatformPersonaCandidates({ ...baseLookupInput, actor: { ...authorizedActor, allowedScopes: [] }, query: { email: 'ada@example.com' }, personaLookup }),
+    ])
+
+    expect(personaLookup.findCandidatesBySignals).not.toHaveBeenCalled()
+    expect(attempts.map((result) => result.ok ? null : result.reason)).toEqual(['actor_required', 'flow_not_allowed', 'missing_required_scope'])
+    for (const result of attempts) {
+      expect(result).toMatchObject({ candidates: [], audit: { decision: 'lookup_denied', resultCount: 0 } })
+      expect(JSON.stringify(result)).not.toContain('ada@example.com')
+    }
+  })
+})

--- a/__tests__/lib/platform/persona.test.ts
+++ b/__tests__/lib/platform/persona.test.ts
@@ -67,11 +67,7 @@ describe('Platform Persona lookup and dedupe base', () => {
 
   it('fails closed for invalid input and keeps no-match responses non-enumerable', async () => {
     const invalidLookup = createLookup([adaPersona])
-    const invalid = await findPlatformPersonaCandidates({
-      ...baseLookupInput,
-      query: { nombre: 'A' },
-      personaLookup: invalidLookup,
-    })
+    const invalid = await findPlatformPersonaCandidates({ ...baseLookupInput, query: { nombre: 'A' }, personaLookup: invalidLookup })
     expect(invalidLookup.findCandidatesBySignals).not.toHaveBeenCalled()
     expect(invalid).toMatchObject({
       ok: false,
@@ -79,6 +75,13 @@ describe('Platform Persona lookup and dedupe base', () => {
       candidates: [],
       audit: { decision: 'lookup_denied', reason: 'invalid_query', signalNames: ['nombre'], resultCount: 0 },
     })
+
+    const malformedLookup = createLookup([adaPersona])
+    for (const query of [{ email: 'ada@' }, { nombre: 'Ada', apellido: 'Lovelace', fechaNacimiento: '1815-99-99' }]) {
+      const malformed = await findPlatformPersonaCandidates({ ...baseLookupInput, query, personaLookup: malformedLookup })
+      expect(malformed).toMatchObject({ ok: false, reason: 'invalid_query', candidates: [] })
+    }
+    expect(malformedLookup.findCandidatesBySignals).not.toHaveBeenCalled()
 
     const noMatch = await findPlatformPersonaCandidates({
       ...baseLookupInput,
@@ -94,18 +97,25 @@ describe('Platform Persona lookup and dedupe base', () => {
       audit: { resultCount: 0, signalNames: ['email'] },
     })
     expect(JSON.stringify(noMatch)).not.toContain('missing.person@example.com')
+
+    const failingLookup = { findCandidatesBySignals: jest.fn().mockRejectedValue(new Error('db leaked ada.lovelace@example.com')) }
+    const failed = await findPlatformPersonaCandidates({ ...baseLookupInput, query: { email: 'ada.lovelace@example.com' }, personaLookup: failingLookup })
+    expect(failed).toMatchObject({ ok: false, reason: 'lookup_failed', candidates: [], audit: { decision: 'lookup_failed', reason: 'lookup_failed', resultCount: 0 } })
+    expect(JSON.stringify(failed)).not.toContain('ada.lovelace@example.com')
   })
 
-  it('marks partial duplicate candidates as ambiguous without auto-merging them', async () => {
-    const personaLookup = createLookup([
-      { ...adaPersona, id: 'persona-ada-1', email: null, telefono: null, cedula: null },
-      { ...adaPersona, id: 'persona-ada-2', auth_id: null, email: null, telefono: null, cedula: null },
-    ])
-    const result = await findPlatformPersonaCandidates({
+  it('requires review for weak-only or conflicting non-tie matches without auto-merge', async () => {
+    const weakOnly = await findPlatformPersonaCandidates({
       ...baseLookupInput,
-      query: { nombre: 'Ada', apellido: 'Lovelace', fechaNacimiento: '1815-12-10' },
-      personaLookup,
+      query: { email: 'ada.lovelace@example.com', nombre: 'Ada' },
+      personaLookup: createLookup([{ ...adaPersona, email: null, telefono: null, cedula: null, apellido: null, fecha_nacimiento: null }]),
     })
+    expect(weakOnly).toMatchObject({ ok: true, decision: 'single_candidate', autoMerge: false, reviewRequired: true, candidates: [{ matchedSignals: ['nombre'] }] })
+
+    const result = await findPlatformPersonaCandidates({ ...baseLookupInput, query: { email: 'ada.lovelace@example.com', telefono: '+54 9 11 1234-7890' }, personaLookup: createLookup([
+      { ...adaPersona, id: 'persona-email', telefono: null, cedula: null },
+      { ...adaPersona, id: 'persona-phone', auth_id: null, email: null, cedula: null },
+    ]) })
 
     expect(result).toMatchObject({
       ok: true,
@@ -113,8 +123,8 @@ describe('Platform Persona lookup and dedupe base', () => {
       autoMerge: false,
       reviewRequired: true,
       candidates: [
-        { personaId: 'persona-ada-1', displayName: 'A. L.', hasAuthAccount: true },
-        { personaId: 'persona-ada-2', displayName: 'A. L.', hasAuthAccount: false },
+        { personaId: 'persona-email', displayName: 'A. L.', hasAuthAccount: true, matchedSignals: ['email'] },
+        { personaId: 'persona-phone', displayName: 'A. L.', hasAuthAccount: false, matchedSignals: ['telefono'] },
       ],
       audit: { resultCount: 2, reviewRequired: true },
     })

--- a/lib/platform/persona.ts
+++ b/lib/platform/persona.ts
@@ -1,0 +1,226 @@
+export type PlatformPersonaSignalName = 'email' | 'telefono' | 'cedula' | 'nombre' | 'apellido' | 'fechaNacimiento'
+export type PlatformPersonaSearchSignals = Partial<Record<PlatformPersonaSignalName, string | null>>
+export type PlatformPersonaNormalizedSignals = Partial<Record<PlatformPersonaSignalName, string>>
+export type PlatformPersonaUsuario = {
+  id: string
+  auth_id: string | null
+  nombre: string | null
+  apellido: string | null
+  email: string | null
+  telefono: string | null
+  cedula: string | null
+  fecha_nacimiento: string | null
+}
+export type PlatformPersonaLookupActor = { personaId: string; allowedFlows: string[]; allowedScopes: string[] }
+export type PlatformPersonaLookup = { findCandidatesBySignals(signals: PlatformPersonaNormalizedSignals): Promise<PlatformPersonaUsuario[]> }
+export type PlatformPersonaLookupInput = {
+  actor: PlatformPersonaLookupActor | null | undefined
+  flow: string
+  requiredScope: string
+  query: PlatformPersonaSearchSignals
+  personaLookup: PlatformPersonaLookup
+}
+export type PlatformPersonaDeniedReason = 'actor_required' | 'flow_not_allowed' | 'missing_required_scope' | 'invalid_query' | 'lookup_failed'
+export type PlatformPersonaLookupAudit = {
+  actorPersonaId?: string
+  decision: 'lookup_allowed' | 'lookup_denied' | 'lookup_failed'
+  reason?: PlatformPersonaDeniedReason
+  flow: string
+  requiredScope: string
+  signalNames: PlatformPersonaSignalName[]
+  resultCount: number
+  reviewRequired: boolean
+}
+export type PlatformPersonaCandidate = {
+  personaId: string
+  displayName: string
+  hasAuthAccount: boolean
+  matchedSignals: PlatformPersonaSignalName[]
+  maskedSignals: Partial<Record<PlatformPersonaSignalName, string>>
+}
+export type PlatformPersonaLookupResult =
+  | { ok: true; decision: 'no_match' | 'single_candidate' | 'ambiguous_candidates'; autoMerge: false; reviewRequired: boolean; candidates: PlatformPersonaCandidate[]; audit: PlatformPersonaLookupAudit }
+  | { ok: false; reason: PlatformPersonaDeniedReason; candidates: []; audit: PlatformPersonaLookupAudit }
+
+const SIGNAL_ORDER: PlatformPersonaSignalName[] = ['email', 'telefono', 'cedula', 'nombre', 'apellido', 'fechaNacimiento']
+const SIGNAL_WEIGHTS = { email: 4, telefono: 3, cedula: 4, nombre: 1, apellido: 1, fechaNacimiento: 2 } satisfies Record<PlatformPersonaSignalName, number>
+type ScoredCandidate = { usuario: PlatformPersonaUsuario; matchedSignals: PlatformPersonaSignalName[]; score: number }
+
+export async function findPlatformPersonaCandidates(input: PlatformPersonaLookupInput): Promise<PlatformPersonaLookupResult> {
+  const signalNames = collectInputSignalNames(input.query)
+  const boundaryFailure = resolveBoundaryFailure(input.actor, input.flow, input.requiredScope)
+  if (boundaryFailure) return deniedResult(input, boundaryFailure, signalNames)
+
+  const normalizedSignals = normalizeSignals(input.query)
+  if (!hasLookupStrength(normalizedSignals)) return deniedResult(input, 'invalid_query', signalNames)
+
+  let usuarios: PlatformPersonaUsuario[]
+  try {
+    usuarios = await input.personaLookup.findCandidatesBySignals(normalizedSignals)
+  } catch {
+    return { ok: false, reason: 'lookup_failed', candidates: [], audit: toAudit(input, 'lookup_failed', signalNames, 0, false, 'lookup_failed') }
+  }
+
+  const matches = usuarios
+    .map((usuario) => scoreCandidate(usuario, normalizedSignals))
+    .filter((candidate) => candidate.score > 0)
+    .sort((left, right) => right.score - left.score || left.usuario.id.localeCompare(right.usuario.id))
+
+  if (matches.length === 0) {
+    return { ok: true, decision: 'no_match', autoMerge: false, reviewRequired: false, candidates: [], audit: toAudit(input, 'lookup_allowed', signalNames, 0, false) }
+  }
+
+  const topScore = matches[0].score
+  const ambiguous = matches.length > 1 && matches[1].score === topScore
+  const selected = ambiguous ? matches.filter((match) => match.score === topScore) : [matches[0]]
+  return {
+    ok: true,
+    decision: ambiguous ? 'ambiguous_candidates' : 'single_candidate',
+    autoMerge: false,
+    reviewRequired: ambiguous,
+    candidates: selected.map(toCandidate),
+    audit: toAudit(input, 'lookup_allowed', signalNames, selected.length, ambiguous),
+  }
+}
+
+function deniedResult(input: PlatformPersonaLookupInput, reason: PlatformPersonaDeniedReason, signalNames: PlatformPersonaSignalName[]): PlatformPersonaLookupResult {
+  return { ok: false, reason, candidates: [], audit: toAudit(input, 'lookup_denied', signalNames, 0, false, reason) }
+}
+
+function resolveBoundaryFailure(actor: PlatformPersonaLookupActor | null | undefined, flow: string, requiredScope: string): PlatformPersonaDeniedReason | null {
+  if (!actor?.personaId.trim()) return 'actor_required'
+  if (!flow.trim() || !actor.allowedFlows.includes(flow)) return 'flow_not_allowed'
+  if (!requiredScope.trim() || !actor.allowedScopes.includes(requiredScope)) return 'missing_required_scope'
+  return null
+}
+
+function toAudit(
+  input: PlatformPersonaLookupInput,
+  decision: PlatformPersonaLookupAudit['decision'],
+  signalNames: PlatformPersonaSignalName[],
+  resultCount: number,
+  reviewRequired: boolean,
+  reason?: PlatformPersonaDeniedReason
+): PlatformPersonaLookupAudit {
+  return {
+    actorPersonaId: input.actor?.personaId.trim() || undefined,
+    decision,
+    reason,
+    flow: input.flow,
+    requiredScope: input.requiredScope,
+    signalNames,
+    resultCount,
+    reviewRequired,
+  }
+}
+
+function collectInputSignalNames(query: PlatformPersonaSearchSignals): PlatformPersonaSignalName[] {
+  return SIGNAL_ORDER.filter((signal) => Boolean(query[signal]?.trim()))
+}
+
+function normalizeSignals(query: PlatformPersonaSearchSignals): PlatformPersonaNormalizedSignals {
+  const signals: PlatformPersonaNormalizedSignals = {}
+  const values = {
+    email: normalizeEmail(query.email),
+    telefono: normalizeDigits(query.telefono, 7),
+    cedula: normalizeAlphanumeric(query.cedula, 4),
+    nombre: normalizeName(query.nombre),
+    apellido: normalizeName(query.apellido),
+    fechaNacimiento: normalizeDate(query.fechaNacimiento),
+  } satisfies Record<PlatformPersonaSignalName, string | null>
+
+  for (const signal of SIGNAL_ORDER) {
+    const value = values[signal]
+    if (value) signals[signal] = value
+  }
+  return signals
+}
+
+function hasLookupStrength(signals: PlatformPersonaNormalizedSignals): boolean {
+  return Boolean(signals.email || signals.telefono || signals.cedula || (signals.nombre && signals.apellido && signals.fechaNacimiento))
+}
+
+function scoreCandidate(usuario: PlatformPersonaUsuario, signals: PlatformPersonaNormalizedSignals): ScoredCandidate {
+  const matchedSignals = SIGNAL_ORDER.filter((signal) => {
+    const expected = signals[signal]
+    return Boolean(expected && normalizeUsuarioSignal(usuario, signal) === expected)
+  })
+  return { usuario, matchedSignals, score: matchedSignals.reduce((total, signal) => total + SIGNAL_WEIGHTS[signal], 0) }
+}
+
+function toCandidate(match: ScoredCandidate): PlatformPersonaCandidate {
+  return {
+    personaId: match.usuario.id,
+    displayName: maskDisplayName(match.usuario),
+    hasAuthAccount: Boolean(match.usuario.auth_id?.trim()),
+    matchedSignals: match.matchedSignals,
+    maskedSignals: maskMatchedSignals(match.usuario, match.matchedSignals),
+  }
+}
+
+function maskMatchedSignals(usuario: PlatformPersonaUsuario, matchedSignals: PlatformPersonaSignalName[]): Partial<Record<PlatformPersonaSignalName, string>> {
+  const maskedSignals: Partial<Record<PlatformPersonaSignalName, string>> = {}
+  const email = maskEmail(usuario.email)
+  const telefono = maskLastFour(usuario.telefono)
+  const cedula = maskLastFour(usuario.cedula)
+  if (matchedSignals.includes('email') && email) maskedSignals.email = email
+  if (matchedSignals.includes('telefono') && telefono) maskedSignals.telefono = telefono
+  if (matchedSignals.includes('cedula') && cedula) maskedSignals.cedula = cedula
+  return maskedSignals
+}
+
+function maskDisplayName(usuario: PlatformPersonaUsuario): string {
+  const initials = [normalizeInitial(usuario.nombre), normalizeInitial(usuario.apellido)].filter(Boolean).join(' ')
+  return initials || `Persona ${maskLastFour(usuario.id)}`
+}
+
+function normalizeUsuarioSignal(usuario: PlatformPersonaUsuario, signal: PlatformPersonaSignalName): string | null {
+  if (signal === 'email') return normalizeEmail(usuario.email)
+  if (signal === 'telefono') return normalizeDigits(usuario.telefono, 7)
+  if (signal === 'cedula') return normalizeAlphanumeric(usuario.cedula, 4)
+  if (signal === 'nombre') return normalizeName(usuario.nombre)
+  if (signal === 'apellido') return normalizeName(usuario.apellido)
+  return normalizeDate(usuario.fecha_nacimiento)
+}
+
+function normalizeEmail(value: string | null | undefined): string | null {
+  const normalized = value?.trim().toLowerCase()
+  return normalized && normalized.includes('@') ? normalized : null
+}
+
+function normalizeDigits(value: string | null | undefined, minLength: number): string | null {
+  const digits = value?.replace(/\D/g, '')
+  return digits && digits.length >= minLength ? digits : null
+}
+
+function normalizeAlphanumeric(value: string | null | undefined, minLength: number): string | null {
+  const normalized = value?.replace(/[^a-zA-Z0-9]/g, '').toLowerCase()
+  return normalized && normalized.length >= minLength ? normalized : null
+}
+
+function normalizeName(value: string | null | undefined): string | null {
+  const normalized = value?.trim().replace(/\s+/g, ' ').toLowerCase()
+  return normalized && normalized.length >= 2 ? normalized : null
+}
+
+function normalizeDate(value: string | null | undefined): string | null {
+  const normalized = value?.trim()
+  return normalized && /^\d{4}-\d{2}-\d{2}$/.test(normalized) ? normalized : null
+}
+
+function maskEmail(value: string | null | undefined): string | undefined {
+  const normalized = normalizeEmail(value)
+  if (!normalized) return undefined
+  const [local, domain] = normalized.split('@')
+  return `${local.slice(0, 1)}***@${domain}`
+}
+
+function maskLastFour(value: string | null | undefined): string | undefined {
+  const normalized = value?.replace(/[^a-zA-Z0-9]/g, '')
+  return normalized ? `••••${normalized.slice(-4)}` : undefined
+}
+
+function normalizeInitial(value: string | null | undefined): string | null {
+  const normalized = normalizeName(value)
+  return normalized ? `${normalized.slice(0, 1).toUpperCase()}.` : null
+}

--- a/lib/platform/persona.ts
+++ b/lib/platform/persona.ts
@@ -43,13 +43,22 @@ export type PlatformPersonaLookupResult =
   | { ok: false; reason: PlatformPersonaDeniedReason; candidates: []; audit: PlatformPersonaLookupAudit }
 
 const SIGNAL_ORDER: PlatformPersonaSignalName[] = ['email', 'telefono', 'cedula', 'nombre', 'apellido', 'fechaNacimiento']
+const DIRECT_MATCH_SIGNALS: PlatformPersonaSignalName[] = ['email', 'telefono', 'cedula']
+const MIN_PHONE_DIGITS = 7
+const MIN_CEDULA_CHARS = 4
+const MIN_NAME_CHARS = 2
+const EMAIL_PATTERN = /^[^\s@]+@[^\s@]+\.[^\s@]+$/
+const DATE_PATTERN = /^\d{4}-\d{2}-\d{2}$/
 const SIGNAL_WEIGHTS = { email: 4, telefono: 3, cedula: 4, nombre: 1, apellido: 1, fechaNacimiento: 2 } satisfies Record<PlatformPersonaSignalName, number>
 type ScoredCandidate = { usuario: PlatformPersonaUsuario; matchedSignals: PlatformPersonaSignalName[]; score: number }
+type AuditParams = Pick<PlatformPersonaLookupAudit, 'decision' | 'signalNames' | 'resultCount' | 'reviewRequired' | 'reason'> & { input: PlatformPersonaLookupInput }
 
 export async function findPlatformPersonaCandidates(input: PlatformPersonaLookupInput): Promise<PlatformPersonaLookupResult> {
   const signalNames = collectInputSignalNames(input.query)
   const boundaryFailure = resolveBoundaryFailure(input.actor, input.flow, input.requiredScope)
   if (boundaryFailure) return deniedResult(input, boundaryFailure, signalNames)
+
+  if (hasMalformedStrongSignal(input.query)) return deniedResult(input, 'invalid_query', signalNames)
 
   const normalizedSignals = normalizeSignals(input.query)
   if (!hasLookupStrength(normalizedSignals)) return deniedResult(input, 'invalid_query', signalNames)
@@ -58,7 +67,7 @@ export async function findPlatformPersonaCandidates(input: PlatformPersonaLookup
   try {
     usuarios = await input.personaLookup.findCandidatesBySignals(normalizedSignals)
   } catch {
-    return { ok: false, reason: 'lookup_failed', candidates: [], audit: toAudit(input, 'lookup_failed', signalNames, 0, false, 'lookup_failed') }
+    return { ok: false, reason: 'lookup_failed', candidates: [], audit: toAudit({ input, decision: 'lookup_failed', signalNames, resultCount: 0, reviewRequired: false, reason: 'lookup_failed' }) }
   }
 
   const matches = usuarios
@@ -67,24 +76,23 @@ export async function findPlatformPersonaCandidates(input: PlatformPersonaLookup
     .sort((left, right) => right.score - left.score || left.usuario.id.localeCompare(right.usuario.id))
 
   if (matches.length === 0) {
-    return { ok: true, decision: 'no_match', autoMerge: false, reviewRequired: false, candidates: [], audit: toAudit(input, 'lookup_allowed', signalNames, 0, false) }
+    return { ok: true, decision: 'no_match', autoMerge: false, reviewRequired: false, candidates: [], audit: toAudit({ input, decision: 'lookup_allowed', signalNames, resultCount: 0, reviewRequired: false }) }
   }
 
-  const topScore = matches[0].score
-  const ambiguous = matches.length > 1 && matches[1].score === topScore
-  const selected = ambiguous ? matches.filter((match) => match.score === topScore) : [matches[0]]
+  const selected = selectReviewCandidates(matches)
+  const reviewRequired = selected.length > 1 || !hasCandidateLookupStrength(selected[0].matchedSignals)
   return {
     ok: true,
-    decision: ambiguous ? 'ambiguous_candidates' : 'single_candidate',
+    decision: selected.length > 1 ? 'ambiguous_candidates' : 'single_candidate',
     autoMerge: false,
-    reviewRequired: ambiguous,
+    reviewRequired,
     candidates: selected.map(toCandidate),
-    audit: toAudit(input, 'lookup_allowed', signalNames, selected.length, ambiguous),
+    audit: toAudit({ input, decision: 'lookup_allowed', signalNames, resultCount: selected.length, reviewRequired }),
   }
 }
 
 function deniedResult(input: PlatformPersonaLookupInput, reason: PlatformPersonaDeniedReason, signalNames: PlatformPersonaSignalName[]): PlatformPersonaLookupResult {
-  return { ok: false, reason, candidates: [], audit: toAudit(input, 'lookup_denied', signalNames, 0, false, reason) }
+  return { ok: false, reason, candidates: [], audit: toAudit({ input, decision: 'lookup_denied', signalNames, resultCount: 0, reviewRequired: false, reason }) }
 }
 
 function resolveBoundaryFailure(actor: PlatformPersonaLookupActor | null | undefined, flow: string, requiredScope: string): PlatformPersonaDeniedReason | null {
@@ -94,14 +102,7 @@ function resolveBoundaryFailure(actor: PlatformPersonaLookupActor | null | undef
   return null
 }
 
-function toAudit(
-  input: PlatformPersonaLookupInput,
-  decision: PlatformPersonaLookupAudit['decision'],
-  signalNames: PlatformPersonaSignalName[],
-  resultCount: number,
-  reviewRequired: boolean,
-  reason?: PlatformPersonaDeniedReason
-): PlatformPersonaLookupAudit {
+function toAudit({ input, decision, signalNames, resultCount, reviewRequired, reason }: AuditParams): PlatformPersonaLookupAudit {
   return {
     actorPersonaId: input.actor?.personaId.trim() || undefined,
     decision,
@@ -118,12 +119,16 @@ function collectInputSignalNames(query: PlatformPersonaSearchSignals): PlatformP
   return SIGNAL_ORDER.filter((signal) => Boolean(query[signal]?.trim()))
 }
 
+function hasMalformedStrongSignal(query: PlatformPersonaSearchSignals): boolean {
+  return Boolean((query.email?.trim() && !normalizeEmail(query.email)) || (query.fechaNacimiento?.trim() && !normalizeDate(query.fechaNacimiento)))
+}
+
 function normalizeSignals(query: PlatformPersonaSearchSignals): PlatformPersonaNormalizedSignals {
   const signals: PlatformPersonaNormalizedSignals = {}
   const values = {
     email: normalizeEmail(query.email),
-    telefono: normalizeDigits(query.telefono, 7),
-    cedula: normalizeAlphanumeric(query.cedula, 4),
+    telefono: normalizeDigits(query.telefono, MIN_PHONE_DIGITS),
+    cedula: normalizeAlphanumeric(query.cedula, MIN_CEDULA_CHARS),
     nombre: normalizeName(query.nombre),
     apellido: normalizeName(query.apellido),
     fechaNacimiento: normalizeDate(query.fechaNacimiento),
@@ -138,6 +143,15 @@ function normalizeSignals(query: PlatformPersonaSearchSignals): PlatformPersonaN
 
 function hasLookupStrength(signals: PlatformPersonaNormalizedSignals): boolean {
   return Boolean(signals.email || signals.telefono || signals.cedula || (signals.nombre && signals.apellido && signals.fechaNacimiento))
+}
+
+function selectReviewCandidates(matches: ScoredCandidate[]): ScoredCandidate[] {
+  const strongMatches = matches.filter((match) => hasCandidateLookupStrength(match.matchedSignals))
+  return strongMatches.length > 1 ? strongMatches : [strongMatches[0] ?? matches[0]]
+}
+
+function hasCandidateLookupStrength(matchedSignals: PlatformPersonaSignalName[]): boolean {
+  return DIRECT_MATCH_SIGNALS.some((signal) => matchedSignals.includes(signal)) || (matchedSignals.includes('nombre') && matchedSignals.includes('apellido') && matchedSignals.includes('fechaNacimiento'))
 }
 
 function scoreCandidate(usuario: PlatformPersonaUsuario, signals: PlatformPersonaNormalizedSignals): ScoredCandidate {
@@ -176,8 +190,8 @@ function maskDisplayName(usuario: PlatformPersonaUsuario): string {
 
 function normalizeUsuarioSignal(usuario: PlatformPersonaUsuario, signal: PlatformPersonaSignalName): string | null {
   if (signal === 'email') return normalizeEmail(usuario.email)
-  if (signal === 'telefono') return normalizeDigits(usuario.telefono, 7)
-  if (signal === 'cedula') return normalizeAlphanumeric(usuario.cedula, 4)
+  if (signal === 'telefono') return normalizeDigits(usuario.telefono, MIN_PHONE_DIGITS)
+  if (signal === 'cedula') return normalizeAlphanumeric(usuario.cedula, MIN_CEDULA_CHARS)
   if (signal === 'nombre') return normalizeName(usuario.nombre)
   if (signal === 'apellido') return normalizeName(usuario.apellido)
   return normalizeDate(usuario.fecha_nacimiento)
@@ -185,7 +199,7 @@ function normalizeUsuarioSignal(usuario: PlatformPersonaUsuario, signal: Platfor
 
 function normalizeEmail(value: string | null | undefined): string | null {
   const normalized = value?.trim().toLowerCase()
-  return normalized && normalized.includes('@') ? normalized : null
+  return normalized && EMAIL_PATTERN.test(normalized) ? normalized : null
 }
 
 function normalizeDigits(value: string | null | undefined, minLength: number): string | null {
@@ -200,12 +214,15 @@ function normalizeAlphanumeric(value: string | null | undefined, minLength: numb
 
 function normalizeName(value: string | null | undefined): string | null {
   const normalized = value?.trim().replace(/\s+/g, ' ').toLowerCase()
-  return normalized && normalized.length >= 2 ? normalized : null
+  return normalized && normalized.length >= MIN_NAME_CHARS ? normalized : null
 }
 
 function normalizeDate(value: string | null | undefined): string | null {
   const normalized = value?.trim()
-  return normalized && /^\d{4}-\d{2}-\d{2}$/.test(normalized) ? normalized : null
+  if (!normalized || !DATE_PATTERN.test(normalized)) return null
+  const [year, month, day] = normalized.split('-').map(Number)
+  const date = new Date(Date.UTC(year, month - 1, day))
+  return date.getUTCFullYear() === year && date.getUTCMonth() === month - 1 && date.getUTCDate() === day ? normalized : null
 }
 
 function maskEmail(value: string | null | undefined): string | undefined {

--- a/openspec/changes/fase-01-platform-foundation/tasks.md
+++ b/openspec/changes/fase-01-platform-foundation/tasks.md
@@ -33,7 +33,7 @@ Chain strategy: stacked-to-main para PR1a; confirmar por slice futuro
 ## Fase 1: Auth, Persona y scopes
 
 - [x] 1.1 Crear `lib/platform/session/types.ts` y builder desde `auth.uid()`/server session; rechazar `personaId` cliente como identidad; tests.
-- [ ] 1.2 Crear `lib/platform/persona.ts` para búsqueda/dedupe con minimización, masking, auditoría, boundaries base de actor/flujo/scope requerido y tests anti-enumeración.
+- [x] 1.2 Crear `lib/platform/persona.ts` para búsqueda/dedupe con minimización, masking, auditoría, boundaries base de actor/flujo/scope requerido y tests anti-enumeración.
 - [ ] 1.3 Crear `lib/platform/experiences.ts` y scopes allowlisted; scopes ausentes/malformados/desconocidos/duplicados/conflictivos fallan cerrado con tests.
 
 ## Fase 2: Adapter GDV read-only


### PR DESCRIPTION
Closes #203

## PR Type
- [x] New feature

## Resumen
- Adds the Platform Persona lookup/dedupe base over usuarios-shaped rows.
- Enforces actor, flow, and required-scope boundaries before lookup.
- Returns masked/minimized candidates, non-enumerable denials/no-match responses, and no automatic merge for ambiguous candidates.

## Qué Incluye
- `lib/platform/persona.ts` with pure platform lookup, normalization, scoring, masking, audit metadata, and fail-closed boundaries.
- `__tests__/lib/platform/persona.test.ts` with focused behavior coverage for anti-enumeration, invalid/no-match inputs, ambiguous candidates, and actor/flow/scope boundaries.
- `openspec/changes/fase-01-platform-foundation/tasks.md` marking only task 1.2 complete.

## Motivación / Por Qué
Issue #203 advances the Fase 1 PR1b slice after PR #204 merged, keeping Persona/dedupe isolated from UI, migrations, GDV adapters, family/minors, ledger, grants, and Phase 2 work.

## Chain Context
Strategy: stacked-to-main from updated main.

Dependency diagram:
`main` -> #204 merged -> 📍 PR1b Persona/dedupe base -> PR1c experiences/scopes

Current PR boundary:
- Start: updated `main` after PR #204.
- End: task 1.2 complete only.
- Out of scope: UI/dashboard/menu, full experiences/scopes, Grupos de Vida adapter, family/minors, participation ledger, uno_a_uno preflight, grants/rollout, migrations, and remote Supabase.
- Review budget: 366 changed lines, under the 400-line budget.

## Migraciones / Base de Datos
- [x] No aplica
- [ ] Sí (orden exacto):
```
N/A
```
Notas: no migrations, remote Supabase, or production data touched.

## Impacto y Riesgos
- Does not change visible routes or existing data flows.
- The lookup module is intentionally repository-driven; future wiring must keep backend authorization as the source of truth.
- Lint passes with existing project warnings unrelated to this PR.

## Checklist Autor
- [x] Código formateado (ESLint executed; existing warnings only)
- [x] Sin `console.log` / debugger
- [x] Validaciones con zod para entradas nuevas (no Zod boundary introduced; pure typed module validates signals directly)
- [x] Estados loading/error/empty cubiertos (not UI; invalid/no-match/error outcomes covered)
- [x] Tipos TypeScript correctos
- [x] Migraciones probadas local (not applicable)
- [x] Documentación actualizada (`tasks.md` progress)
- [x] Variables de entorno documentadas (not applicable)
- [x] Rebase con `main` limpio

## Pruebas Manuales Realizadas
- [x] `pnpm test -- __tests__/lib/platform/persona.test.ts`
- [x] `npx tsc --noEmit`
- [x] `pnpm test:ci`
- [x] `pnpm lint` (passes with existing warnings)

## Pendientes / Follow-up
- Task 1.3 remains pending: experiences/scopes allowlist and fail-closed scope validation.

## Notas Adicionales
Ambiguous candidates are returned for future human review metadata only and are never auto-merged by this base module.