### PR TITLE
feat(auth): integra platformSession read-only en auth base

### DIFF
--- a/__tests__/lib/auth/platform-session-auth-base.test.ts
+++ b/__tests__/lib/auth/platform-session-auth-base.test.ts
@@ -1,0 +1,124 @@
+import { requireAuth, requireRole } from '@/lib/auth/requireAuth'
+import type { AuthBaseSupabaseClient } from '@/lib/auth/platformSessionReadOnly'
+import { getUserWithRoles } from '@/lib/getUserWithRoles'
+
+const createSupabaseServerClient = jest.fn()
+
+jest.mock('@/lib/supabase/server', () => ({
+  createSupabaseServerClient: () => createSupabaseServerClient(),
+}))
+
+type AuthUser = { id: string; email?: string }
+type PersonaRow = { id: string; auth_id: string | null }
+
+const defaultUser = { id: 'auth-1', email: 'staff@example.com' } satisfies AuthUser
+const linkedPersona = { id: 'persona-1', auth_id: 'auth-1' } satisfies PersonaRow
+
+function createAuthBaseClient(input: {
+  user?: AuthUser | null
+  authError?: Error | null
+  rolesData?: unknown
+  rolesError?: Error | null
+  personaData?: PersonaRow | null
+  personaError?: Error | null
+}) {
+  const personaQuery = {
+    select: jest.fn(),
+    eq: jest.fn(),
+    maybeSingle: jest.fn().mockResolvedValue({ data: input.personaData ?? linkedPersona, error: input.personaError ?? null }),
+  }
+  personaQuery.select.mockReturnValue(personaQuery)
+  personaQuery.eq.mockReturnValue(personaQuery)
+
+  const client: AuthBaseSupabaseClient = {
+    auth: {
+      getUser: jest.fn().mockResolvedValue({ data: { user: input.user === undefined ? defaultUser : input.user }, error: input.authError ?? null }),
+    },
+    rpc: jest.fn().mockResolvedValue({ data: input.rolesData ?? [], error: input.rolesError ?? null }),
+    from: jest.fn((table: string) => {
+      if (table !== 'usuarios') throw new Error(`Unexpected table ${table}`)
+      return personaQuery
+    }),
+  }
+
+  return { client, personaQuery }
+}
+
+describe('platformSession read-only auth base integration', () => {
+  beforeEach(() => {
+    createSupabaseServerClient.mockReset()
+  })
+
+  it('exposes platformSession from getUserWithRoles without changing legacy roles', async () => {
+    const { client, personaQuery } = createAuthBaseClient({
+      rolesData: [{ nombre_interno: 'admin' }, 'lider'],
+    })
+
+    const result = await getUserWithRoles(client)
+
+    expect(result).toEqual({
+      user: defaultUser,
+      roles: ['admin', 'lider'],
+      platformSession: {
+        personaId: 'persona-1',
+        subjectAuthId: 'auth-1',
+        globalRoles: ['admin', 'lider'],
+        contexts: [],
+        capabilities: [],
+      },
+    })
+    expect(personaQuery.select).toHaveBeenCalledWith('id, auth_id')
+    expect(personaQuery.eq).toHaveBeenCalledWith('auth_id', 'auth-1')
+  })
+
+  it('keeps legacy roles when platformSession lookup fails closed', async () => {
+    const { client } = createAuthBaseClient({
+      rolesData: ['admin'],
+      personaError: new Error('platform lookup timeout'),
+    })
+
+    await expect(getUserWithRoles(client)).resolves.toEqual({
+      user: defaultUser,
+      roles: ['admin'],
+      platformSession: null,
+    })
+  })
+
+  it('adds read-only platformSession to requireAuth when persona lookup is safe', async () => {
+    const { client } = createAuthBaseClient({})
+    createSupabaseServerClient.mockResolvedValue(client)
+
+    await expect(requireAuth()).resolves.toEqual({
+      authId: 'auth-1',
+      email: 'staff@example.com',
+      platformSession: {
+        personaId: 'persona-1',
+        subjectAuthId: 'auth-1',
+        globalRoles: [],
+        contexts: [],
+        capabilities: [],
+      },
+    })
+  })
+
+  it('preserves requireRole legacy fallback when platformSession lookup fails', async () => {
+    const { client } = createAuthBaseClient({
+      rolesData: ['admin'],
+      personaError: new Error('platform lookup timeout'),
+    })
+    createSupabaseServerClient.mockResolvedValue(client)
+
+    await expect(requireRole('admin')).resolves.toEqual({
+      authId: 'auth-1',
+      email: 'staff@example.com',
+      platformSession: null,
+    })
+  })
+
+  it('does not authorize requireRole from platformSession availability alone', async () => {
+    const { client } = createAuthBaseClient({ rolesData: [] })
+    createSupabaseServerClient.mockResolvedValue(client)
+
+    await expect(requireRole('admin')).rejects.toThrow('Permiso denegado: se requiere rol admin')
+  })
+})

