### PR TITLE
feat(platform): implementar experiencias y scopes fail-closed

### DIFF
--- a/__tests__/lib/platform/experiences.test.ts
+++ b/__tests__/lib/platform/experiences.test.ts
@@ -1,0 +1,98 @@
+import { resolvePlatformCapability } from '@/lib/platform/experiences'
+import type { PlatformCapabilityActor, PlatformCapabilityResolutionInput } from '@/lib/platform/experiences'
+
+const gdvStageGrant = {
+  key: 'grupos_vida.stage.read',
+  scope: { experience: 'grupos_vida', type: 'etapa', id: 'adultos' },
+  source: 'gdv-adapter',
+}
+const dpsMusicGrant = {
+  key: 'dps.team.serve',
+  scope: { experience: 'dps', type: 'equipo', id: 'musica' },
+  source: 'dream-team',
+}
+const authorizedActor: PlatformCapabilityActor = {
+  personaId: 'persona-actor-1',
+  allowedFlows: ['dashboard'],
+  grants: [dpsMusicGrant, gdvStageGrant],
+}
+const gdvReadInput: PlatformCapabilityResolutionInput = {
+  actor: authorizedActor,
+  flow: 'dashboard',
+  required: {
+    key: 'grupos_vida.stage.read',
+    scope: { experience: 'grupos_vida', type: 'etapa', id: 'adultos' },
+  },
+}
+
+describe('Platform experiences and scoped capabilities', () => {
+  it('allows an allowlisted scoped capability and resolves grants deterministically', () => {
+    const result = resolvePlatformCapability(gdvReadInput)
+
+    expect(result).toEqual({
+      ok: true,
+      decision: 'allowed',
+      grant: {
+        key: 'grupos_vida.stage.read',
+        scope: { experience: 'grupos_vida', type: 'etapa', id: 'adultos' },
+        source: 'gdv-adapter',
+      },
+      audit: {
+        actorPersonaId: 'persona-actor-1',
+        decision: 'allowed',
+        flow: 'dashboard',
+        requiredCapability: 'grupos_vida.stage.read',
+        requiredScope: 'grupos_vida:etapa:adultos',
+        evaluatedGrantSignatures: ['grupos_vida.stage.read|grupos_vida:etapa:adultos'],
+      },
+    })
+  })
+
+  it('denies access outside actor, flow, or required capability boundaries', () => {
+    const attempts = [
+      resolvePlatformCapability({ ...gdvReadInput, actor: null }),
+      resolvePlatformCapability({ ...gdvReadInput, flow: 'admin' }),
+      resolvePlatformCapability({ ...gdvReadInput, required: { ...gdvReadInput.required, key: 'dps.admin.manage' } }),
+      resolvePlatformCapability({ ...gdvReadInput, required: { ...gdvReadInput.required, key: 'dps.team.serve', scope: dpsMusicGrant.scope }, actor: { ...authorizedActor, grants: [gdvStageGrant] } }),
+    ]
+
+    expect(attempts.map((result) => result.ok ? null : result.reason)).toEqual([
+      'actor_required',
+      'flow_not_allowed',
+      'unknown_capability',
+      'missing_required_capability',
+    ])
+    for (const result of attempts) {
+      expect(result).toMatchObject({ ok: false, decision: 'denied', audit: { decision: 'denied' } })
+    }
+  })
+
+  it('fails closed for missing, malformed, or unknown required scopes', () => {
+    const attempts = [
+      resolvePlatformCapability({ ...gdvReadInput, required: { key: 'grupos_vida.stage.read' } }),
+      resolvePlatformCapability({ ...gdvReadInput, required: { key: 'grupos_vida.stage.read', scope: { experience: 'grupos_vida', type: 'etapa', id: '../adultos' } } }),
+      resolvePlatformCapability({ ...gdvReadInput, required: { key: 'grupos_vida.stage.read', scope: { experience: 'unknown', type: 'etapa', id: 'adultos' } } }),
+    ]
+
+    expect(attempts.map((result) => result.ok ? null : result.reason)).toEqual([
+      'missing_required_scope',
+      'malformed_required_scope',
+      'unknown_required_scope',
+    ])
+  })
+
+  it('fails closed for missing, malformed, unknown, duplicate, or conflicting grant scopes', () => {
+    const cases: Array<[PlatformCapabilityActor['grants'], string]> = [
+      [[{ ...gdvStageGrant, scope: null }], 'grant_scope_missing'],
+      [[{ ...gdvStageGrant, scope: { experience: 'grupos_vida', type: 'etapa', id: '../adultos' } }], 'grant_scope_malformed'],
+      [[{ ...gdvStageGrant, scope: { experience: 'grupos_vida', type: 'equipo', id: 'adultos' } }], 'grant_scope_unknown'],
+      [[gdvStageGrant, { ...gdvStageGrant, source: 'duplicate-source' }], 'duplicate_scope'],
+      [[{ ...gdvStageGrant, scope: { experience: 'dps', type: 'equipo', id: 'adultos' } }], 'conflicting_scope'],
+    ]
+
+    for (const [grants, reason] of cases) {
+      const result = resolvePlatformCapability({ ...gdvReadInput, actor: { ...authorizedActor, grants } })
+      expect(result).toMatchObject({ ok: false, decision: 'denied', reason, audit: { reason } })
+    }
+  })
+})

