### PR TITLE
feat(platform): agrega adapter read-only de grupos de vida

### DIFF
--- a/__tests__/lib/platform/grupos-vida-adapter.test.ts
+++ b/__tests__/lib/platform/grupos-vida-adapter.test.ts
@@ -3,7 +3,7 @@ import {
   filterGruposVidaRecordsByScope,
   resolveGruposVidaPlatformContext,
 } from '@/lib/platform/adapters/grupos-vida'
-import type { GruposVidaDirectorEtapaAssignment, GruposVidaReadRepository } from '@/lib/platform/adapters/grupos-vida'
+import type { GruposVidaAdapterInput, GruposVidaDirectorEtapaAssignment, GruposVidaReadRepository } from '@/lib/platform/adapters/grupos-vida'
 import type { PlatformSession } from '@/lib/platform/session/types'
 
 const directorSession: PlatformSession = {
@@ -59,21 +59,59 @@ describe('Grupos de Vida platform read adapter', () => {
     })
   })
 
+  it('fails closed when a director assignment does not expose any explicit group scope', async () => {
+    const reader = createReader([{ ...directorAssignment, assignedGroupIds: [] }])
+
+    const result = await resolveGruposVidaPlatformContext({ session: directorSession, reader })
+
+    expect(result).toEqual({
+      ok: false,
+      reason: 'invalid_gdv_scope',
+      contexts: [],
+      capabilities: [],
+      scope: { stageIds: [], groupIds: [] },
+      audit: { decision: 'denied', reason: 'invalid_gdv_scope', personaId: 'persona-director', assignmentCount: 0, exposedGroupCount: 0 },
+    })
+  })
+
   it('does not grant Grupos de Vida permissions from padre or tutor family relationships', async () => {
     const parentSession: PlatformSession = { ...directorSession, personaId: 'persona-padre', subjectAuthId: 'auth-padre' }
-    const reader = createReader([])
+    const childAssignment: GruposVidaDirectorEtapaAssignment = {
+      ...directorAssignment,
+      directorEtapaId: 'director-child-waumba',
+      personaId: 'child-waumba',
+      segmentoId: 'segmento-ninos',
+      segmentoLabel: 'Niños',
+      assignedGroupIds: ['grupo-child-waumba'],
+    }
+    const reader: GruposVidaReadRepository = {
+      findDirectorEtapaAssignmentsByPersonaId: jest.fn(async (personaId: string) => {
+        if (personaId === 'child-waumba') return [childAssignment]
+        if (personaId === 'child-insideout') return [{ ...childAssignment, personaId, assignedGroupIds: ['grupo-child-insideout'] }]
+        return []
+      }),
+    }
 
     const result = await resolveGruposVidaPlatformContext({
       session: parentSession,
       reader,
-      familyRelations: [
-        { personaId: 'persona-padre', relatedPersonaId: 'child-waumba', type: 'padre' },
-        { personaId: 'persona-padre', relatedPersonaId: 'child-insideout', type: 'tutor' },
-      ],
     })
 
     expect(result).toMatchObject({ ok: false, reason: 'missing_gdv_scope', capabilities: [], scope: { groupIds: [] } })
     expect(reader.findDirectorEtapaAssignmentsByPersonaId).toHaveBeenCalledWith('persona-padre')
+    expect(reader.findDirectorEtapaAssignmentsByPersonaId).not.toHaveBeenCalledWith('child-waumba')
+    expect(reader.findDirectorEtapaAssignmentsByPersonaId).not.toHaveBeenCalledWith('child-insideout')
+  })
+
+  it('keeps the adapter input boundary free from unused family relationship data', () => {
+    const inputWithoutFamilySurface = {
+      session: directorSession,
+      reader: createReader([]),
+      // @ts-expect-error Family relationships are context-only and must not be accepted by the GDV adapter boundary.
+      familyRelations: [{ personaId: 'persona-padre', relatedPersonaId: 'child-waumba', type: 'padre' }],
+    } satisfies GruposVidaAdapterInput
+
+    expect(inputWithoutFamilySurface.familyRelations).toEqual([{ personaId: 'persona-padre', relatedPersonaId: 'child-waumba', type: 'padre' }])
   })
 
   it('does not copy or create cross-experience permissions', async () => {

--- a/__tests__/lib/platform/grupos-vida-adapter.test.ts
+++ b/__tests__/lib/platform/grupos-vida-adapter.test.ts
@@ -44,6 +44,27 @@ describe('Grupos de Vida platform read adapter', () => {
     })
   })
 