--- a/__tests__/lib/auth/platform-session-auth-base.test.ts
+++ b/__tests__/lib/auth/platform-session-auth-base.test.ts
@@ -22,10 +22,11 @@ function createAuthBaseClient(input: {
   personaData?: PersonaRow | null
   personaError?: Error | null
 }) {
+  const personaData = input.personaData === undefined ? linkedPersona : input.personaData
   const personaQuery = {
     select: jest.fn(),
     eq: jest.fn(),
-    maybeSingle: jest.fn().mockResolvedValue({ data: input.personaData ?? linkedPersona, error: input.personaError ?? null }),
+    maybeSingle: jest.fn().mockResolvedValue({ data: personaData, error: input.personaError ?? null }),
   }
   personaQuery.select.mockReturnValue(personaQuery)
   personaQuery.eq.mockReturnValue(personaQuery)
@@ -84,6 +85,24 @@ describe('platformSession read-only auth base integration', () => {
     })
   })
 
+  it('resolves platformSession with empty roles when legacy roles lookup fails', async () => {
+    const { client } = createAuthBaseClient({
+      rolesError: new Error('roles rpc timeout'),
+    })
+
+    await expect(getUserWithRoles(client)).resolves.toEqual({
+      user: defaultUser,
+      roles: [],
+      platformSession: {
+        personaId: 'persona-1',
+        subjectAuthId: 'auth-1',
+        globalRoles: [],
+        contexts: [],
+        capabilities: [],
+      },
+    })
+  })
+
   it('adds read-only platformSession to requireAuth when persona lookup is safe', async () => {
     const { client } = createAuthBaseClient({})
     createSupabaseServerClient.mockResolvedValue(client)
@@ -98,6 +117,32 @@ describe('platformSession read-only auth base integration', () => {
         contexts: [],
         capabilities: [],
       },
+    })
+  })
+
+  it('keeps requireAuth authenticated when platformSession lookup fails closed', async () => {
+    const { client } = createAuthBaseClient({
+      personaError: new Error('platform lookup timeout'),
+    })
+    createSupabaseServerClient.mockResolvedValue(client)
+
+    await expect(requireAuth()).resolves.toEqual({
+      authId: 'auth-1',
+      email: 'staff@example.com',
+      platformSession: null,
+    })
+  })
+
+  it('keeps requireAuth authenticated when no Persona row is linked', async () => {
+    const { client } = createAuthBaseClient({
+      personaData: null,
+    })
+    createSupabaseServerClient.mockResolvedValue(client)
+
+    await expect(requireAuth()).resolves.toEqual({
+      authId: 'auth-1',
+      email: 'staff@example.com',
+      platformSession: null,
     })
   })
 