--- a/__tests__/lib/platform/experiences.test.ts
+++ b/__tests__/lib/platform/experiences.test.ts
@@ -81,6 +81,57 @@ describe('Platform experiences and scoped capabilities', () => {
     ])
   })
 
+  it('fails closed without throwing for prototype-inherited scope experience keys', () => {
+    const inheritedKeys = ['constructor', 'toString', '__proto__']
+    const requiredScopeResults = inheritedKeys.map((experience) => resolvePlatformCapability({
+      ...gdvReadInput,
+      required: { key: 'grupos_vida.stage.read', scope: { experience, type: 'etapa', id: 'adultos' } },
+    }))
+    const grantScopeResults = inheritedKeys.map((experience) => resolvePlatformCapability({
+      ...gdvReadInput,
+      actor: {
+        ...authorizedActor,
+        grants: [{ ...gdvStageGrant, scope: { experience, type: 'etapa', id: 'adultos' } }],
+      },
+    }))
+
+    expect(requiredScopeResults.map((result) => result.ok ? null : result.reason)).toEqual([
+      'unknown_required_scope',
+      'unknown_required_scope',
+      'unknown_required_scope',
+    ])
+    expect(grantScopeResults.map((result) => result.ok ? null : result.reason)).toEqual([
+      'grant_scope_unknown',
+      'grant_scope_unknown',
+      'grant_scope_unknown',
+    ])
+  })
+
+  it('keeps scope id validation bounded to documented characters and length', () => {
+    const maxLengthScopeId = `a${'b'.repeat(63)}`
+    const validBoundaryResult = resolvePlatformCapability({
+      ...gdvReadInput,
+      actor: {
+        ...authorizedActor,
+        grants: [{ ...gdvStageGrant, scope: { experience: 'grupos_vida', type: 'etapa', id: maxLengthScopeId } }],
+      },
+      required: { key: 'grupos_vida.stage.read', scope: { experience: 'grupos_vida', type: 'etapa', id: maxLengthScopeId } },
+    })
+    const malformedResults = ['-adultos', `a${'b'.repeat(64)}`].map((id) => resolvePlatformCapability({
+      ...gdvReadInput,
+      required: { key: 'grupos_vida.stage.read', scope: { experience: 'grupos_vida', type: 'etapa', id } },
+    }))
+
+    expect(validBoundaryResult).toMatchObject({
+      ok: true,
+      audit: { requiredScope: `grupos_vida:etapa:${maxLengthScopeId}` },
+    })
+    expect(malformedResults.map((result) => result.ok ? null : result.reason)).toEqual([
+      'malformed_required_scope',
+      'malformed_required_scope',
+    ])
+  })
+
   it('fails closed for missing, malformed, unknown, duplicate, or conflicting grant scopes', () => {
     const cases: Array<[PlatformCapabilityActor['grants'], string]> = [
       [[{ ...gdvStageGrant, scope: null }], 'grant_scope_missing'],

--- a/lib/platform/experiences.ts
+++ b/lib/platform/experiences.ts
@@ -1,4 +1,6 @@
-export type PlatformScopeType = 'experience' | 'equipo' | 'etapa' | 'grupo' | 'salon' | 'taller'
+export const PLATFORM_SCOPE_TYPES = ['experience', 'equipo', 'etapa', 'grupo', 'salon', 'taller'] as const
+
+export type PlatformScopeType = (typeof PLATFORM_SCOPE_TYPES)[number]
 
 export const PLATFORM_EXPERIENCE_CATALOG = {
   grupos_vida: { label: 'Grupos de Vida', scopeTypes: ['etapa', 'grupo'] },
@@ -62,40 +64,76 @@ type CapabilityDefinition = { experience: PlatformExperienceKey; scopeType: Plat
 type ScopeValidationFailure = 'missing' | 'malformed' | 'unknown' | 'conflicting'
 type ScopeValidationResult = { ok: true; scope: PlatformScope; signature: string } | { ok: false; reason: ScopeValidationFailure }
 type NormalizedGrant = PlatformCapabilityGrant & { signature: string }
+type DeniedParams = {
+  input: PlatformCapabilityResolutionInput
+  reason: PlatformCapabilityDeniedReason
+  evaluatedGrantSignatures: string[]
+  requiredCapability: string
+  requiredScope?: string
+}
+type AuditParams = {
+  input: PlatformCapabilityResolutionInput
+  decision: 'allowed' | 'denied'
+  evaluatedGrantSignatures: string[]
+  requiredCapability: string
+  requiredScope?: string
+  reason?: PlatformCapabilityDeniedReason
+}
 
-const SCOPE_ID_PATTERN = /^[a-z0-9][a-z0-9._:-]{0,63}$/
+const PLATFORM_SCOPE_TYPE_SET: ReadonlySet<string> = new Set(PLATFORM_SCOPE_TYPES)
+const SCOPE_ID_MAX_LENGTH = 64
+const SCOPE_ID_FIRST_CHARACTER_PATTERN = /^[a-z0-9]$/
+const SCOPE_ID_ALLOWED_CHARACTERS_PATTERN = /^[a-z0-9._:-]+$/
 
 export function resolvePlatformCapability(input: PlatformCapabilityResolutionInput): PlatformCapabilityResolution {
   const actorPersonaId = input.actor?.personaId.trim() || undefined
   const requiredCapability = normalizeToken(input.required.key)
-  if (!actorPersonaId) return denied(input, 'actor_required', [], requiredCapability)
-  if (!input.flow.trim() || !input.actor?.allowedFlows.includes(input.flow)) return denied(input, 'flow_not_allowed', [], requiredCapability)
-  if (!isPlatformCapabilityKey(requiredCapability)) return denied(input, 'unknown_capability', [], requiredCapability)
+  if (!actorPersonaId) return denied({ input, reason: 'actor_required', evaluatedGrantSignatures: [], requiredCapability })
+  if (!input.flow.trim() || !input.actor?.allowedFlows.includes(input.flow)) {
+    return denied({ input, reason: 'flow_not_allowed', evaluatedGrantSignatures: [], requiredCapability })
+  }
+  if (!isPlatformCapabilityKey(requiredCapability)) {
+    return denied({ input, reason: 'unknown_capability', evaluatedGrantSignatures: [], requiredCapability })
+  }
 
   const definition = PLATFORM_CAPABILITIES[requiredCapability]
   const requiredScope = normalizeScope(input.required.scope, definition)
-  if (!requiredScope.ok) return denied(input, toRequiredScopeReason(requiredScope.reason), [], requiredCapability)
+  if (!requiredScope.ok) {
+    return denied({ input, reason: toRequiredScopeReason(requiredScope.reason), evaluatedGrantSignatures: [], requiredCapability })
+  }
 
   const grants = input.actor.grants.filter((grant) => normalizeToken(grant.key) === requiredCapability)
   const normalizedGrants: NormalizedGrant[] = []
   for (const grant of grants) {
     const normalized = normalizeScope(grant.scope, definition)
-    if (!normalized.ok) return denied(input, toGrantScopeReason(normalized.reason), normalizedGrants.map((item) => item.signature), requiredCapability, requiredScope.signature)
+    if (!normalized.ok) {
+      return denied({
+        input,
+        reason: toGrantScopeReason(normalized.reason),
+        evaluatedGrantSignatures: normalizedGrants.map((item) => item.signature),
+        requiredCapability,
+        requiredScope: requiredScope.signature,
+      })
+    }
     normalizedGrants.push({ key: requiredCapability, scope: normalized.scope, source: normalizeSource(grant.source), signature: `${requiredCapability}|${normalized.signature}` })
   }
 
   normalizedGrants.sort((left, right) => left.signature.localeCompare(right.signature) || left.source.localeCompare(right.source))
   const evaluatedGrantSignatures = normalizedGrants.map((grant) => grant.signature)
-  if (hasDuplicateSignature(evaluatedGrantSignatures)) return denied(input, 'duplicate_scope', evaluatedGrantSignatures, requiredCapability, requiredScope.signature)
+  if (hasDuplicateSignature(evaluatedGrantSignatures)) {
+    return denied({ input, reason: 'duplicate_scope', evaluatedGrantSignatures, requiredCapability, requiredScope: requiredScope.signature })
+  }
 
   const matchingGrant = normalizedGrants.find((grant) => grant.signature === `${requiredCapability}|${requiredScope.signature}`)
-  if (!matchingGrant) return denied(input, 'missing_required_capability', evaluatedGrantSignatures, requiredCapability, requiredScope.signature)
+  if (!matchingGrant) {
+    return denied({ input, reason: 'missing_required_capability', evaluatedGrantSignatures, requiredCapability, requiredScope: requiredScope.signature })
+  }
 
   return {
     ok: true,
     decision: 'allowed',
     grant: { key: matchingGrant.key, scope: matchingGrant.scope, source: matchingGrant.source },
-    audit: toAudit(input, 'allowed', evaluatedGrantSignatures, requiredCapability, requiredScope.signature),
+    audit: toAudit({ input, decision: 'allowed', evaluatedGrantSignatures, requiredCapability, requiredScope: requiredScope.signature }),
   }
 }
 
@@ -116,11 +154,18 @@ function normalizeScope(scope: PlatformScopeInput | null | undefined, definition
   return { ok: true, scope: normalizedScope, signature: scopeSignature(normalizedScope) }
 }
 
-function denied(input: PlatformCapabilityResolutionInput, reason: PlatformCapabilityDeniedReason, evaluatedGrantSignatures: string[], requiredCapability: string, requiredScope?: string): PlatformCapabilityResolution {
-  return { ok: false, decision: 'denied', reason, audit: toAudit(input, 'denied', evaluatedGrantSignatures, requiredCapability, requiredScope, reason) }
+function denied(params: DeniedParams): PlatformCapabilityResolution {
+  const { input, reason, evaluatedGrantSignatures, requiredCapability, requiredScope } = params
+  return {
+    ok: false,
+    decision: 'denied',
+    reason,
+    audit: toAudit({ input, decision: 'denied', evaluatedGrantSignatures, requiredCapability, requiredScope, reason }),
+  }
 }
 
-function toAudit(input: PlatformCapabilityResolutionInput, decision: 'allowed' | 'denied', evaluatedGrantSignatures: string[], requiredCapability: string, requiredScope?: string, reason?: PlatformCapabilityDeniedReason): PlatformCapabilityAudit {
+function toAudit(params: AuditParams): PlatformCapabilityAudit {
+  const { input, decision, evaluatedGrantSignatures, requiredCapability, requiredScope, reason } = params
   const actorPersonaId = input.actor?.personaId.trim() || undefined
   return {
     ...(actorPersonaId ? { actorPersonaId } : {}),
@@ -157,7 +202,9 @@ function normalizeSource(value: string | null | undefined): string {
 
 function normalizeScopeId(value: string | null | undefined): string | undefined {
   const normalized = normalizeToken(value)
-  return normalized && SCOPE_ID_PATTERN.test(normalized) ? normalized : undefined
+  if (!normalized || normalized.length > SCOPE_ID_MAX_LENGTH) return undefined
+  if (!SCOPE_ID_FIRST_CHARACTER_PATTERN.test(normalized[0] ?? '')) return undefined
+  return SCOPE_ID_ALLOWED_CHARACTERS_PATTERN.test(normalized) ? normalized : undefined
 }
 
 function scopeSignature(scope: PlatformScope): string {
@@ -174,13 +221,17 @@ function experienceAllowsScopeType(experience: PlatformExperienceKey, type: Plat
 }
 
 function isPlatformCapabilityKey(value: string): value is PlatformCapabilityKey {
-  return value in PLATFORM_CAPABILITIES
+  return hasOwnStringKey(PLATFORM_CAPABILITIES, value)
 }
 
 function isPlatformExperienceKey(value: string): value is PlatformExperienceKey {
-  return value in PLATFORM_EXPERIENCE_CATALOG
+  return hasOwnStringKey(PLATFORM_EXPERIENCE_CATALOG, value)
 }
 
 function isPlatformScopeType(value: string): value is PlatformScopeType {
-  return ['experience', 'equipo', 'etapa', 'grupo', 'salon', 'taller'].includes(value)
+  return PLATFORM_SCOPE_TYPE_SET.has(value)
+}
+
+function hasOwnStringKey<T extends object>(record: T, value: string): value is Extract<keyof T, string> {
+  return Object.prototype.hasOwnProperty.call(record, value)
 }

--- a/lib/platform/experiences.ts
+++ b/lib/platform/experiences.ts
@@ -1,0 +1,186 @@
+export type PlatformScopeType = 'experience' | 'equipo' | 'etapa' | 'grupo' | 'salon' | 'taller'
+
+export const PLATFORM_EXPERIENCE_CATALOG = {
+  grupos_vida: { label: 'Grupos de Vida', scopeTypes: ['etapa', 'grupo'] },
+  dps: { label: 'DPS', scopeTypes: ['equipo'] },
+  ninos: { label: 'Niños', scopeTypes: ['salon'] },
+  estudiantes: { label: 'Estudiantes', scopeTypes: ['salon'] },
+  the_living_room: { label: 'The Living Room', scopeTypes: ['experience'] },
+  talleres_crecimiento: { label: 'Talleres de Crecimiento', scopeTypes: ['taller'] },
+} satisfies Record<string, { label: string; scopeTypes: readonly PlatformScopeType[] }>
+
+export type PlatformExperienceKey = keyof typeof PLATFORM_EXPERIENCE_CATALOG
+
+export const PLATFORM_CAPABILITIES = {
+  'platform.context.read': { experience: 'the_living_room', scopeType: 'experience' },
+  'grupos_vida.stage.read': { experience: 'grupos_vida', scopeType: 'etapa' },
+  'dps.team.serve': { experience: 'dps', scopeType: 'equipo' },
+  'ninos.room.read': { experience: 'ninos', scopeType: 'salon' },
+  'estudiantes.room.read': { experience: 'estudiantes', scopeType: 'salon' },
+  'talleres_crecimiento.participation.read': { experience: 'talleres_crecimiento', scopeType: 'taller' },
+} satisfies Record<string, { experience: PlatformExperienceKey; scopeType: PlatformScopeType }>
+
+export type PlatformCapabilityKey = keyof typeof PLATFORM_CAPABILITIES
+export type PlatformScopeInput = { experience?: string | null; type?: string | null; id?: string | null }
+export type PlatformCapabilityGrantInput = { key?: string | null; scope?: PlatformScopeInput | null; source?: string | null }
+export type PlatformCapabilityActor = { personaId: string; allowedFlows: string[]; grants: PlatformCapabilityGrantInput[] }
+export type PlatformCapabilityRequirement = { key: string; scope?: PlatformScopeInput | null }
+export type PlatformCapabilityResolutionInput = {
+  actor: PlatformCapabilityActor | null | undefined
+  flow: string
+  required: PlatformCapabilityRequirement
+}
+export type PlatformCapabilityDeniedReason =
+  | 'actor_required'
+  | 'flow_not_allowed'
+  | 'unknown_capability'
+  | 'missing_required_scope'
+  | 'malformed_required_scope'
+  | 'unknown_required_scope'
+  | 'grant_scope_missing'
+  | 'grant_scope_malformed'
+  | 'grant_scope_unknown'
+  | 'duplicate_scope'
+  | 'conflicting_scope'
+  | 'missing_required_capability'
+export type PlatformCapabilityAudit = {
+  actorPersonaId?: string
+  decision: 'allowed' | 'denied'
+  reason?: PlatformCapabilityDeniedReason
+  flow: string
+  requiredCapability: string
+  requiredScope?: string
+  evaluatedGrantSignatures: string[]
+}
+export type PlatformCapabilityGrant = { key: PlatformCapabilityKey; scope: PlatformScope; source: string }
+export type PlatformScope = { experience: PlatformExperienceKey; type: PlatformScopeType; id?: string }
+export type PlatformCapabilityResolution =
+  | { ok: true; decision: 'allowed'; grant: PlatformCapabilityGrant; audit: PlatformCapabilityAudit }
+  | { ok: false; decision: 'denied'; reason: PlatformCapabilityDeniedReason; audit: PlatformCapabilityAudit }
+
+type CapabilityDefinition = { experience: PlatformExperienceKey; scopeType: PlatformScopeType }
+type ScopeValidationFailure = 'missing' | 'malformed' | 'unknown' | 'conflicting'
+type ScopeValidationResult = { ok: true; scope: PlatformScope; signature: string } | { ok: false; reason: ScopeValidationFailure }
+type NormalizedGrant = PlatformCapabilityGrant & { signature: string }
+
+const SCOPE_ID_PATTERN = /^[a-z0-9][a-z0-9._:-]{0,63}$/
+
+export function resolvePlatformCapability(input: PlatformCapabilityResolutionInput): PlatformCapabilityResolution {
+  const actorPersonaId = input.actor?.personaId.trim() || undefined
+  const requiredCapability = normalizeToken(input.required.key)
+  if (!actorPersonaId) return denied(input, 'actor_required', [], requiredCapability)
+  if (!input.flow.trim() || !input.actor?.allowedFlows.includes(input.flow)) return denied(input, 'flow_not_allowed', [], requiredCapability)
+  if (!isPlatformCapabilityKey(requiredCapability)) return denied(input, 'unknown_capability', [], requiredCapability)
+
+  const definition = PLATFORM_CAPABILITIES[requiredCapability]
+  const requiredScope = normalizeScope(input.required.scope, definition)
+  if (!requiredScope.ok) return denied(input, toRequiredScopeReason(requiredScope.reason), [], requiredCapability)
+
+  const grants = input.actor.grants.filter((grant) => normalizeToken(grant.key) === requiredCapability)
+  const normalizedGrants: NormalizedGrant[] = []
+  for (const grant of grants) {
+    const normalized = normalizeScope(grant.scope, definition)
+    if (!normalized.ok) return denied(input, toGrantScopeReason(normalized.reason), normalizedGrants.map((item) => item.signature), requiredCapability, requiredScope.signature)
+    normalizedGrants.push({ key: requiredCapability, scope: normalized.scope, source: normalizeSource(grant.source), signature: `${requiredCapability}|${normalized.signature}` })
+  }
+
+  normalizedGrants.sort((left, right) => left.signature.localeCompare(right.signature) || left.source.localeCompare(right.source))
+  const evaluatedGrantSignatures = normalizedGrants.map((grant) => grant.signature)
+  if (hasDuplicateSignature(evaluatedGrantSignatures)) return denied(input, 'duplicate_scope', evaluatedGrantSignatures, requiredCapability, requiredScope.signature)
+
+  const matchingGrant = normalizedGrants.find((grant) => grant.signature === `${requiredCapability}|${requiredScope.signature}`)
+  if (!matchingGrant) return denied(input, 'missing_required_capability', evaluatedGrantSignatures, requiredCapability, requiredScope.signature)
+
+  return {
+    ok: true,
+    decision: 'allowed',
+    grant: { key: matchingGrant.key, scope: matchingGrant.scope, source: matchingGrant.source },
+    audit: toAudit(input, 'allowed', evaluatedGrantSignatures, requiredCapability, requiredScope.signature),
+  }
+}
+
+function normalizeScope(scope: PlatformScopeInput | null | undefined, definition: CapabilityDefinition): ScopeValidationResult {
+  if (!scope) return { ok: false, reason: 'missing' }
+  const experience = normalizeToken(scope.experience)
+  const type = normalizeToken(scope.type)
+  if (!experience || !type) return { ok: false, reason: 'missing' }
+  if (!isPlatformExperienceKey(experience) || !isPlatformScopeType(type)) return { ok: false, reason: 'unknown' }
+  if (!experienceAllowsScopeType(experience, type)) return { ok: false, reason: 'unknown' }
+  if (experience !== definition.experience || type !== definition.scopeType) return { ok: false, reason: 'conflicting' }
+
+  const id = normalizeScopeId(scope.id)
+  if (type !== 'experience' && !id) return { ok: false, reason: scope.id?.trim() ? 'malformed' : 'missing' }
+  if (type === 'experience' && scope.id?.trim() && !id) return { ok: false, reason: 'malformed' }
+
+  const normalizedScope = id ? { experience, type, id } : { experience, type }
+  return { ok: true, scope: normalizedScope, signature: scopeSignature(normalizedScope) }
+}
+
+function denied(input: PlatformCapabilityResolutionInput, reason: PlatformCapabilityDeniedReason, evaluatedGrantSignatures: string[], requiredCapability: string, requiredScope?: string): PlatformCapabilityResolution {
+  return { ok: false, decision: 'denied', reason, audit: toAudit(input, 'denied', evaluatedGrantSignatures, requiredCapability, requiredScope, reason) }
+}
+
+function toAudit(input: PlatformCapabilityResolutionInput, decision: 'allowed' | 'denied', evaluatedGrantSignatures: string[], requiredCapability: string, requiredScope?: string, reason?: PlatformCapabilityDeniedReason): PlatformCapabilityAudit {
+  const actorPersonaId = input.actor?.personaId.trim() || undefined
+  return {
+    ...(actorPersonaId ? { actorPersonaId } : {}),
+    decision,
+    ...(reason ? { reason } : {}),
+    flow: input.flow,
+    requiredCapability,
+    ...(requiredScope ? { requiredScope } : {}),
+    evaluatedGrantSignatures,
+  }
+}
+
+function toRequiredScopeReason(reason: ScopeValidationFailure): PlatformCapabilityDeniedReason {
+  if (reason === 'missing') return 'missing_required_scope'
+  if (reason === 'malformed') return 'malformed_required_scope'
+  if (reason === 'unknown') return 'unknown_required_scope'
+  return 'conflicting_scope'
+}
+
+function toGrantScopeReason(reason: ScopeValidationFailure): PlatformCapabilityDeniedReason {
+  if (reason === 'missing') return 'grant_scope_missing'
+  if (reason === 'malformed') return 'grant_scope_malformed'
+  if (reason === 'unknown') return 'grant_scope_unknown'
+  return 'conflicting_scope'
+}
+
+function normalizeToken(value: string | null | undefined): string {
+  return value?.trim().toLowerCase() ?? ''
+}
+
+function normalizeSource(value: string | null | undefined): string {
+  return value?.trim() || 'unknown'
+}
+
+function normalizeScopeId(value: string | null | undefined): string | undefined {
+  const normalized = normalizeToken(value)
+  return normalized && SCOPE_ID_PATTERN.test(normalized) ? normalized : undefined
+}
+
+function scopeSignature(scope: PlatformScope): string {
+  return scope.id ? `${scope.experience}:${scope.type}:${scope.id}` : `${scope.experience}:${scope.type}`
+}
+
+function hasDuplicateSignature(signatures: string[]): boolean {
+  return new Set(signatures).size !== signatures.length
+}
+
+function experienceAllowsScopeType(experience: PlatformExperienceKey, type: PlatformScopeType): boolean {
+  const scopeTypes: readonly PlatformScopeType[] = PLATFORM_EXPERIENCE_CATALOG[experience].scopeTypes
+  return scopeTypes.includes(type)
+}
+
+function isPlatformCapabilityKey(value: string): value is PlatformCapabilityKey {
+  return value in PLATFORM_CAPABILITIES
+}
+
+function isPlatformExperienceKey(value: string): value is PlatformExperienceKey {
+  return value in PLATFORM_EXPERIENCE_CATALOG
+}
+
+function isPlatformScopeType(value: string): value is PlatformScopeType {
+  return ['experience', 'equipo', 'etapa', 'grupo', 'salon', 'taller'].includes(value)
+}

--- a/openspec/changes/fase-01-platform-foundation/tasks.md
+++ b/openspec/changes/fase-01-platform-foundation/tasks.md
@@ -34,7 +34,7 @@ Chain strategy: stacked-to-main para PR1a; confirmar por slice futuro
 
 - [x] 1.1 Crear `lib/platform/session/types.ts` y builder desde `auth.uid()`/server session; rechazar `personaId` cliente como identidad; tests.
 - [x] 1.2 Crear `lib/platform/persona.ts` para búsqueda/dedupe con minimización, masking, auditoría, boundaries base de actor/flujo/scope requerido y tests anti-enumeración.
-- [ ] 1.3 Crear `lib/platform/experiences.ts` y scopes allowlisted; scopes ausentes/malformados/desconocidos/duplicados/conflictivos fallan cerrado con tests.
+- [x] 1.3 Crear `lib/platform/experiences.ts` y scopes allowlisted; scopes ausentes/malformados/desconocidos/duplicados/conflictivos fallan cerrado con tests.
 
 ## Fase 2: Adapter GDV read-only
 


### PR DESCRIPTION
Closes #206

## Resumen
Implementa el contrato base de experiencias y capabilities scoped para Fase 1, task 1.3. El resolver valida actor, flow, capability y required scope antes de permitir acceso.

## Qué Incluye
- Catálogo allowlisted de experiencias iniciales y capabilities scoped.
- Resolver puro fail-closed para scopes ausentes, malformados, desconocidos, duplicados o conflictivos.
- Tests unitarios estrictos para resolución determinística y boundaries actor/flow/required-scope.
- Marca task 1.3 como completa en OpenSpec.

## Motivación / Por Qué
Reduce el riesgo de permisos globales o scopes ambiguos antes de integrar adapters, UI o grants persistidos.

## Evidencia Visual (si aplica)
No aplica: cambio platform-layer sin UI.

## Migraciones / Base de Datos
- [x] No aplica
- [ ] Sí (orden exacto):
```
N/A
```
Notas: sin Supabase remoto, migraciones ni cambios de datos.

## Impacto y Riesgos
- No rompe compatibilidad: solo agrega módulo y tests aislados.
- Sin coordinación de despliegue requerida.
- Riesgo principal: futuras capabilities deberán extender la allowlist explícitamente para no quedar denegadas.

## Chain Context
- Strategy: stacked-to-main
- Base: main actualizado después de PR #205
- Current PR: task 1.3, experiences/scopes fail-closed
- Dependency diagram: main + #204 + #205 -> this PR (#206) -> Fase 2 GDV adapter
- Out of scope: UI/dashboard/menu, Grupos de Vida adapter, familia/menores, ledger, uno_a_uno, grants/rollout, migraciones y Supabase remoto.

## Checklist Autor
- [x] Sin console.log / debugger
- [x] Tipos TypeScript correctos
- [x] Rebase con main limpio
- [ ] Código formateado (Prettier/ESLint)
- [ ] Validaciones con zod para entradas nuevas
- [ ] Estados loading/error/empty cubiertos
- [ ] Migraciones probadas local
- [ ] Documentación actualizada (docs/ o README)
- [ ] Variables de entorno documentadas

## Checklist Revisor
- [ ] Propósito claro
- [ ] Nombres descriptivos
- [ ] Sin lógica duplicada evidente
- [ ] Manejo adecuado de errores
- [ ] Cambios acotados al alcance
- [ ] Sin secretos / datos sensibles

## Pruebas Manuales Realizadas
- pnpm test -- __tests__/lib/platform/experiences.test.ts
- pnpm test -- __tests__/lib/platform/session.test.ts __tests__/lib/platform/persona.test.ts __tests__/lib/platform/experiences.test.ts
- pnpm exec tsc --noEmit --pretty false
- pnpm test:ci
- git diff --check

## Pendientes / Follow-up (opcional)
- Fase 2: adapter read-only de Grupos de Vida.

## Notas Adicionales
Changed lines: 286, debajo del presupuesto de 400.