### PR TITLE
feat(auth): expone platformSession en useCurrentUser

### DIFF
--- a/__tests__/hooks/useCurrentUser.test.tsx
+++ b/__tests__/hooks/useCurrentUser.test.tsx
@@ -1,4 +1,4 @@
-import { renderHook, waitFor } from '@testing-library/react'
+import { act, renderHook, waitFor } from '@testing-library/react'
 
 import { useCurrentUser } from '@/hooks/useCurrentUser'
 
@@ -6,12 +6,30 @@ const createClient = jest.fn()
 
 jest.mock('@/lib/supabase/client', () => ({ createClient: () => createClient() }))
 
+type MockAuthUser = { id: string }
+type MockUsuario = { id: string; auth_id: string; nombre: string; telefono?: string }
+type AuthStateEvent = 'SIGNED_IN' | 'SIGNED_OUT'
+type CapturedAuthStateCallback = (event: AuthStateEvent, session: unknown | null) => void
+type SupabaseMockStep = {
+  user: MockAuthUser | null
+  usuario?: MockUsuario | null
+  roles?: unknown[]
+  supportCapabilities?: string[]
+}
+
+const DETERMINISTIC_NOW_MS = 1_700_000_000_000
+const HOOK_CACHE_TTL_MS = 15_000
+const CACHE_EXPIRY_ADVANCE_MS = HOOK_CACHE_TTL_MS + 5_000
+const AUTH_SESSION_PLACEHOLDER = { user: { id: 'auth-session-placeholder' } }
+let authStateCallback: CapturedAuthStateCallback | null = null
+
 describe('useCurrentUser', () => {
-  let mockNow = 1_700_000_000_000
+  let mockNow = DETERMINISTIC_NOW_MS
 
   beforeEach(() => {
-    mockNow += 20_000
+    mockNow += CACHE_EXPIRY_ADVANCE_MS
     jest.spyOn(Date, 'now').mockReturnValue(mockNow)
+    authStateCallback = null
     createClient.mockReset()
   })
 
@@ -22,30 +40,9 @@ describe('useCurrentUser', () => {
   it('loads support capabilities separately from role names', async () => {
     const user = { id: 'auth-1' }
     const usuario = { id: 'usuario-1', auth_id: 'auth-1', nombre: 'Staff User' }
-    const rolesRpc = jest.fn().mockResolvedValue({ data: ['admin'], error: null })
-    const supportCapabilitiesQuery = {
-      select: jest.fn().mockReturnThis(),
-      eq: jest.fn().mockReturnThis(),
-      is: jest.fn().mockResolvedValue({ data: [{ capability: 'support.view' }, { capability: 'support.reply' }], error: null }),
-    }
-    const usuariosQuery = {
-      select: jest.fn().mockReturnThis(),
-      eq: jest.fn().mockReturnThis(),
-      maybeSingle: jest.fn().mockResolvedValue({ data: usuario, error: null }),
-    }
-    const client = {
-      auth: {
-        getUser: jest.fn().mockResolvedValue({ data: { user }, error: null }),
-        onAuthStateChange: jest.fn().mockReturnValue({ data: { subscription: { unsubscribe: jest.fn() } } }),
-      },
-      from: jest.fn((table: string) => {
-        if (table === 'usuarios') return usuariosQuery
-        if (table === 'support_user_capabilities') return supportCapabilitiesQuery
-        throw new Error(`Unexpected table ${table}`)
-      }),
-      rpc: rolesRpc,
-    }
-    createClient.mockReturnValue(client)
+    const { client, supportCapabilitiesQuery } = setupSupabaseClient([
+      { user, usuario, roles: ['admin'], supportCapabilities: ['support.view', 'support.reply'] },
+    ])
 
     const { result } = renderHook(() => useCurrentUser())
 
@@ -65,30 +62,9 @@ describe('useCurrentUser', () => {
       nombre: 'Staff User',
       telefono: '+5491111111111',
     }
-    const rolesRpc = jest.fn().mockResolvedValue({ data: [{ nombre_interno: 'admin' }], error: null })
-    const supportCapabilitiesQuery = {
-      select: jest.fn().mockReturnThis(),
-      eq: jest.fn().mockReturnThis(),
-      is: jest.fn().mockResolvedValue({ data: [{ capability: 'support.manage' }], error: null }),
-    }
-    const usuariosQuery = {
-      select: jest.fn().mockReturnThis(),
-      eq: jest.fn().mockReturnThis(),
-      maybeSingle: jest.fn().mockResolvedValue({ data: usuario, error: null }),
-    }
-    const client = {
-      auth: {
-        getUser: jest.fn().mockResolvedValue({ data: { user }, error: null }),
-        onAuthStateChange: jest.fn().mockReturnValue({ data: { subscription: { unsubscribe: jest.fn() } } }),
-      },
-      from: jest.fn((table: string) => {
-        if (table === 'usuarios') return usuariosQuery
-        if (table === 'support_user_capabilities') return supportCapabilitiesQuery
-        throw new Error(`Unexpected table ${table}`)
-      }),
-      rpc: rolesRpc,
-    }
-    createClient.mockReturnValue(client)
+    setupSupabaseClient([
+      { user, usuario, roles: [{ nombre_interno: 'admin' }], supportCapabilities: ['support.manage'] },
+    ])
 
     const { result } = renderHook(() => useCurrentUser())
 
@@ -113,24 +89,9 @@ describe('useCurrentUser', () => {
 
   it('fails closed to legacy data when no Persona row is linked', async () => {
     const user = { id: 'auth-missing-persona' }
-    const rolesRpc = jest.fn().mockResolvedValue({ data: ['lider'], error: null })
-    const usuariosQuery = {
-      select: jest.fn().mockReturnThis(),
-      eq: jest.fn().mockReturnThis(),
-      maybeSingle: jest.fn().mockResolvedValue({ data: null, error: null }),
-    }
-    const client = {
-      auth: {
-        getUser: jest.fn().mockResolvedValue({ data: { user }, error: null }),
-        onAuthStateChange: jest.fn().mockReturnValue({ data: { subscription: { unsubscribe: jest.fn() } } }),
-      },
-      from: jest.fn((table: string) => {
-        if (table === 'usuarios') return usuariosQuery
-        throw new Error(`Unexpected table ${table}`)
-      }),
-      rpc: rolesRpc,
-    }
-    createClient.mockReturnValue(client)
+    const { client } = setupSupabaseClient([
+      { user, usuario: null, roles: ['lider'] },
+    ])
 
     const { result } = renderHook(() => useCurrentUser())
 
@@ -141,4 +102,126 @@ describe('useCurrentUser', () => {
     expect(result.current.platformSession).toBeNull()
     expect(client.from).not.toHaveBeenCalledWith('support_user_capabilities')
   })
+
+  it('clears user and platformSession state on SIGNED_OUT', async () => {
+    const user = { id: 'auth-1' }
+    const usuario = { id: 'usuario-1', auth_id: 'auth-1', nombre: 'Staff User' }
+    const { triggerAuthStateChange } = setupSupabaseClient([
+      { user, usuario, roles: ['admin'], supportCapabilities: ['support.view'] },
+    ])
+
+    const { result } = renderHook(() => useCurrentUser())
+
+    await waitFor(() => expect(result.current.loading).toBe(false))
+    expect(result.current.usuario?.id).toBe('usuario-1')
+    expect(result.current.platformSession?.personaId).toBe('usuario-1')
+
+    await act(async () => {
+      triggerAuthStateChange('SIGNED_OUT', null)
+    })
+
+    expect(result.current.loading).toBe(false)
+    expect(result.current.usuario).toBeNull()
+    expect(result.current.roles).toEqual([])
+    expect(result.current.supportCapabilities).toEqual([])
+    expect(result.current.platformSession).toBeNull()
+  })
+
+  it('reloads platformSession for the signed-in user without stale Persona data', async () => {
+    const firstUser = { id: 'auth-1' }
+    const secondUser = { id: 'auth-2' }
+    const firstUsuario = { id: 'usuario-1', auth_id: 'auth-1', nombre: 'First User' }
+    const secondUsuario = { id: 'usuario-2', auth_id: 'auth-2', nombre: 'Second User' }
+    const { client, triggerAuthStateChange } = setupSupabaseClient([
+      { user: firstUser, usuario: firstUsuario, roles: ['admin'], supportCapabilities: ['support.view'] },
+      { user: secondUser, usuario: secondUsuario, roles: ['lider'], supportCapabilities: ['support.reply'] },
+    ])
+
+    const { result } = renderHook(() => useCurrentUser())
+
+    await waitFor(() => expect(result.current.platformSession?.personaId).toBe('usuario-1'))
+
+    await act(async () => {
+      triggerAuthStateChange('SIGNED_IN', AUTH_SESSION_PLACEHOLDER)
+    })
+
+    await waitFor(() => expect(result.current.platformSession?.personaId).toBe('usuario-2'))
+    expect(result.current.usuario?.id).toBe('usuario-2')
+    expect(result.current.roles).toEqual(['lider'])
+    expect(result.current.supportCapabilities).toEqual(['support.reply'])
+    expect(result.current.platformSession).toEqual({
+      personaId: 'usuario-2',
+      subjectAuthId: 'auth-2',
+      globalRoles: ['lider'],
+      contexts: [],
+      capabilities: [],
+    })
+    expect(result.current.platformSession?.subjectAuthId).not.toBe('auth-1')
+    expect(result.current.supportCapabilities).not.toContain('support.view')
+    expect(client.auth.getUser).toHaveBeenCalledTimes(2)
+  })
 })
+
+function setupSupabaseClient(steps: SupabaseMockStep[]) {
+  const getUser = jest.fn()
+  const maybeSingle = jest.fn()
+  const rolesRpc = jest.fn()
+  const supportCapabilitiesResolver = jest.fn()
+
+  for (const step of steps) {
+    getUser.mockResolvedValueOnce({ data: { user: step.user }, error: null })
+
+    if (!step.user) continue
+
+    maybeSingle.mockResolvedValueOnce({ data: step.usuario ?? null, error: null })
+    rolesRpc.mockResolvedValueOnce({ data: step.roles ?? [], error: null })
+
+    if (step.usuario?.id) {
+      supportCapabilitiesResolver.mockResolvedValueOnce({
+        data: supportCapabilityRows(step.supportCapabilities ?? []),
+        error: null,
+      })
+    }
+  }
+
+  const usuariosQuery = {
+    select: jest.fn().mockReturnThis(),
+    eq: jest.fn().mockReturnThis(),
+    maybeSingle,
+  }
+  const supportCapabilitiesQuery = {
+    select: jest.fn().mockReturnThis(),
+    eq: jest.fn().mockReturnThis(),
+    is: supportCapabilitiesResolver,
+  }
+  const client = {
+    auth: {
+      getUser,
+      onAuthStateChange: jest.fn((callback: CapturedAuthStateCallback) => {
+        authStateCallback = callback
+        return { data: { subscription: { unsubscribe: jest.fn() } } }
+      }),
+    },
+    from: jest.fn((table: string) => {
+      if (table === 'usuarios') return usuariosQuery
+      if (table === 'support_user_capabilities') return supportCapabilitiesQuery
+      throw new Error(`Unexpected table ${table}`)
+    }),
+    rpc: rolesRpc,
+  }
+  createClient.mockReturnValue(client)
+
+  return { client, usuariosQuery, supportCapabilitiesQuery, triggerAuthStateChange }
+}
+
+function triggerAuthStateChange(event: AuthStateEvent, session: unknown | null) {
+  if (!authStateCallback) {
+    throw new Error('Auth state change callback was not registered')
+  }
+
+  authStateCallback(event, session)
+}
+
+function supportCapabilityRows(capabilities: string[]) {
+  return capabilities.map((capability) => ({ capability }))
+}

--- a/__tests__/hooks/useCurrentUser.test.tsx
+++ b/__tests__/hooks/useCurrentUser.test.tsx
@@ -165,6 +165,41 @@ describe('useCurrentUser', () => {
     expect(result.current.platformSession).toBeNull()
   })
 
+  it('does not cache stale in-flight data for later mounts after SIGNED_OUT', async () => {
+    const pendingGetUser = createDeferred<GetUserResponse>()
+    const user = { id: 'auth-1' }
+    const usuario = { id: 'usuario-1', auth_id: 'auth-1', nombre: 'Staff User' }
+    const { client, triggerAuthStateChange } = setupSupabaseClient([
+      { user, usuario, roles: ['admin'], supportCapabilities: ['support.view'], getUserDeferred: pendingGetUser },
+      { user: null },
+    ])
+
+    const { unmount } = renderHook(() => useCurrentUser())
+
+    await act(async () => {
+      triggerAuthStateChange('SIGNED_OUT', null)
+    })
+
+    await act(async () => {
+      pendingGetUser.resolve(getUserResponse(user))
+      await flushPendingPromises()
+    })
+
+    await waitFor(() => expect(client.rpc).toHaveBeenCalledWith('obtener_roles_usuario', { p_auth_id: 'auth-1' }))
+    unmount()
+
+    const remounted = renderHook(() => useCurrentUser())
+
+    await waitFor(() => expect(remounted.result.current.loading).toBe(false))
+    expect(remounted.result.current.usuario).toBeNull()
+    expect(remounted.result.current.roles).toEqual([])
+    expect(remounted.result.current.supportCapabilities).toEqual([])
+    expect(remounted.result.current.platformSession).toBeNull()
+    expect(client.auth.getUser).toHaveBeenCalledTimes(2)
+
+    remounted.unmount()
+  })
+
   it('reloads platformSession for the signed-in user without stale Persona data', async () => {
     const firstUser = { id: 'auth-1' }
     const secondUser = { id: 'auth-2' }

--- a/__tests__/hooks/useCurrentUser.test.tsx
+++ b/__tests__/hooks/useCurrentUser.test.tsx
@@ -7,8 +7,16 @@ const createClient = jest.fn()
 jest.mock('@/lib/supabase/client', () => ({ createClient: () => createClient() }))
 
 describe('useCurrentUser', () => {
+  let mockNow = 1_700_000_000_000
+
   beforeEach(() => {
+    mockNow += 20_000
+    jest.spyOn(Date, 'now').mockReturnValue(mockNow)
     createClient.mockReset()
+  })
+
+  afterEach(() => {
+    jest.restoreAllMocks()
   })
 
   it('loads support capabilities separately from role names', async () => {
@@ -47,5 +55,90 @@ describe('useCurrentUser', () => {
     expect(client.from).toHaveBeenCalledWith('support_user_capabilities')
     expect(supportCapabilitiesQuery.eq).toHaveBeenCalledWith('usuario_id', 'usuario-1')
     expect(supportCapabilitiesQuery.is).toHaveBeenCalledWith('revoked_at', null)
+  })
+
+  it('exposes a client-safe read-only platformSession for a linked user', async () => {
+    const user = { id: 'auth-1' }
+    const usuario = {
+      id: 'usuario-1',
+      auth_id: 'auth-1',
+      nombre: 'Staff User',
+      telefono: '+5491111111111',
+    }
+    const rolesRpc = jest.fn().mockResolvedValue({ data: [{ nombre_interno: 'admin' }], error: null })
+    const supportCapabilitiesQuery = {
+      select: jest.fn().mockReturnThis(),
+      eq: jest.fn().mockReturnThis(),
+      is: jest.fn().mockResolvedValue({ data: [{ capability: 'support.manage' }], error: null }),
+    }
+    const usuariosQuery = {
+      select: jest.fn().mockReturnThis(),
+      eq: jest.fn().mockReturnThis(),
+      maybeSingle: jest.fn().mockResolvedValue({ data: usuario, error: null }),
+    }
+    const client = {
+      auth: {
+        getUser: jest.fn().mockResolvedValue({ data: { user }, error: null }),
+        onAuthStateChange: jest.fn().mockReturnValue({ data: { subscription: { unsubscribe: jest.fn() } } }),
+      },
+      from: jest.fn((table: string) => {
+        if (table === 'usuarios') return usuariosQuery
+        if (table === 'support_user_capabilities') return supportCapabilitiesQuery
+        throw new Error(`Unexpected table ${table}`)
+      }),
+      rpc: rolesRpc,
+    }
+    createClient.mockReturnValue(client)
+
+    const { result } = renderHook(() => useCurrentUser())
+
+    await waitFor(() => expect(result.current.loading).toBe(false))
+    expect(result.current.roles).toEqual(['admin'])
+    expect(result.current.supportCapabilities).toEqual(['support.manage'])
+    expect(result.current.platformSession).toEqual({
+      personaId: 'usuario-1',
+      subjectAuthId: 'auth-1',
+      globalRoles: ['admin'],
+      contexts: [],
+      capabilities: [],
+    })
+    expect(Object.keys(result.current.platformSession ?? {}).sort()).toEqual([
+      'capabilities',
+      'contexts',
+      'globalRoles',
+      'personaId',
+      'subjectAuthId',
+    ])
+  })
+
+  it('fails closed to legacy data when no Persona row is linked', async () => {
+    const user = { id: 'auth-missing-persona' }
+    const rolesRpc = jest.fn().mockResolvedValue({ data: ['lider'], error: null })
+    const usuariosQuery = {
+      select: jest.fn().mockReturnThis(),
+      eq: jest.fn().mockReturnThis(),
+      maybeSingle: jest.fn().mockResolvedValue({ data: null, error: null }),
+    }
+    const client = {
+      auth: {
+        getUser: jest.fn().mockResolvedValue({ data: { user }, error: null }),
+        onAuthStateChange: jest.fn().mockReturnValue({ data: { subscription: { unsubscribe: jest.fn() } } }),
+      },
+      from: jest.fn((table: string) => {
+        if (table === 'usuarios') return usuariosQuery
+        throw new Error(`Unexpected table ${table}`)
+      }),
+      rpc: rolesRpc,
+    }
+    createClient.mockReturnValue(client)
+
+    const { result } = renderHook(() => useCurrentUser())
+
+    await waitFor(() => expect(result.current.loading).toBe(false))
+    expect(result.current.usuario).toBeNull()
+    expect(result.current.roles).toEqual(['lider'])
+    expect(result.current.supportCapabilities).toEqual([])
+    expect(result.current.platformSession).toBeNull()
+    expect(client.from).not.toHaveBeenCalledWith('support_user_capabilities')
   })
 })

--- a/__tests__/hooks/useCurrentUser.test.tsx
+++ b/__tests__/hooks/useCurrentUser.test.tsx
@@ -71,8 +71,6 @@ describe('useCurrentUser', () => {
     const { result } = renderHook(() => useCurrentUser())
 
     await waitFor(() => expect(result.current.loading).toBe(false))
-    expect(result.current.roles).toEqual(['admin'])
-    expect(result.current.supportCapabilities).toEqual(['support.manage'])
     expect(result.current.platformSession).toEqual({
       personaId: 'usuario-1',
       subjectAuthId: 'auth-1',
@@ -215,8 +213,6 @@ describe('useCurrentUser', () => {
       contexts: [],
       capabilities: [],
     })
-    expect(result.current.platformSession?.subjectAuthId).not.toBe('auth-1')
-    expect(result.current.supportCapabilities).not.toContain('support.view')
     expect(client.auth.getUser).toHaveBeenCalledTimes(4)
   })
 

--- a/__tests__/hooks/useCurrentUser.test.tsx
+++ b/__tests__/hooks/useCurrentUser.test.tsx
@@ -10,11 +10,17 @@ type MockAuthUser = { id: string }
 type MockUsuario = { id: string; auth_id: string; nombre: string; telefono?: string }
 type AuthStateEvent = 'SIGNED_IN' | 'SIGNED_OUT'
 type CapturedAuthStateCallback = (event: AuthStateEvent, session: unknown | null) => void
+type GetUserResponse = { data: { user: MockAuthUser | null }; error: null }
+type Deferred<T> = {
+  promise: Promise<T>
+  resolve: (value: T) => void
+}
 type SupabaseMockStep = {
   user: MockAuthUser | null
   usuario?: MockUsuario | null
   roles?: unknown[]
   supportCapabilities?: string[]
+  getUserDeferred?: Deferred<GetUserResponse>
 }
 
 const DETERMINISTIC_NOW_MS = 1_700_000_000_000
@@ -127,6 +133,38 @@ describe('useCurrentUser', () => {
     expect(result.current.platformSession).toBeNull()
   })
 
+  it('keeps user and platformSession cleared when SIGNED_OUT happens while a fetch is pending', async () => {
+    const pendingGetUser = createDeferred<GetUserResponse>()
+    const user = { id: 'auth-1' }
+    const usuario = { id: 'usuario-1', auth_id: 'auth-1', nombre: 'Staff User' }
+    const { client, triggerAuthStateChange } = setupSupabaseClient([
+      { user, usuario, roles: ['admin'], supportCapabilities: ['support.view'], getUserDeferred: pendingGetUser },
+    ])
+
+    const { result } = renderHook(() => useCurrentUser())
+
+    await act(async () => {
+      triggerAuthStateChange('SIGNED_OUT', null)
+    })
+
+    expect(result.current.loading).toBe(false)
+    expect(result.current.usuario).toBeNull()
+    expect(result.current.roles).toEqual([])
+    expect(result.current.supportCapabilities).toEqual([])
+    expect(result.current.platformSession).toBeNull()
+
+    await act(async () => {
+      pendingGetUser.resolve(getUserResponse(user))
+      await flushPendingPromises()
+    })
+
+    await waitFor(() => expect(client.rpc).toHaveBeenCalledWith('obtener_roles_usuario', { p_auth_id: 'auth-1' }))
+    expect(result.current.usuario).toBeNull()
+    expect(result.current.roles).toEqual([])
+    expect(result.current.supportCapabilities).toEqual([])
+    expect(result.current.platformSession).toBeNull()
+  })
+
   it('reloads platformSession for the signed-in user without stale Persona data', async () => {
     const firstUser = { id: 'auth-1' }
     const secondUser = { id: 'auth-2' }
@@ -160,6 +198,7 @@ describe('useCurrentUser', () => {
     expect(result.current.supportCapabilities).not.toContain('support.view')
     expect(client.auth.getUser).toHaveBeenCalledTimes(2)
   })
+
 })
 
 function setupSupabaseClient(steps: SupabaseMockStep[]) {
@@ -169,7 +208,11 @@ function setupSupabaseClient(steps: SupabaseMockStep[]) {
   const supportCapabilitiesResolver = jest.fn()
 
   for (const step of steps) {
-    getUser.mockResolvedValueOnce({ data: { user: step.user }, error: null })
+    if (step.getUserDeferred) {
+      getUser.mockReturnValueOnce(step.getUserDeferred.promise)
+    } else {
+      getUser.mockResolvedValueOnce(getUserResponse(step.user))
+    }
 
     if (!step.user) continue
 
@@ -224,4 +267,22 @@ function triggerAuthStateChange(event: AuthStateEvent, session: unknown | null) 
 
 function supportCapabilityRows(capabilities: string[]) {
   return capabilities.map((capability) => ({ capability }))
+}
+
+function getUserResponse(user: MockAuthUser | null): GetUserResponse {
+  return { data: { user }, error: null }
+}
+
+function createDeferred<T>(): Deferred<T> {
+  let resolve!: Deferred<T>['resolve']
+  const promise = new Promise<T>((promiseResolve) => {
+    resolve = promiseResolve
+  })
+  return { promise, resolve }
+}
+
+async function flushPendingPromises() {
+  for (let cycle = 0; cycle < 10; cycle += 1) {
+    await Promise.resolve()
+  }
 }

--- a/__tests__/hooks/useCurrentUser.test.tsx
+++ b/__tests__/hooks/useCurrentUser.test.tsx
@@ -17,6 +17,7 @@ type Deferred<T> = {
 }
 type SupabaseMockStep = {
   user: MockAuthUser | null
+  cacheAuthUser?: MockAuthUser | null
   usuario?: MockUsuario | null
   roles?: unknown[]
   supportCapabilities?: string[]
@@ -62,12 +63,7 @@ describe('useCurrentUser', () => {
 
   it('exposes a client-safe read-only platformSession for a linked user', async () => {
     const user = { id: 'auth-1' }
-    const usuario = {
-      id: 'usuario-1',
-      auth_id: 'auth-1',
-      nombre: 'Staff User',
-      telefono: '+5491111111111',
-    }
+    const usuario = { id: 'usuario-1', auth_id: 'auth-1', nombre: 'Staff User' }
     setupSupabaseClient([
       { user, usuario, roles: [{ nombre_interno: 'admin' }], supportCapabilities: ['support.manage'] },
     ])
@@ -84,13 +80,6 @@ describe('useCurrentUser', () => {
       contexts: [],
       capabilities: [],
     })
-    expect(Object.keys(result.current.platformSession ?? {}).sort()).toEqual([
-      'capabilities',
-      'contexts',
-      'globalRoles',
-      'personaId',
-      'subjectAuthId',
-    ])
   })
 
   it('fails closed to legacy data when no Persona row is linked', async () => {
@@ -165,20 +154,17 @@ describe('useCurrentUser', () => {
     expect(result.current.platformSession).toBeNull()
   })
 
-  it('does not cache stale in-flight data for later mounts after SIGNED_OUT', async () => {
+  it('does not cache stale in-flight data after unmount and auth change', async () => {
     const pendingGetUser = createDeferred<GetUserResponse>()
     const user = { id: 'auth-1' }
     const usuario = { id: 'usuario-1', auth_id: 'auth-1', nombre: 'Staff User' }
-    const { client, triggerAuthStateChange } = setupSupabaseClient([
-      { user, usuario, roles: ['admin'], supportCapabilities: ['support.view'], getUserDeferred: pendingGetUser },
+    const { client } = setupSupabaseClient([
+      { user, cacheAuthUser: null, usuario, roles: ['admin'], supportCapabilities: ['support.view'], getUserDeferred: pendingGetUser },
       { user: null },
     ])
 
     const { unmount } = renderHook(() => useCurrentUser())
-
-    await act(async () => {
-      triggerAuthStateChange('SIGNED_OUT', null)
-    })
+    unmount()
 
     await act(async () => {
       pendingGetUser.resolve(getUserResponse(user))
@@ -195,7 +181,7 @@ describe('useCurrentUser', () => {
     expect(remounted.result.current.roles).toEqual([])
     expect(remounted.result.current.supportCapabilities).toEqual([])
     expect(remounted.result.current.platformSession).toBeNull()
-    expect(client.auth.getUser).toHaveBeenCalledTimes(2)
+    expect(client.auth.getUser).toHaveBeenCalledTimes(4)
 
     remounted.unmount()
   })
@@ -231,7 +217,7 @@ describe('useCurrentUser', () => {
     })
     expect(result.current.platformSession?.subjectAuthId).not.toBe('auth-1')
     expect(result.current.supportCapabilities).not.toContain('support.view')
-    expect(client.auth.getUser).toHaveBeenCalledTimes(2)
+    expect(client.auth.getUser).toHaveBeenCalledTimes(4)
   })
 
 })
@@ -248,6 +234,8 @@ function setupSupabaseClient(steps: SupabaseMockStep[]) {
     } else {
       getUser.mockResolvedValueOnce(getUserResponse(step.user))
     }
+    const cacheAuthUser = 'cacheAuthUser' in step ? step.cacheAuthUser ?? null : step.user
+    getUser.mockResolvedValueOnce(getUserResponse(cacheAuthUser))
 
     if (!step.user) continue
 

--- a/hooks/useCurrentUser.ts
+++ b/hooks/useCurrentUser.ts
@@ -21,43 +21,33 @@ interface CurrentUserData {
 const SUPPORT_CAPABILITIES = ['support.view', 'support.reply', 'support.manage'] as const
 type SupportCapability = (typeof SUPPORT_CAPABILITIES)[number]
 type CurrentUserResult = Omit<CurrentUserData, 'loading' | 'error'>
+  & { authUserId: string | null }
 
 const CURRENT_USER_CACHE_TTL_MS = 15_000
-let currentUserCache: { expiresAt: number; value: CurrentUserResult } | null = null
-let currentUserRequest: Promise<CurrentUserResult> | null = null
+let currentUserCache: { authUserId: string | null; expiresAt: number; value: CurrentUserResult } | null = null
 let currentUserCacheGeneration = 0
 
 function clearCurrentUserCache() {
   currentUserCacheGeneration += 1
   currentUserCache = null
-  currentUserRequest = null
 }
 
 async function fetchCurrentUserData(): Promise<CurrentUserResult> {
   const now = Date.now()
   if (currentUserCache && currentUserCache.expiresAt > now) {
-    return currentUserCache.value
-  }
-
-  if (currentUserRequest) {
-    return currentUserRequest
+    if (await isCurrentAuthUser(currentUserCache.authUserId)) return currentUserCache.value
+    clearCurrentUserCache()
   }
 
   const requestGeneration = currentUserCacheGeneration
-  currentUserRequest = loadCurrentUserData().then((value) => {
+  return loadCurrentUserData().then(async (value) => {
     if (requestGeneration === currentUserCacheGeneration) {
-      currentUserCache = { value, expiresAt: Date.now() + CURRENT_USER_CACHE_TTL_MS }
-      currentUserRequest = null
+      if (await isCurrentAuthUser(value.authUserId)) {
+        currentUserCache = { authUserId: value.authUserId, value, expiresAt: Date.now() + CURRENT_USER_CACHE_TTL_MS }
+      }
     }
     return value
-  }).catch((error: unknown) => {
-    if (requestGeneration === currentUserCacheGeneration) {
-      currentUserRequest = null
-    }
-    throw error
   })
-
-  return currentUserRequest
 }
 
 async function loadCurrentUserData(): Promise<CurrentUserResult> {
@@ -70,7 +60,7 @@ async function loadCurrentUserData(): Promise<CurrentUserResult> {
   }
 
   if (!user) {
-    return { usuario: null, roles: [], supportCapabilities: [], platformSession: null }
+    return { authUserId: null, usuario: null, roles: [], supportCapabilities: [], platformSession: null }
   }
 
   const { data: userData, error: userError } = await supabase
@@ -111,7 +101,12 @@ async function loadCurrentUserData(): Promise<CurrentUserResult> {
     globalRoles: roles,
   })
 
-  return { usuario: userData, roles, supportCapabilities, platformSession }
+  return { authUserId: user.id, usuario: userData, roles, supportCapabilities, platformSession }
+}
+
+async function isCurrentAuthUser(authUserId: string | null): Promise<boolean> {
+  const { data, error } = await createClient().auth.getUser()
+  return !error && (data.user?.id ?? null) === authUserId
 }
 
 export function useCurrentUser(): CurrentUserData {

--- a/hooks/useCurrentUser.ts
+++ b/hooks/useCurrentUser.ts
@@ -2,7 +2,9 @@
 
 import { useState, useEffect } from 'react'
 import { createClient } from '@/lib/supabase/client'
+import { buildPlatformSession } from '@/lib/platform/session/build'
 import type { Database } from '@/lib/supabase/database.types'
+import type { PlatformSession, PlatformSessionPersona } from '@/lib/platform/session/types'
 import type { AuthChangeEvent, Session } from '@supabase/supabase-js'
 
 type Usuario = Database['public']['Tables']['usuarios']['Row']
@@ -11,6 +13,7 @@ interface CurrentUserData {
   usuario: Usuario | null
   roles: string[]
   supportCapabilities: string[]
+  platformSession: PlatformSession | null
   loading: boolean
   error: string | null
 }
@@ -60,7 +63,7 @@ async function loadCurrentUserData(): Promise<CurrentUserResult> {
   }
 
   if (!user) {
-    return { usuario: null, roles: [], supportCapabilities: [] }
+    return { usuario: null, roles: [], supportCapabilities: [], platformSession: null }
   }
 
   const { data: userData, error: userError } = await supabase
@@ -95,13 +98,20 @@ async function loadCurrentUserData(): Promise<CurrentUserResult> {
     }
   }
 
-  return { usuario: userData, roles, supportCapabilities }
+  const platformSession = await resolveClientPlatformSession({
+    subjectAuthId: user.id,
+    usuario: userData,
+    globalRoles: roles,
+  })
+
+  return { usuario: userData, roles, supportCapabilities, platformSession }
 }
 
 export function useCurrentUser(): CurrentUserData {
   const [usuario, setUsuario] = useState<Usuario | null>(null)
   const [roles, setRoles] = useState<string[]>([])
   const [supportCapabilities, setSupportCapabilities] = useState<string[]>([])
+  const [platformSession, setPlatformSession] = useState<PlatformSession | null>(null)
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState<string | null>(null)
 
@@ -116,12 +126,14 @@ export function useCurrentUser(): CurrentUserData {
         setUsuario(userData.usuario)
         setRoles(userData.roles)
         setSupportCapabilities(userData.supportCapabilities)
+        setPlatformSession(userData.platformSession)
       } catch (err) {
         console.error('Error en useCurrentUser:', err)
         setError(err instanceof Error ? err.message : 'Error desconocido')
         setUsuario(null)
         setRoles([])
         setSupportCapabilities([])
+        setPlatformSession(null)
       } finally {
         setLoading(false)
       }
@@ -137,6 +149,7 @@ export function useCurrentUser(): CurrentUserData {
         setUsuario(null)
         setRoles([])
         setSupportCapabilities([])
+        setPlatformSession(null)
         setLoading(false)
       } else if (event === 'SIGNED_IN' && session) {
         fetchCurrentUser()
@@ -148,7 +161,27 @@ export function useCurrentUser(): CurrentUserData {
     }
   }, [])
 
-  return { usuario, roles, supportCapabilities, loading, error }
+  return { usuario, roles, supportCapabilities, platformSession, loading, error }
+}
+
+async function resolveClientPlatformSession(input: {
+  subjectAuthId: string
+  usuario: Usuario | null
+  globalRoles: string[]
+}): Promise<PlatformSession | null> {
+  const result = await buildPlatformSession({
+    subjectAuthId: input.subjectAuthId,
+    personaLookup: {
+      findByAuthId: async (authId) => toClientPlatformPersona(input.usuario, authId),
+    },
+  })
+
+  return result.ok ? { ...result.session, globalRoles: [...input.globalRoles] } : null
+}
+
+function toClientPlatformPersona(usuario: Usuario | null, authId: string): PlatformSessionPersona | null {
+  if (!usuario?.id || usuario.auth_id !== authId) return null
+  return { id: usuario.id, authId: usuario.auth_id }
 }
 
 function getRoleName(role: unknown) {

--- a/hooks/useCurrentUser.ts
+++ b/hooks/useCurrentUser.ts
@@ -1,6 +1,6 @@
 "use client"
 
-import { useState, useEffect } from 'react'
+import { useState, useEffect, useRef } from 'react'
 import { createClient } from '@/lib/supabase/client'
 import { buildPlatformSession } from '@/lib/platform/session/build'
 import type { Database } from '@/lib/supabase/database.types'
@@ -114,20 +114,28 @@ export function useCurrentUser(): CurrentUserData {
   const [platformSession, setPlatformSession] = useState<PlatformSession | null>(null)
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState<string | null>(null)
+  const authGenerationRef = useRef(0)
 
   useEffect(() => {
     const fetchCurrentUser = async () => {
+      const authGeneration = authGenerationRef.current + 1
+      authGenerationRef.current = authGeneration
+
       try {
         setLoading(true)
         setError(null)
 
         const userData = await fetchCurrentUserData()
 
+        if (authGeneration !== authGenerationRef.current) return
+
         setUsuario(userData.usuario)
         setRoles(userData.roles)
         setSupportCapabilities(userData.supportCapabilities)
         setPlatformSession(userData.platformSession)
       } catch (err) {
+        if (authGeneration !== authGenerationRef.current) return
+
         console.error('Error en useCurrentUser:', err)
         setError(err instanceof Error ? err.message : 'Error desconocido')
         setUsuario(null)
@@ -135,6 +143,8 @@ export function useCurrentUser(): CurrentUserData {
         setSupportCapabilities([])
         setPlatformSession(null)
       } finally {
+        if (authGeneration !== authGenerationRef.current) return
+
         setLoading(false)
       }
     }
@@ -146,12 +156,14 @@ export function useCurrentUser(): CurrentUserData {
     const { data: { subscription } } = supabase.auth.onAuthStateChange((event: AuthChangeEvent, session: Session | null) => {
       clearCurrentUserCache()
       if (event === 'SIGNED_OUT') {
+        authGenerationRef.current += 1
         setUsuario(null)
         setRoles([])
         setSupportCapabilities([])
         setPlatformSession(null)
         setLoading(false)
       } else if (event === 'SIGNED_IN' && session) {
+        authGenerationRef.current += 1
         fetchCurrentUser()
       }
     })

--- a/hooks/useCurrentUser.ts
+++ b/hooks/useCurrentUser.ts
@@ -25,8 +25,10 @@ type CurrentUserResult = Omit<CurrentUserData, 'loading' | 'error'>
 const CURRENT_USER_CACHE_TTL_MS = 15_000
 let currentUserCache: { expiresAt: number; value: CurrentUserResult } | null = null
 let currentUserRequest: Promise<CurrentUserResult> | null = null
+let currentUserCacheGeneration = 0
 
 function clearCurrentUserCache() {
+  currentUserCacheGeneration += 1
   currentUserCache = null
   currentUserRequest = null
 }
@@ -41,12 +43,17 @@ async function fetchCurrentUserData(): Promise<CurrentUserResult> {
     return currentUserRequest
   }
 
+  const requestGeneration = currentUserCacheGeneration
   currentUserRequest = loadCurrentUserData().then((value) => {
-    currentUserCache = { value, expiresAt: Date.now() + CURRENT_USER_CACHE_TTL_MS }
-    currentUserRequest = null
+    if (requestGeneration === currentUserCacheGeneration) {
+      currentUserCache = { value, expiresAt: Date.now() + CURRENT_USER_CACHE_TTL_MS }
+      currentUserRequest = null
+    }
     return value
   }).catch((error: unknown) => {
-    currentUserRequest = null
+    if (requestGeneration === currentUserCacheGeneration) {
+      currentUserRequest = null
+    }
     throw error
   })
 

--- a/openspec/changes/fase-01-platform-foundation/tasks.md
+++ b/openspec/changes/fase-01-platform-foundation/tasks.md
@@ -43,8 +43,9 @@ Chain strategy: stacked-to-main para PR1a; confirmar por slice futuro
 
 ## Fase 3: Menú y dashboard
 
-- [ ] 3.1 Actualizar `lib/getUserWithRoles.ts`, `lib/auth/requireAuth.ts` y `hooks/useCurrentUser.ts` con `platformSession` read-only y fallback legado.
-  - Progreso PR #211 / issue #210: `lib/getUserWithRoles.ts` y `lib/auth/requireAuth.ts` exponen `platformSession` read-only con fallback legado; `hooks/useCurrentUser.ts` queda diferido y trazable para un slice client/UI posterior sin cambios visibles.
+- [x] 3.1 Actualizar `lib/getUserWithRoles.ts`, `lib/auth/requireAuth.ts` y `hooks/useCurrentUser.ts` con `platformSession` read-only y fallback legado.
+  - PR #211 / issue #210: `lib/getUserWithRoles.ts` y `lib/auth/requireAuth.ts` exponen `platformSession` read-only con fallback legado.
+  - Issue #212: `hooks/useCurrentUser.ts` expone `platformSession` client-safe de solo lectura (`personaId`, `subjectAuthId`, roles legados y arrays vacíos de contextos/capabilities), conserva roles/capabilities legacy, falla cerrado a `null` si no hay Persona vinculada y no cambia navegación/dashboard visible.
 - [ ] 3.2 Actualizar `lib/platform/navigation.ts`, `sidebar-moderna.tsx`, `header-movil.tsx`, `menu-inferior-movil.tsx` y dashboard con flag/kill switch.
 - [ ] 3.3 Verificar rutas directas denegadas, fallback legado si adapters fallan, y no mostrar DPS admin, NextGen, taller admin ni 1:1 global.
 


### PR DESCRIPTION
Closes #212

## Resumen
Expone `platformSession` de solo lectura desde `hooks/useCurrentUser.ts` sin cambiar navegación, dashboard ni autorización legacy.

## Qué Incluye
- Tipo de PR: feature + reliability fixes del hook.
- Agrega `platformSession` client-safe al contrato del hook: `personaId`, `subjectAuthId`, roles legacy y arrays vacíos para `contexts`/`capabilities`.
- Mantiene `roles` y `supportCapabilities` como contrato legacy separado; no promueve permisos de soporte ni roles a capabilities de plataforma.
- Revalida la identidad Supabase Auth antes de usar o escribir caché del hook para que requests in-flight obsoletos no repueblen `usuario`, roles, `supportCapabilities` ni `platformSession` tras logout/auth-change sin listener montado.
- Marca la tarea OpenSpec 3.1 como completa porque PR #211 cubrió auth/base y este PR cubre el hook.

## Motivación / Por Qué
Completa el slice pendiente de la tarea 3.1 para que cliente pueda leer metadata mínima de PlatformSession sin cambios visibles ni exposición de capacidades servidor/backend-only.

## Evidencia Visual (si aplica)
No aplica: no hay cambios visibles de UI.

## Migraciones / Base de Datos
- [x] No aplica
- [ ] Sí (orden exacto):
```
N/A
```
Notas: no migrations, no remote Supabase, no data mutations.

## Impacto y Riesgos
- Compatibilidad: preserva el contrato legacy del hook y solo agrega una propiedad opcionalmente consumible.
- Seguridad: `platformSession.capabilities` y `contexts` permanecen vacíos en cliente; no se expone PII del row `usuarios` dentro de `platformSession`.
- Autorización: no cambia rutas, menús, dashboard, RPC/RLS ni flujos de Grupos de Vida/permisos.
- Fallback: sin Persona vinculada, `platformSession` falla cerrado a `null` y conserva roles legacy.
- Caché: entradas compartidas quedan ligadas a la identidad Auth actual; si la identidad cambió, se descarta caché y se fuerza relectura.

## Chain Context
- Strategy: `stacked-to-main` desde `main` actualizado.
- Previous dependency: PR #211 / issue #210 merged, auth/base exposes read-only `platformSession`.
- Current boundary: PR #213 / issue #212 only, `hooks/useCurrentUser.ts` client-safe/no-visible-change slice plus reliability review fixes.
- Out of scope: navigation/dashboard/sidebar/header/mobile nav, route authorization, DPS admin, NextGen, taller admin, 1:1 global, migrations, remote Supabase.

```text
main
└── PR #211 auth/base platformSession (merged)
    └── 📍 PR #213 / issue #212: useCurrentUser platformSession client-safe hook
        └── next: task 3.2 navigation/dashboard flag + kill switch
```

Review budget: 351 additions + 47 deletions = 398 changed lines, under 400 but near budget (2-line margin). Keep follow-up fixes/scope out of this PR unless split first.

## Checklist Autor
- [x] Código formateado (Prettier/ESLint)
- [x] Sin `console.log` / debugger
- [x] Validaciones con zod para entradas nuevas
- [x] Estados loading/error/empty cubiertos
- [x] Tipos TypeScript correctos
- [x] Migraciones probadas local
- [x] Documentación actualizada (`docs/` o README)
- [x] Variables de entorno documentadas
- [x] Rebase con `main` limpio

## Checklist Revisor
- [x] Propósito claro
- [x] Nombres descriptivos
- [x] Sin lógica duplicada evidente
- [x] Manejo adecuado de errores
- [x] Cambios acotados al alcance
- [x] Sin secretos / datos sensibles

## Pruebas Manuales Realizadas
- `pnpm test -- __tests__/hooks/useCurrentUser.test.tsx --runInBand`
- `pnpm test -- __tests__/hooks/useCurrentUser.test.tsx __tests__/lib/auth/platform-session-auth-base.test.ts __tests__/lib/platform/session.test.ts __tests__/lib/platform/grupos-vida-adapter.test.ts --runInBand`
- `npx tsc --noEmit`
- `pnpm test:ci`
- `git diff --check`

## Pendientes / Follow-up (opcional)
- Task 3.2: navigation/dashboard contextual integration behind flag/kill switch.
- Task 3.3: direct-route denial and hidden-entry verification.

## Notas Adicionales
No visible navigation/dashboard behavior changed in this PR.