--- a/lib/auth/platformSessionReadOnly.ts
+++ b/lib/auth/platformSessionReadOnly.ts
@@ -1,0 +1,91 @@
+import { buildPlatformSession } from '@/lib/platform/session/build'
+import type { PlatformSession, PlatformSessionPersona } from '@/lib/platform/session/types'
+import type { SupabaseClient } from '@supabase/supabase-js'
+
+export type AuthBaseUser = { id: string; email?: string }
+
+type AuthBasePersonaRow = { id: string; auth_id: string | null }
+type AuthBasePersonaSelection = {
+  eq(column: string, value: string): AuthBasePersonaSingleQuery
+}
+type AuthBasePersonaSingleQuery = {
+  maybeSingle(): PromiseLike<{ data: AuthBasePersonaRow | null; error: unknown }>
+}
+type AuthBasePersonaQuery = {
+  select(columns: string): AuthBasePersonaSelection
+}
+
+export type AuthBaseSupabaseClient = {
+  auth: {
+    getUser(): Promise<{ data: { user: AuthBaseUser | null }; error: unknown }>
+  }
+  rpc(functionName: string, args: { p_auth_id: string }): PromiseLike<{ data: unknown; error: unknown }>
+  from(table: 'usuarios'): AuthBasePersonaQuery
+}
+
+export function toAuthBaseSupabaseClient(value: unknown): AuthBaseSupabaseClient {
+  if (!isAuthBaseSupabaseClient(value)) throw new Error('Invalid auth base Supabase client')
+  return value
+}
+
+export function normalizeLegacyRoles(rolesData: unknown): string[] {
+  if (!Array.isArray(rolesData)) return []
+  return rolesData
+    .map((role) => (typeof role === 'string' ? role : getRoleName(role)))
+    .filter((role): role is string => Boolean(role))
+}
+
+export async function resolveReadOnlyPlatformSession(input: {
+  subjectAuthId: string | null | undefined
+  findPersonaByAuthId: (authId: string) => Promise<PlatformSessionPersona | null>
+  globalRoles?: string[]
+}): Promise<PlatformSession | null> {
+  try {
+    const result = await buildPlatformSession({
+      subjectAuthId: input.subjectAuthId,
+      personaLookup: {
+        findByAuthId: input.findPersonaByAuthId,
+      },
+    })
+
+    return result.ok ? { ...result.session, globalRoles: [...(input.globalRoles ?? [])] } : null
+  } catch {
+    return null
+  }
+}
+
+export function findPlatformSessionPersonaByAuthId(supabase: SupabaseClient, authId: string): Promise<PlatformSessionPersona | null>
+export function findPlatformSessionPersonaByAuthId(supabase: AuthBaseSupabaseClient, authId: string): Promise<PlatformSessionPersona | null>
+export async function findPlatformSessionPersonaByAuthId(supabase: SupabaseClient | AuthBaseSupabaseClient, authId: string): Promise<PlatformSessionPersona | null> {
+  const { data, error } = await supabase
+    .from('usuarios')
+    .select('id, auth_id')
+    .eq('auth_id', authId)
+    .maybeSingle()
+
+  if (error) throw new Error('platform persona lookup failed')
+  return toPlatformSessionPersona(data)
+}
+
+function toPlatformSessionPersona(row: AuthBasePersonaRow | null): PlatformSessionPersona | null {
+  if (!row?.id.trim()) return null
+  return { id: row.id, authId: row.auth_id }
+}
+
+function getRoleName(role: unknown): string | undefined {
+  if (typeof role !== 'object' || role === null || !('nombre_interno' in role)) return undefined
+  const roleName = role.nombre_interno
+  return typeof roleName === 'string' ? roleName : undefined
+}
+
+function isAuthBaseSupabaseClient(value: unknown): value is AuthBaseSupabaseClient {
+  if (typeof value !== 'object' || value === null) return false
+  const auth = Reflect.get(value, 'auth')
+  return (
+    typeof auth === 'object'
+    && auth !== null
+    && typeof Reflect.get(auth, 'getUser') === 'function'
+    && typeof Reflect.get(value, 'rpc') === 'function'
+    && typeof Reflect.get(value, 'from') === 'function'
+  )
+}

--- a/lib/auth/requireAuth.ts
+++ b/lib/auth/requireAuth.ts
@@ -1,10 +1,13 @@
 "use server"
 
 import { createSupabaseServerClient } from "@/lib/supabase/server"