+  it.each([
+    { label: 'undefined session', session: undefined },
+    { label: 'null session', session: null },
+    { label: 'blank backend auth subject', session: { ...directorSession, subjectAuthId: '   ' }, expectedPersonaId: 'persona-director' },
+    { label: 'malformed persona scope', session: { ...directorSession, personaId: '../persona-director' } },
+  ] satisfies Array<{ label: string; session: GruposVidaAdapterInput['session']; expectedPersonaId?: string }>)('fails closed for $label before reading assignments', async ({ session, expectedPersonaId }) => {
+    const reader = createReader([directorAssignment])
+
+    const result = await resolveGruposVidaPlatformContext({ session, reader })
+
+    expect(reader.findDirectorEtapaAssignmentsByPersonaId).not.toHaveBeenCalled()
+    expect(result).toEqual({
+      ok: false,
+      reason: 'session_required',
+      contexts: [],
+      capabilities: [],
+      scope: { stageIds: [], groupIds: [] },
+      audit: { decision: 'denied', reason: 'session_required', ...(expectedPersonaId ? { personaId: expectedPersonaId } : {}), assignmentCount: 0, exposedGroupCount: 0 },
+    })
+  })
+
   it('fails closed for a user without Grupos de Vida scope', async () => {
     const reader = createReader([])
 

--- a/__tests__/lib/platform/grupos-vida-adapter.test.ts
+++ b/__tests__/lib/platform/grupos-vida-adapter.test.ts
@@ -1,0 +1,136 @@
+import {
+  canReadGruposVidaGroup,
+  filterGruposVidaRecordsByScope,
+  resolveGruposVidaPlatformContext,
+} from '@/lib/platform/adapters/grupos-vida'
+import type { GruposVidaDirectorEtapaAssignment, GruposVidaReadRepository } from '@/lib/platform/adapters/grupos-vida'
+import type { PlatformSession } from '@/lib/platform/session/types'
+
+const directorSession: PlatformSession = {
+  personaId: 'persona-director',
+  subjectAuthId: 'auth-director',
+  globalRoles: [],
+  contexts: [],
+  capabilities: [],
+}
+
+const directorAssignment: GruposVidaDirectorEtapaAssignment = {
+  directorEtapaId: 'director-etapa-1',
+  personaId: 'persona-director',
+  segmentoId: 'segmento-adultos',
+  segmentoLabel: 'Adultos',
+  assignedGroupIds: ['grupo-norte', 'grupo-sur'],
+}
+
+function createReader(assignments: readonly GruposVidaDirectorEtapaAssignment[]): GruposVidaReadRepository {
+  return {
+    findDirectorEtapaAssignmentsByPersonaId: jest.fn().mockResolvedValue(assignments),
+  }
+}
+
+describe('Grupos de Vida platform read adapter', () => {
+  it('resolves the expected platform context for an authorized director de etapa', async () => {
+    const reader = createReader([directorAssignment])
+
+    const result = await resolveGruposVidaPlatformContext({ session: directorSession, reader })
+
+    expect(reader.findDirectorEtapaAssignmentsByPersonaId).toHaveBeenCalledWith('persona-director')
+    expect(result).toEqual({
+      ok: true,
+      contexts: [{ experience: 'grupos_vida', scopeType: 'etapa', scopeId: 'segmento-adultos', label: 'Grupos de Vida — Adultos' }],
+      capabilities: [{ key: 'grupos_vida.stage.read', experience: 'grupos_vida', scopeType: 'etapa', scopeId: 'segmento-adultos', source: 'gdv:director_etapa' }],
+      scope: { stageIds: ['segmento-adultos'], groupIds: ['grupo-norte', 'grupo-sur'] },
+      audit: { decision: 'allowed', personaId: 'persona-director', assignmentCount: 1, exposedGroupCount: 2 },
+    })
+  })
+
+  it('fails closed for a user without Grupos de Vida scope', async () => {
+    const reader = createReader([])
+
+    const result = await resolveGruposVidaPlatformContext({ session: directorSession, reader })
+
+    expect(result).toEqual({
+      ok: false,
+      reason: 'missing_gdv_scope',
+      contexts: [],
+      capabilities: [],
+      scope: { stageIds: [], groupIds: [] },
+      audit: { decision: 'denied', reason: 'missing_gdv_scope', personaId: 'persona-director', assignmentCount: 0, exposedGroupCount: 0 },
+    })
+  })
+
+  it('does not grant Grupos de Vida permissions from padre or tutor family relationships', async () => {
+    const parentSession: PlatformSession = { ...directorSession, personaId: 'persona-padre', subjectAuthId: 'auth-padre' }
+    const reader = createReader([])
+
+    const result = await resolveGruposVidaPlatformContext({
+      session: parentSession,
+      reader,
+      familyRelations: [
+        { personaId: 'persona-padre', relatedPersonaId: 'child-waumba', type: 'padre' },
+        { personaId: 'persona-padre', relatedPersonaId: 'child-insideout', type: 'tutor' },
+      ],
+    })
+
+    expect(result).toMatchObject({ ok: false, reason: 'missing_gdv_scope', capabilities: [], scope: { groupIds: [] } })
+    expect(reader.findDirectorEtapaAssignmentsByPersonaId).toHaveBeenCalledWith('persona-padre')
+  })
+
+  it('does not copy or create cross-experience permissions', async () => {
+    const reader = createReader([directorAssignment])
+    const sessionWithOtherExperience: PlatformSession = {
+      ...directorSession,
+      capabilities: [{ key: 'dps.team.serve', experience: 'dps', scopeType: 'equipo', scopeId: 'musica', source: 'dream-team' }],
+    }
+
+    const result = await resolveGruposVidaPlatformContext({ session: sessionWithOtherExperience, reader })
+
+    expect(result).toMatchObject({ ok: true })
+    expect(result.capabilities).toEqual([{ key: 'grupos_vida.stage.read', experience: 'grupos_vida', scopeType: 'etapa', scopeId: 'segmento-adultos', source: 'gdv:director_etapa' }])
+    expect(JSON.stringify(result)).not.toContain('dps.team.serve')
+  })
+
+  it('does not expose records outside the resolved Grupos de Vida scope', async () => {
+    const reader = createReader([{ ...directorAssignment, assignedGroupIds: ['grupo-autorizado'] }])
+    const result = await resolveGruposVidaPlatformContext({ session: directorSession, reader })
+    if (!result.ok) throw new Error(`expected authorized scope, got ${result.reason}`)
+
+    const visibleRecords = filterGruposVidaRecordsByScope(
+      result.scope,
+      [
+        { grupoId: 'grupo-autorizado', name: 'Visible group' },
+        { grupoId: 'grupo-externo', name: 'Hidden group' },
+      ],
+      (record) => record.grupoId,
+    )
+
+    expect(canReadGruposVidaGroup(result.scope, 'grupo-autorizado')).toBe(true)
+    expect(canReadGruposVidaGroup(result.scope, 'grupo-externo')).toBe(false)
+    expect(visibleRecords).toEqual([{ grupoId: 'grupo-autorizado', name: 'Visible group' }])
+  })
+
+  it('fails closed when adapter reads fail or mapped GDV scope is unsafe', async () => {
+    const failingReader: GruposVidaReadRepository = {
+      findDirectorEtapaAssignmentsByPersonaId: jest.fn().mockRejectedValue(new Error('database timeout')),
+    }
+    const malformedReader = createReader([{ ...directorAssignment, segmentoId: '../segmento-adultos' }])
+
+    await expect(resolveGruposVidaPlatformContext({ session: directorSession, reader: failingReader })).resolves.toEqual({
+      ok: false,
+      reason: 'adapter_read_failed',
+      contexts: [],
+      capabilities: [],
+      scope: { stageIds: [], groupIds: [] },
+      audit: { decision: 'denied', reason: 'adapter_read_failed', personaId: 'persona-director', assignmentCount: 0, exposedGroupCount: 0 },
+    })
+
+    await expect(resolveGruposVidaPlatformContext({ session: directorSession, reader: malformedReader })).resolves.toMatchObject({
+      ok: false,
+      reason: 'invalid_gdv_scope',
+      contexts: [],
+      capabilities: [],
+      scope: { stageIds: [], groupIds: [] },
+      audit: { decision: 'denied', reason: 'invalid_gdv_scope' },
+    })
+  })
+})

--- a/lib/platform/adapters/grupos-vida.ts
+++ b/lib/platform/adapters/grupos-vida.ts
@@ -1,0 +1,161 @@
+import type { PlatformSession, PlatformSessionCapability, PlatformSessionContext } from '@/lib/platform/session/types'
+
+export type GruposVidaDirectorEtapaAssignment = {
+  directorEtapaId: string
+  personaId: string
+  segmentoId: string
+  segmentoLabel: string | null
+  assignedGroupIds: readonly string[]
+}
+
+export type GruposVidaReadRepository = {
+  findDirectorEtapaAssignmentsByPersonaId(personaId: string): Promise<readonly GruposVidaDirectorEtapaAssignment[]>
+}
+
+export type GruposVidaFamilyRelation = {
+  personaId: string
+  relatedPersonaId: string
+  type: 'conyuge' | 'padre' | 'hijo' | 'tutor' | 'hermano' | 'otro_familiar'
+}
+
+export type GruposVidaAdapterInput = {
+  session: PlatformSession | null | undefined
+  reader: GruposVidaReadRepository
+  familyRelations?: readonly GruposVidaFamilyRelation[]
+}
+
+export type GruposVidaAuthorizedScope = { stageIds: string[]; groupIds: string[] }
+export type GruposVidaAdapterDeniedReason = 'session_required' | 'adapter_read_failed' | 'missing_gdv_scope' | 'invalid_gdv_scope'
+export type GruposVidaAdapterAudit = {
+  decision: 'allowed' | 'denied'
+  reason?: GruposVidaAdapterDeniedReason
+  personaId?: string
+  assignmentCount: number
+  exposedGroupCount: number
+}
+
+export type GruposVidaAdapterResult =
+  | { ok: true; contexts: PlatformSessionContext[]; capabilities: PlatformSessionCapability[]; scope: GruposVidaAuthorizedScope; audit: GruposVidaAdapterAudit }
+  | { ok: false; reason: GruposVidaAdapterDeniedReason; contexts: []; capabilities: []; scope: GruposVidaAuthorizedScope; audit: GruposVidaAdapterAudit }
+
+type NormalizedDirectorAssignment = { stageId: string; label: string; groupIds: string[] }
+
+const GDV_STAGE_READ_CAPABILITY = 'grupos_vida.stage.read'
+const GDV_CONTEXT_SOURCE = 'gdv:director_etapa'
+const SCOPE_ID_MAX_LENGTH = 64
+const SCOPE_ID_FIRST_CHARACTER_PATTERN = /^[a-z0-9]$/
+const SCOPE_ID_ALLOWED_CHARACTERS_PATTERN = /^[a-z0-9._:-]+$/
+
+export async function resolveGruposVidaPlatformContext(input: GruposVidaAdapterInput): Promise<GruposVidaAdapterResult> {
+  const personaId = normalizeScopeId(input.session?.personaId)
+  if (!personaId || !input.session?.subjectAuthId.trim()) {
+    return denied('session_required', personaId)
+  }
+
+  let assignments: readonly GruposVidaDirectorEtapaAssignment[]
+  try {
+    assignments = await input.reader.findDirectorEtapaAssignmentsByPersonaId(personaId)
+  } catch {
+    return denied('adapter_read_failed', personaId)
+  }
+
+  const normalizedAssignments = normalizeDirectorAssignments(assignments, personaId)
+  if (!normalizedAssignments) {
+    return denied('invalid_gdv_scope', personaId)
+  }
+  if (normalizedAssignments.length === 0) {
+    return denied('missing_gdv_scope', personaId)
+  }
+
+  const scope = toAuthorizedScope(normalizedAssignments)
+  return {
+    ok: true,
+    contexts: normalizedAssignments.map(toPlatformContext),
+    capabilities: normalizedAssignments.map(toPlatformCapability),
+    scope,
+    audit: { decision: 'allowed', personaId, assignmentCount: normalizedAssignments.length, exposedGroupCount: scope.groupIds.length },
+  }
+}
+
+export function canReadGruposVidaGroup(scope: GruposVidaAuthorizedScope, groupId: string | null | undefined): boolean {
+  const normalizedGroupId = normalizeScopeId(groupId)
+  return Boolean(normalizedGroupId && new Set(scope.groupIds).has(normalizedGroupId))
+}
+
+export function filterGruposVidaRecordsByScope<T>(scope: GruposVidaAuthorizedScope, records: readonly T[], selectGroupId: (record: T) => string | null | undefined): T[] {
+  const allowedGroupIds = new Set(scope.groupIds)
+  return records.filter((record) => {
+    const groupId = normalizeScopeId(selectGroupId(record))
+    return Boolean(groupId && allowedGroupIds.has(groupId))
+  })
+}
+
+function normalizeDirectorAssignments(assignments: readonly GruposVidaDirectorEtapaAssignment[], personaId: string): NormalizedDirectorAssignment[] | null {
+  const byStageId = new Map<string, NormalizedDirectorAssignment>()
+  for (const assignment of assignments) {
+    const assignmentPersonaId = normalizeScopeId(assignment.personaId)
+    const directorEtapaId = normalizeScopeId(assignment.directorEtapaId)
+    const stageId = normalizeScopeId(assignment.segmentoId)
+    const groupIds = normalizeGroupIds(assignment.assignedGroupIds)
+    if (!assignmentPersonaId || assignmentPersonaId !== personaId || !directorEtapaId || !stageId || !groupIds) {
+      return null
+    }
+
+    const existing = byStageId.get(stageId)
+    const mergedGroupIds = uniqueSorted([...(existing?.groupIds ?? []), ...groupIds])
+    byStageId.set(stageId, { stageId, label: formatStageLabel(assignment.segmentoLabel, stageId), groupIds: mergedGroupIds })
+  }
+  return [...byStageId.values()].sort((left, right) => left.stageId.localeCompare(right.stageId))
+}
+
+function normalizeGroupIds(groupIds: readonly string[]): string[] | null {
+  const normalizedGroupIds: string[] = []
+  for (const groupId of groupIds) {
+    const normalizedGroupId = normalizeScopeId(groupId)
+    if (!normalizedGroupId) return null
+    normalizedGroupIds.push(normalizedGroupId)
+  }
+  return uniqueSorted(normalizedGroupIds)
+}
+
+function toAuthorizedScope(assignments: readonly NormalizedDirectorAssignment[]): GruposVidaAuthorizedScope {
+  return {
+    stageIds: assignments.map((assignment) => assignment.stageId),
+    groupIds: uniqueSorted(assignments.flatMap((assignment) => assignment.groupIds)),
+  }
+}
+
+function toPlatformContext(assignment: NormalizedDirectorAssignment): PlatformSessionContext {
+  return { experience: 'grupos_vida', scopeType: 'etapa', scopeId: assignment.stageId, label: assignment.label }
+}
+
+function toPlatformCapability(assignment: NormalizedDirectorAssignment): PlatformSessionCapability {
+  return { key: GDV_STAGE_READ_CAPABILITY, experience: 'grupos_vida', scopeType: 'etapa', scopeId: assignment.stageId, source: GDV_CONTEXT_SOURCE }
+}
+
+function denied(reason: GruposVidaAdapterDeniedReason, personaId?: string): GruposVidaAdapterResult {
+  return {
+    ok: false,
+    reason,
+    contexts: [],
+    capabilities: [],
+    scope: { stageIds: [], groupIds: [] },
+    audit: { decision: 'denied', reason, ...(personaId ? { personaId } : {}), assignmentCount: 0, exposedGroupCount: 0 },
+  }
+}
+
+function formatStageLabel(label: string | null, stageId: string): string {
+  const cleanLabel = label?.trim()
+  return `Grupos de Vida — ${cleanLabel || stageId}`
+}
+
+function normalizeScopeId(value: string | null | undefined): string | undefined {
+  const normalized = value?.trim().toLowerCase()
+  if (!normalized || normalized.length > SCOPE_ID_MAX_LENGTH) return undefined
+  if (!SCOPE_ID_FIRST_CHARACTER_PATTERN.test(normalized[0] ?? '')) return undefined
+  return SCOPE_ID_ALLOWED_CHARACTERS_PATTERN.test(normalized) ? normalized : undefined
+}
+
+function uniqueSorted(values: readonly string[]): string[] {
+  return [...new Set(values)].sort((left, right) => left.localeCompare(right))
+}

--- a/lib/platform/adapters/grupos-vida.ts
+++ b/lib/platform/adapters/grupos-vida.ts
@@ -1,3 +1,4 @@
+import { normalizePlatformScopeId } from '@/lib/platform/experiences'
 import type { PlatformSession, PlatformSessionCapability, PlatformSessionContext } from '@/lib/platform/session/types'
 
 export type GruposVidaDirectorEtapaAssignment = {
@@ -12,16 +13,9 @@ export type GruposVidaReadRepository = {
   findDirectorEtapaAssignmentsByPersonaId(personaId: string): Promise<readonly GruposVidaDirectorEtapaAssignment[]>
 }
 
-export type GruposVidaFamilyRelation = {
-  personaId: string
-  relatedPersonaId: string
-  type: 'conyuge' | 'padre' | 'hijo' | 'tutor' | 'hermano' | 'otro_familiar'
-}
-
 export type GruposVidaAdapterInput = {
   session: PlatformSession | null | undefined
   reader: GruposVidaReadRepository
-  familyRelations?: readonly GruposVidaFamilyRelation[]
 }
 
 export type GruposVidaAuthorizedScope = { stageIds: string[]; groupIds: string[] }
@@ -42,12 +36,9 @@ type NormalizedDirectorAssignment = { stageId: string; label: string; groupIds: 
 
 const GDV_STAGE_READ_CAPABILITY = 'grupos_vida.stage.read'
 const GDV_CONTEXT_SOURCE = 'gdv:director_etapa'
-const SCOPE_ID_MAX_LENGTH = 64
-const SCOPE_ID_FIRST_CHARACTER_PATTERN = /^[a-z0-9]$/
-const SCOPE_ID_ALLOWED_CHARACTERS_PATTERN = /^[a-z0-9._:-]+$/
 
 export async function resolveGruposVidaPlatformContext(input: GruposVidaAdapterInput): Promise<GruposVidaAdapterResult> {
-  const personaId = normalizeScopeId(input.session?.personaId)
+  const personaId = normalizePlatformScopeId(input.session?.personaId)
   if (!personaId || !input.session?.subjectAuthId.trim()) {
     return denied('session_required', personaId)
   }
@@ -78,14 +69,14 @@ export async function resolveGruposVidaPlatformContext(input: GruposVidaAdapterI
 }
 
 export function canReadGruposVidaGroup(scope: GruposVidaAuthorizedScope, groupId: string | null | undefined): boolean {
-  const normalizedGroupId = normalizeScopeId(groupId)
+  const normalizedGroupId = normalizePlatformScopeId(groupId)
   return Boolean(normalizedGroupId && new Set(scope.groupIds).has(normalizedGroupId))
 }
 
 export function filterGruposVidaRecordsByScope<T>(scope: GruposVidaAuthorizedScope, records: readonly T[], selectGroupId: (record: T) => string | null | undefined): T[] {
   const allowedGroupIds = new Set(scope.groupIds)
   return records.filter((record) => {
-    const groupId = normalizeScopeId(selectGroupId(record))
+    const groupId = normalizePlatformScopeId(selectGroupId(record))
     return Boolean(groupId && allowedGroupIds.has(groupId))
   })
 }
@@ -93,9 +84,9 @@ export function filterGruposVidaRecordsByScope<T>(scope: GruposVidaAuthorizedSco
 function normalizeDirectorAssignments(assignments: readonly GruposVidaDirectorEtapaAssignment[], personaId: string): NormalizedDirectorAssignment[] | null {
   const byStageId = new Map<string, NormalizedDirectorAssignment>()
   for (const assignment of assignments) {
-    const assignmentPersonaId = normalizeScopeId(assignment.personaId)
-    const directorEtapaId = normalizeScopeId(assignment.directorEtapaId)
-    const stageId = normalizeScopeId(assignment.segmentoId)
+    const assignmentPersonaId = normalizePlatformScopeId(assignment.personaId)
+    const directorEtapaId = normalizePlatformScopeId(assignment.directorEtapaId)
+    const stageId = normalizePlatformScopeId(assignment.segmentoId)
     const groupIds = normalizeGroupIds(assignment.assignedGroupIds)
     if (!assignmentPersonaId || assignmentPersonaId !== personaId || !directorEtapaId || !stageId || !groupIds) {
       return null
@@ -111,11 +102,11 @@ function normalizeDirectorAssignments(assignments: readonly GruposVidaDirectorEt
 function normalizeGroupIds(groupIds: readonly string[]): string[] | null {
   const normalizedGroupIds: string[] = []
   for (const groupId of groupIds) {
-    const normalizedGroupId = normalizeScopeId(groupId)
+    const normalizedGroupId = normalizePlatformScopeId(groupId)
     if (!normalizedGroupId) return null
     normalizedGroupIds.push(normalizedGroupId)
   }
-  return uniqueSorted(normalizedGroupIds)
+  return normalizedGroupIds.length > 0 ? uniqueSorted(normalizedGroupIds) : null
 }
 
 function toAuthorizedScope(assignments: readonly NormalizedDirectorAssignment[]): GruposVidaAuthorizedScope {
@@ -147,13 +138,6 @@ function denied(reason: GruposVidaAdapterDeniedReason, personaId?: string): Grup
 function formatStageLabel(label: string | null, stageId: string): string {
   const cleanLabel = label?.trim()
   return `Grupos de Vida — ${cleanLabel || stageId}`
-}
-
-function normalizeScopeId(value: string | null | undefined): string | undefined {
-  const normalized = value?.trim().toLowerCase()
-  if (!normalized || normalized.length > SCOPE_ID_MAX_LENGTH) return undefined
-  if (!SCOPE_ID_FIRST_CHARACTER_PATTERN.test(normalized[0] ?? '')) return undefined
-  return SCOPE_ID_ALLOWED_CHARACTERS_PATTERN.test(normalized) ? normalized : undefined
 }
 
 function uniqueSorted(values: readonly string[]): string[] {

--- a/lib/platform/experiences.ts
+++ b/lib/platform/experiences.ts
@@ -146,7 +146,7 @@ function normalizeScope(scope: PlatformScopeInput | null | undefined, definition
   if (!experienceAllowsScopeType(experience, type)) return { ok: false, reason: 'unknown' }
   if (experience !== definition.experience || type !== definition.scopeType) return { ok: false, reason: 'conflicting' }
 
-  const id = normalizeScopeId(scope.id)
+  const id = normalizePlatformScopeId(scope.id)
   if (type !== 'experience' && !id) return { ok: false, reason: scope.id?.trim() ? 'malformed' : 'missing' }
   if (type === 'experience' && scope.id?.trim() && !id) return { ok: false, reason: 'malformed' }
 
@@ -200,7 +200,7 @@ function normalizeSource(value: string | null | undefined): string {
   return value?.trim() || 'unknown'
 }
 
-function normalizeScopeId(value: string | null | undefined): string | undefined {
+export function normalizePlatformScopeId(value: string | null | undefined): string | undefined {
   const normalized = normalizeToken(value)
   if (!normalized || normalized.length > SCOPE_ID_MAX_LENGTH) return undefined
   if (!SCOPE_ID_FIRST_CHARACTER_PATTERN.test(normalized[0] ?? '')) return undefined

--- a/openspec/changes/fase-01-platform-foundation/tasks.md
+++ b/openspec/changes/fase-01-platform-foundation/tasks.md
@@ -38,8 +38,8 @@ Chain strategy: stacked-to-main para PR1a; confirmar por slice futuro
 
 ## Fase 2: Adapter GDV read-only
 
-- [ ] 2.1 Crear `lib/platform/adapters/grupos-vida.ts` para mapear contexto GDV sin reemplazar RPC/RLS ni flujos existentes.
-- [ ] 2.2 Agregar `__tests__/lib/platform/grupos-vida-adapter.test.ts`: director autorizado, adapter fallido, tutor sin permiso y ausencia de permisos cruzados.
+- [x] 2.1 Crear `lib/platform/adapters/grupos-vida.ts` para mapear contexto GDV sin reemplazar RPC/RLS ni flujos existentes.
+- [x] 2.2 Agregar `__tests__/lib/platform/grupos-vida-adapter.test.ts`: director autorizado, adapter fallido, tutor sin permiso y ausencia de permisos cruzados.
 
 ## Fase 3: Menú y dashboard
 


### PR DESCRIPTION
## Resumen
Closes #208

Implementa el adapter read-only de Grupos de Vida para Platform Foundation como capa interna de compatibilidad. No cambia flujos existentes de GDV, UI, rutas, server actions, RPC/RLS ni base de datos.

## Qué Incluye
- Adapter puro e inyectado para mapear asignaciones actuales de `director_etapa` a contexto/capability de plataforma.
- Helpers para limitar lectura de records GDV al scope autorizado.
- Tests de director autorizado, fail-closed sin scope, padre/tutor sin permisos, sin permisos cruzados, no exposición fuera de scope y errores/fallback fail-closed.
- Marcado de tasks 2.1 y 2.2 en OpenSpec.

## Motivación / Por Qué
Platform Foundation necesita leer contexto GDV sin reemplazar el source of truth operativo. Este slice mantiene GDV intacto y prepara la integración futura de sesión/menu/dashboard desde contratos internos seguros.

## Chain Context
- Estrategia: `stacked-to-main` desde `main` actualizado.
- Dependencias previas: PR #204, PR #205 y PR #207 ya mergeados en `main`.
- PR actual: 📍 issue #208 / tasks 2.1 + 2.2.
- Fuera de alcance: asistencia, líderes, directores, permisos, dashboards, rutas, server actions, RPC/RLS, UI, migraciones y Supabase remoto.
- Follow-up: Fase 3 menú/dashboard contextual con feature flag/fallback legado.

```text
main
├─ PR #204 PlatformSession/auth base (merged)
├─ PR #205 Persona/dedupe base (merged)
├─ PR #207 Experiences/scopes fail-closed (merged)
└─ 📍 PR actual: GDV read-only adapter (#208)
```

## Evidencia Visual (si aplica)
No aplica: cambio interno sin UI.

## Migraciones / Base de Datos
- [x] No aplica
- [ ] Sí (orden exacto):
```
N/A
```
Notas: no se crean ni modifican migraciones, tablas, RPCs, RLS ni datos.

## Impacto y Riesgos
- No rompe compatibilidad: solo agrega adapter interno y tests.
- No requiere coordinación de despliegue ni cambios visibles en producción.
- Riesgo principal: usar el adapter fuera de su scope; mitigado con fail-closed, dependency injection y helper de filtrado por grupos autorizados.

## Checklist Autor
- [x] Código formateado en archivos nuevos
- [x] Sin `console.log` / debugger
- [x] Validaciones con zod para entradas nuevas: no aplica, no hay entradas de usuario ni API pública
- [x] Estados loading/error/empty cubiertos: no aplica, no hay UI
- [x] Tipos TypeScript correctos
- [x] Migraciones probadas local: no aplica, sin migraciones
- [x] Documentación actualizada (`docs/` o README): no aplica, OpenSpec tasks actualizado
- [x] Variables de entorno documentadas: no aplica
- [x] Rebase con `main` limpio

## Checklist Revisor
- [ ] Propósito claro
- [ ] Nombres descriptivos
- [ ] Sin lógica duplicada evidente
- [ ] Manejo adecuado de errores
- [ ] Cambios acotados al alcance
- [ ] Sin secretos / datos sensibles

## Pruebas Manuales Realizadas
- [x] `pnpm test -- __tests__/lib/platform/grupos-vida-adapter.test.ts` — 6 tests passed
- [x] `pnpm test -- __tests__/lib/platform/session.test.ts __tests__/lib/platform/persona.test.ts __tests__/lib/platform/experiences.test.ts __tests__/lib/platform/grupos-vida-adapter.test.ts` — 4 suites / 25 tests passed
- [x] `pnpm exec tsc --noEmit --pretty false` — passed
- [x] `pnpm test:ci` — 43 Jest suites / 415 Jest tests and 26 node tests passed
- [x] `git diff --check main...HEAD` — passed

## Pendientes / Follow-up (opcional)
- Fase 3: menú/dashboard contextual con feature flag, kill switch y fallback legado.

## Notas Adicionales
El adapter no usa Supabase remoto ni realiza escrituras. La integración real con clientes GDV queda para un slice posterior y debe seguir delegando permisos productivos a los mecanismos actuales.