+import { findPlatformSessionPersonaByAuthId, normalizeLegacyRoles, resolveReadOnlyPlatformSession } from '@/lib/auth/platformSessionReadOnly'
+import type { PlatformSession } from '@/lib/platform/session/types'
 
 interface AuthenticatedUser {
   authId: string
   email: string | undefined
+  platformSession: PlatformSession | null
 }
 
 /**
@@ -20,9 +23,15 @@ export async function requireAuth(): Promise<AuthenticatedUser> {
     throw new Error("No autenticado")
   }
 
+  const platformSession = await resolveReadOnlyPlatformSession({
+    subjectAuthId: user.id,
+    findPersonaByAuthId: (authId) => findPlatformSessionPersonaByAuthId(supabase, authId),
+  })
+
   return {
     authId: user.id,
     email: user.email,
+    platformSession,
   }
 }
 
@@ -47,14 +56,18 @@ export async function requireRole(
   })
 
   const rolesArray = Array.isArray(rolesRequeridos) ? rolesRequeridos : [rolesRequeridos]
-  const rolesUsuario = Array.isArray(roles)
-    ? (roles as any[]).map(r => typeof r === "string" ? r : r?.nombre_interno).filter(Boolean)
-    : []
+  const rolesUsuario = normalizeLegacyRoles(roles)
 
   const tieneRol = rolesUsuario.some(r => rolesArray.includes(r))
   if (!tieneRol) {
     throw new Error(`Permiso denegado: se requiere rol ${rolesArray.join(" o ")}`)
   }
 
-  return { authId: user.id, email: user.email }
+  const platformSession = await resolveReadOnlyPlatformSession({
+    subjectAuthId: user.id,
+    findPersonaByAuthId: (authId) => findPlatformSessionPersonaByAuthId(supabase, authId),
+    globalRoles: rolesUsuario,
+  })
+
+  return { authId: user.id, email: user.email, platformSession }
 }

--- a/lib/getUserWithRoles.ts
+++ b/lib/getUserWithRoles.ts
@@ -1,18 +1,35 @@
 
-import type { SupabaseClient } from "@supabase/supabase-js"
+import {
+  findPlatformSessionPersonaByAuthId,
+  normalizeLegacyRoles,
+  resolveReadOnlyPlatformSession,
+  toAuthBaseSupabaseClient,
+  type AuthBaseSupabaseClient,
+} from '@/lib/auth/platformSessionReadOnly'
+import type { PlatformSession } from '@/lib/platform/session/types'
+import type { SupabaseClient } from '@supabase/supabase-js'
 
-export async function getUserWithRoles(supabase: SupabaseClient) {
-  const { data: { user }, error: errorUser } = await supabase.auth.getUser();
+type UserWithRolesResult = {
+  user: { id: string; email?: string }
+  roles: string[]
+  platformSession: PlatformSession | null
+}
+
+export function getUserWithRoles(supabase: SupabaseClient): Promise<UserWithRolesResult | null>
+export function getUserWithRoles(supabase: AuthBaseSupabaseClient): Promise<UserWithRolesResult | null>
+export async function getUserWithRoles(supabase: SupabaseClient | AuthBaseSupabaseClient): Promise<UserWithRolesResult | null> {
+  const authBaseSupabase = toAuthBaseSupabaseClient(supabase)
+  const { data: { user }, error: errorUser } = await authBaseSupabase.auth.getUser();
   if (errorUser || !user) return null;
 
   // Usa la instancia recibida para la función RPC
-  const { data: rolesData, error: errorRoles } = await supabase.rpc("obtener_roles_usuario", { p_auth_id: user.id });
-  if (errorRoles || !rolesData) return { user, roles: [] };
+  const { data: rolesData, error: errorRoles } = await authBaseSupabase.rpc("obtener_roles_usuario", { p_auth_id: user.id });
+  const roles = errorRoles || !rolesData ? [] : normalizeLegacyRoles(rolesData)
+  const platformSession = await resolveReadOnlyPlatformSession({
+    subjectAuthId: user.id,
+    findPersonaByAuthId: (authId) => findPlatformSessionPersonaByAuthId(authBaseSupabase, authId),
+    globalRoles: roles,
+  })
 
-  // rolesData puede ser array de strings o de objetos
-  const roles = Array.isArray(rolesData)
-    ? rolesData.map(r => typeof r === "string" ? r : r.nombre_interno).filter(Boolean)
-    : [];
-
-  return { user, roles };
+  return { user, roles, platformSession };
 }

--- a/openspec/changes/fase-01-platform-foundation/tasks.md
+++ b/openspec/changes/fase-01-platform-foundation/tasks.md
@@ -44,7 +44,7 @@ Chain strategy: stacked-to-main para PR1a; confirmar por slice futuro
 ## Fase 3: Menú y dashboard
 
 - [ ] 3.1 Actualizar `lib/getUserWithRoles.ts`, `lib/auth/requireAuth.ts` y `hooks/useCurrentUser.ts` con `platformSession` read-only y fallback legado.
-  - Progreso PR #210: `lib/getUserWithRoles.ts` y `lib/auth/requireAuth.ts` exponen `platformSession` read-only con fallback legado; `hooks/useCurrentUser.ts` queda pendiente para un slice client/UI sin cambios visibles.
+  - Progreso PR #211 / issue #210: `lib/getUserWithRoles.ts` y `lib/auth/requireAuth.ts` exponen `platformSession` read-only con fallback legado; `hooks/useCurrentUser.ts` queda diferido y trazable para un slice client/UI posterior sin cambios visibles.
 - [ ] 3.2 Actualizar `lib/platform/navigation.ts`, `sidebar-moderna.tsx`, `header-movil.tsx`, `menu-inferior-movil.tsx` y dashboard con flag/kill switch.
 - [ ] 3.3 Verificar rutas directas denegadas, fallback legado si adapters fallan, y no mostrar DPS admin, NextGen, taller admin ni 1:1 global.
 

--- a/openspec/changes/fase-01-platform-foundation/tasks.md
+++ b/openspec/changes/fase-01-platform-foundation/tasks.md
@@ -44,6 +44,7 @@ Chain strategy: stacked-to-main para PR1a; confirmar por slice futuro
 ## Fase 3: Menú y dashboard
 
 - [ ] 3.1 Actualizar `lib/getUserWithRoles.ts`, `lib/auth/requireAuth.ts` y `hooks/useCurrentUser.ts` con `platformSession` read-only y fallback legado.
+  - Progreso PR #210: `lib/getUserWithRoles.ts` y `lib/auth/requireAuth.ts` exponen `platformSession` read-only con fallback legado; `hooks/useCurrentUser.ts` queda pendiente para un slice client/UI sin cambios visibles.
 - [ ] 3.2 Actualizar `lib/platform/navigation.ts`, `sidebar-moderna.tsx`, `header-movil.tsx`, `menu-inferior-movil.tsx` y dashboard con flag/kill switch.
 - [ ] 3.3 Verificar rutas directas denegadas, fallback legado si adapters fallan, y no mostrar DPS admin, NextGen, taller admin ni 1:1 global.
 


### PR DESCRIPTION
## PR Type
- [ ] Bug fix
- [x] New feature
- [ ] Documentation only
- [ ] Code refactoring
- [ ] Maintenance/tooling
- [ ] Breaking change

## Resumen
Closes #210

- Integra `platformSession` como capa read-only en `getUserWithRoles` y `requireAuth`.
- Mantiene permisos legacy como autoridad: roles RPC siguen decidiendo acceso y PlatformSession falla cerrado a `null`.
- Agrega cobertura determinística para fallback de roles RPC, fallback/null de `requireAuth` y ausencia de Persona vinculada.
- Deja `hooks/useCurrentUser.ts` para un próximo slice client/UI sin cambios visibles.

## Qué Incluye
- `lib/auth/platformSessionReadOnly.ts`: helper read-only para resolver Persona desde `auth_id`, normalizar roles legacy y construir PlatformSession con fallback seguro.
- `lib/getUserWithRoles.ts`: expone `platformSession` sin cambiar `roles` legacy.
- `lib/auth/requireAuth.ts`: expone `platformSession`; `requireRole` no autoriza por PlatformSession.
- `__tests__/lib/auth/platform-session-auth-base.test.ts`: cobertura Strict TDD de fallback legacy, fail-closed, no Persona vinculada y no escalación.
- `openspec/changes/fase-01-platform-foundation/tasks.md`: nota de progreso parcial para task 3.1 con trazabilidad PR #211 / issue #210.

## Motivación / Por Qué
Este slice habilita disponibilidad read-only de PlatformSession en la base de auth sin tocar navegación, dashboard, route auth, Grupos de Vida ni permisos legacy. Si la resolución de plataforma falla o no hay Persona vinculada, el contrato vuelve al comportamiento seguro anterior.

## Chain Context
- Strategy: `stacked-to-main` desde `main` actualizado.
- Prior dependencies: PR #204, PR #205, PR #207 y PR #209 ya mergeados.
- Current PR: PR #211 para issue #210, read-only auth/base integration.
- Deferred trace: `hooks/useCurrentUser.ts` queda para el siguiente slice client/UI si puede mantenerse sin cambios visibles.
- Next: client hook/UI/navigation/dashboard slices con feature flag y sin mezclar alcance.

```text
main
└── PR #211 📍 issue #210 platformSession auth/base read-only
    └── next: useCurrentUser/client + menu/dashboard guarded slices
```

Boundary:
- Starts from merged PR #209 on `main`.
- Ends with internal auth/base read-only exposure and tests.
- Out of scope: visible menu/dashboard/sidebar/header/mobile nav changes, route authorization changes, GDV flow changes, migrations, Supabase remote mutations.

## Evidencia Visual (si aplica)
No aplica; no hay cambios visibles de UI.

## Migraciones / Base de Datos
- [x] No aplica
- [ ] Sí (orden exacto):
```
N/A
```
Notas: no migrations, no remote Supabase, no data mutations.

## Impacto y Riesgos
- Compatibilidad: aditivo; callers pueden ignorar `platformSession`.
- Permisos: `requireRole` sigue usando solo roles legacy; PlatformSession no escala acceso.
- Fallback: lookup de plataforma falla cerrado a `null` y conserva auth/roles legacy; roles RPC fallida conserva lookup de plataforma con `roles = []`.
- Empty state: ausencia de Persona vinculada conserva auth legacy y devuelve `platformSession: null`.
- Performance: agrega una lectura de `usuarios` por auth/base helper; sin adapter GDV ni consultas de navegación.

## Checklist Autor
- [x] Código formateado (Prettier/ESLint)
- [x] Sin `console.log` / debugger
- [x] Validaciones con zod para entradas nuevas
- [x] Estados loading/error/empty cubiertos
- [x] Tipos TypeScript correctos
- [x] Migraciones probadas local
- [x] Documentación actualizada (`docs/` o README)
- [x] Variables de entorno documentadas
- [x] Rebase con `main` limpio

## Checklist Revisor
- [x] Propósito claro
- [x] Nombres descriptivos
- [x] Sin lógica duplicada evidente
- [x] Manejo adecuado de errores
- [x] Cambios acotados al alcance
- [x] Sin secretos / datos sensibles

## Pruebas Manuales Realizadas
- Safety net: `pnpm test -- __tests__/lib/auth/platform-session-auth-base.test.ts` — 1 suite / 5 tests passed.
- RED: `pnpm test -- __tests__/lib/auth/platform-session-auth-base.test.ts` — failed on missing no-Persona-row helper support before fixing test helper.
- Focused GREEN: `pnpm test -- __tests__/lib/auth/platform-session-auth-base.test.ts` — 1 suite / 8 tests passed.
- Relevant auth/platform: `pnpm test -- __tests__/lib/platform/session.test.ts __tests__/lib/platform/persona.test.ts __tests__/lib/platform/experiences.test.ts __tests__/lib/platform/grupos-vida-adapter.test.ts __tests__/lib/auth/platform-session-auth-base.test.ts __tests__/hooks/useCurrentUser.test.tsx` — 6 suites / 40 tests passed.
- `pnpm exec tsc --noEmit --pretty false` — passed.
- `pnpm test:ci` — 44 Jest suites / 429 Jest tests and 26 node tests passed.
- `git diff --check` and `git diff --cached --check` — passed.

## Pendientes / Follow-up (opcional)
- `hooks/useCurrentUser.ts` queda para el siguiente slice client/UI si puede mantenerse sin cambios visibles ni exposición de secretos.
- Navegación/dashboard contextual siguen fuera de este PR.

## Notas Adicionales
- Task 3.1 queda parcialmente avanzado, no marcado como completo en OpenSpec.
- Review budget: 306 additions + 15 deletions = 321 changed lines, under 400.