### PR TITLE
feat(platform): crear resolver de navegación contextual

### DIFF
--- a/__tests__/lib/platform/navigation.test.ts
+++ b/__tests__/lib/platform/navigation.test.ts
@@ -34,11 +34,16 @@ describe('Platform navigation resolver', () => {
   })
 
   it('uses legacy fallback and denies platform entries when the kill switch is enabled', async () => {
+    const adapter = jest.fn<ReturnType<PlatformNavigationAdapter>, Parameters<PlatformNavigationAdapter>>()
+      .mockRejectedValue(new Error('adapter must be skipped while kill switch is active'))
+
     const result = await resolvePlatformNavigation({
       flags: { enabled: true, killSwitch: true },
       platformSession: baseSession,
+      adapters: [adapter],
     })
 
+    expect(adapter).not.toHaveBeenCalled()
     expect(result).toMatchObject({
       mode: 'legacy_fallback',
       legacyFallback: true,
@@ -71,6 +76,18 @@ describe('Platform navigation resolver', () => {
       { id: 'grupos_vida_stage', label: 'Grupos de Vida — Adultos', href: '/dashboard/grupos-vida', experience: 'grupos_vida', scope: { type: 'etapa', id: 'segmento-adultos' } },
     ])
     expect(JSON.stringify(result)).not.toContain('auth-1')
+  })
+
+  it('denies known capability keys when the capability scope conflicts with its catalog definition', async () => {
+    const session: PlatformSession = {
+      ...baseSession,
+      capabilities: [{ key: 'dps.team.serve', experience: 'grupos_vida', scopeType: 'etapa', scopeId: 'adultos', source: 'wrong-scope' }],
+    }
+
+    const result = await resolvePlatformNavigation({ flags: { enabled: true }, platformSession: session })
+
+    expect(result.visibleItems).toEqual([])
+    expect(deniedReasons(result)).toMatchObject({ dps_team_service: 'conflicting_scope' })
   })
 
   it.each([

--- a/__tests__/lib/platform/navigation.test.ts
+++ b/__tests__/lib/platform/navigation.test.ts
@@ -1,0 +1,131 @@
+import {
+  PLATFORM_NAVIGATION_FLOW,
+  resolvePlatformNavigation,
+} from '@/lib/platform/navigation'
+import type { PlatformNavigationAdapter, PlatformNavigationResolution } from '@/lib/platform/navigation'
+import type { PlatformSession } from '@/lib/platform/session/types'
+
+const baseSession: PlatformSession = {
+  personaId: 'persona-1',
+  subjectAuthId: 'auth-1',
+  globalRoles: ['admin'],
+  contexts: [],
+  capabilities: [],
+}
+
+describe('Platform navigation resolver', () => {
+  it('uses legacy fallback and denies platform entries when the feature flag is off', async () => {
+    const adapter = jest.fn<ReturnType<PlatformNavigationAdapter>, Parameters<PlatformNavigationAdapter>>()
+
+    const result = await resolvePlatformNavigation({
+      flags: { enabled: false },
+      platformSession: baseSession,
+      adapters: [adapter],
+    })
+
+    expect(adapter).not.toHaveBeenCalled()
+    expect(result).toMatchObject({
+      mode: 'legacy_fallback',
+      legacyFallback: true,
+      visibleItems: [],
+      audit: { decision: 'denied', reason: 'feature_flag_disabled', flow: PLATFORM_NAVIGATION_FLOW },
+    })
+    expect(result.deniedItems.map((item) => item.id)).toContain('dps_admin')
+  })
+
+  it('uses legacy fallback and denies platform entries when the kill switch is enabled', async () => {
+    const result = await resolvePlatformNavigation({
+      flags: { enabled: true, killSwitch: true },
+      platformSession: baseSession,
+    })
+
+    expect(result).toMatchObject({
+      mode: 'legacy_fallback',
+      legacyFallback: true,
+      visibleItems: [],
+      audit: { decision: 'denied', reason: 'kill_switch_enabled' },
+    })
+  })
+
+  it('resolves scoped navigation from client-safe platformSession and adapter contributions', async () => {
+    const gdvAdapter: PlatformNavigationAdapter = jest.fn().mockResolvedValue({
+      ok: true,
+      contexts: [{ experience: 'grupos_vida', scopeType: 'etapa', scopeId: 'segmento-adultos', label: 'Grupos de Vida — Adultos' }],
+      capabilities: [{ key: 'grupos_vida.stage.read', experience: 'grupos_vida', scopeType: 'etapa', scopeId: 'segmento-adultos', source: 'gdv:director_etapa' }],
+    })
+    const session: PlatformSession = {
+      ...baseSession,
+      capabilities: [{ key: 'dps.team.serve', experience: 'dps', scopeType: 'equipo', scopeId: 'musica', source: 'dream-team' }],
+    }
+
+    const result = await resolvePlatformNavigation({
+      flags: { enabled: true },
+      platformSession: session,
+      adapters: [gdvAdapter],
+    })
+
+    expect(gdvAdapter).toHaveBeenCalledWith(baseSessionShape(session))
+    expect(result).toMatchObject({ mode: 'platform', legacyFallback: false, audit: { decision: 'allowed', flow: PLATFORM_NAVIGATION_FLOW } })
+    expect(result.visibleItems).toEqual([
+      { id: 'dps_team_service', label: 'DPS Música', href: '/dashboard/dps', experience: 'dps', scope: { type: 'equipo', id: 'musica' } },
+      { id: 'grupos_vida_stage', label: 'Grupos de Vida — Adultos', href: '/dashboard/grupos-vida', experience: 'grupos_vida', scope: { type: 'etapa', id: 'segmento-adultos' } },
+    ])
+    expect(JSON.stringify(result)).not.toContain('auth-1')
+  })
+
+  it.each([
+    ['missing platformSession', null, undefined, 'platform_session_required'],
+    ['adapter denied result', baseSession, jest.fn().mockResolvedValue({ ok: false, reason: 'adapter_read_failed' }), 'adapter_failed'],
+    ['adapter rejection', baseSession, jest.fn().mockRejectedValue(new Error('adapter timeout')), 'adapter_failed'],
+  ] satisfies Array<[string, PlatformSession | null, PlatformNavigationAdapter | undefined, string]>)('uses legacy fallback for %s', async (_label, platformSession, adapter, reason) => {
+    const result = await resolvePlatformNavigation({
+      flags: { enabled: true },
+      platformSession,
+      adapters: adapter ? [adapter] : [],
+    })
+
+    expect(result).toMatchObject({
+      mode: 'legacy_fallback',
+      legacyFallback: true,
+      visibleItems: [],
+      audit: { decision: 'denied', reason },
+    })
+    expect(result.deniedItems.every((item) => item.reason === reason)).toBe(true)
+  })
+
+  it('does not expose global access without explicit allowlisted scope', async () => {
+    const session: PlatformSession = {
+      ...baseSession,
+      capabilities: [
+        { key: 'dps.team.serve', experience: 'dps', scopeType: 'equipo', source: 'dream-team' },
+        { key: 'dps.admin.manage', experience: 'dps', scopeType: 'equipo', scopeId: 'musica', source: 'unsafe' },
+        { key: 'uno_a_uno.global.read', experience: 'the_living_room', scopeType: 'experience', source: 'unsafe' },
+      ],
+    }
+
+    const result = await resolvePlatformNavigation({ flags: { enabled: true }, platformSession: session })
+
+    expect(result.visibleItems).toEqual([])
+    expect(deniedReasons(result)).toMatchObject({
+      dps_team_service: 'grant_scope_missing',
+      dps_admin: 'unknown_capability',
+      nextgen_admin: 'unknown_capability',
+      talleres_admin: 'unknown_capability',
+      uno_a_uno_global: 'unknown_capability',
+    })
+  })
+})
+
+function deniedReasons(result: PlatformNavigationResolution): Record<string, string> {
+  return Object.fromEntries(result.deniedItems.map((item) => [item.id, item.reason]))
+}
+
+function baseSessionShape(session: PlatformSession) {
+  return {
+    personaId: session.personaId,
+    subjectAuthId: session.subjectAuthId,
+    globalRoles: session.globalRoles,
+    contexts: session.contexts,
+    capabilities: session.capabilities,
+  }
+}

--- a/lib/platform/navigation.ts
+++ b/lib/platform/navigation.ts
@@ -1,0 +1,205 @@
+import { resolvePlatformCapability } from '@/lib/platform/experiences'
+import type { PlatformCapabilityDeniedReason, PlatformCapabilityGrantInput, PlatformScopeInput } from '@/lib/platform/experiences'
+import type { PlatformSession, PlatformSessionCapability, PlatformSessionContext } from '@/lib/platform/session/types'
+
+export const PLATFORM_NAVIGATION_FLOW = 'navigation'
+
+export type PlatformNavigationSession = Pick<PlatformSession, 'personaId' | 'subjectAuthId' | 'globalRoles' | 'contexts' | 'capabilities'>
+export type PlatformNavigationFlags = { enabled: boolean; killSwitch?: boolean }
+export type PlatformNavigationAdapterResult =
+  | { ok: true; contexts?: readonly PlatformSessionContext[]; capabilities?: readonly PlatformSessionCapability[] }
+  | { ok: false; reason: string }
+export type PlatformNavigationAdapter = (session: PlatformNavigationSession) => Promise<PlatformNavigationAdapterResult>
+export type PlatformNavigationFallbackReason = 'feature_flag_disabled' | 'kill_switch_enabled' | 'platform_session_required' | 'adapter_failed'
+export type PlatformNavigationDeniedReason = PlatformNavigationFallbackReason | PlatformCapabilityDeniedReason
+export type PlatformNavigationItemId =
+  | 'grupos_vida_stage'
+  | 'dps_team_service'
+  | 'ninos_room_context'
+  | 'estudiantes_room_context'
+  | 'talleres_participation'
+  | 'dps_admin'
+  | 'nextgen_admin'
+  | 'talleres_admin'
+  | 'uno_a_uno_global'
+export type PlatformNavigationItem = {
+  id: PlatformNavigationItemId
+  label: string
+  href: string
+  experience: string
+  scope: { type: string; id?: string }
+}
+export type PlatformNavigationDeniedItem = { id: PlatformNavigationItemId; reason: PlatformNavigationDeniedReason }
+export type PlatformNavigationAudit = {
+  decision: 'allowed' | 'denied'
+  flow: typeof PLATFORM_NAVIGATION_FLOW
+  reason?: PlatformNavigationDeniedReason
+  visibleItemCount: number
+  deniedItemCount: number
+}
+export type PlatformNavigationResolution = {
+  mode: 'platform' | 'legacy_fallback'
+  legacyFallback: boolean
+  visibleItems: PlatformNavigationItem[]
+  deniedItems: PlatformNavigationDeniedItem[]
+  audit: PlatformNavigationAudit
+}
+export type PlatformNavigationResolverInput = {
+  flags: PlatformNavigationFlags
+  platformSession: PlatformNavigationSession | null | undefined
+  adapters?: readonly PlatformNavigationAdapter[]
+}
+
+type PlatformNavigationDefinition = {
+  id: PlatformNavigationItemId
+  capability: string
+  label: string
+  href: string
+  experience: string
+  fallbackScope: PlatformScopeInput
+}
+
+const PLATFORM_NAVIGATION_DEFINITIONS = [
+  { id: 'grupos_vida_stage', capability: 'grupos_vida.stage.read', label: 'Grupos de Vida', href: '/dashboard/grupos-vida', experience: 'grupos_vida', fallbackScope: { experience: 'grupos_vida', type: 'etapa', id: 'required' } },
+  { id: 'dps_team_service', capability: 'dps.team.serve', label: 'DPS', href: '/dashboard/dps', experience: 'dps', fallbackScope: { experience: 'dps', type: 'equipo', id: 'required' } },
+  { id: 'ninos_room_context', capability: 'ninos.room.read', label: 'Niños', href: '/dashboard/ninos', experience: 'ninos', fallbackScope: { experience: 'ninos', type: 'salon', id: 'required' } },
+  { id: 'estudiantes_room_context', capability: 'estudiantes.room.read', label: 'Estudiantes', href: '/dashboard/estudiantes', experience: 'estudiantes', fallbackScope: { experience: 'estudiantes', type: 'salon', id: 'required' } },
+  { id: 'talleres_participation', capability: 'talleres_crecimiento.participation.read', label: 'Talleres de Crecimiento', href: '/dashboard/talleres', experience: 'talleres_crecimiento', fallbackScope: { experience: 'talleres_crecimiento', type: 'taller', id: 'required' } },
+  { id: 'dps_admin', capability: 'dps.admin.manage', label: 'Administración DPS', href: '/dashboard/dps/admin', experience: 'dps', fallbackScope: { experience: 'dps', type: 'equipo', id: 'global' } },
+  { id: 'nextgen_admin', capability: 'nextgen.admin.manage', label: 'Administración NextGen', href: '/dashboard/nextgen/admin', experience: 'nextgen', fallbackScope: { experience: 'nextgen', type: 'experience' } },
+  { id: 'talleres_admin', capability: 'talleres_crecimiento.admin.manage', label: 'Administración Talleres', href: '/dashboard/talleres/admin', experience: 'talleres_crecimiento', fallbackScope: { experience: 'talleres_crecimiento', type: 'taller', id: 'global' } },
+  { id: 'uno_a_uno_global', capability: 'uno_a_uno.global.read', label: '1:1 Global', href: '/dashboard/uno-a-uno', experience: 'uno_a_uno', fallbackScope: { experience: 'the_living_room', type: 'experience' } },
+] satisfies readonly PlatformNavigationDefinition[]
+
+export async function resolvePlatformNavigation(input: PlatformNavigationResolverInput): Promise<PlatformNavigationResolution> {
+  if (!input.flags.enabled) return legacyFallback('feature_flag_disabled')
+  if (input.flags.killSwitch) return legacyFallback('kill_switch_enabled')
+  if (!input.platformSession?.personaId.trim() || !input.platformSession.subjectAuthId.trim()) return legacyFallback('platform_session_required')
+
+  const adapterState = await applyAdapters(input.platformSession, input.adapters ?? [])
+  if (!adapterState.ok) return legacyFallback('adapter_failed')
+
+  const visibleItems: PlatformNavigationItem[] = []
+  const deniedItems: PlatformNavigationDeniedItem[] = []
+  for (const definition of PLATFORM_NAVIGATION_DEFINITIONS) {
+    const resolved = resolveNavigationDefinition(definition, adapterState.session)
+    visibleItems.push(...resolved.visibleItems)
+    if (resolved.deniedItem) deniedItems.push(resolved.deniedItem)
+  }
+
+  visibleItems.sort((left, right) => left.id.localeCompare(right.id) || left.label.localeCompare(right.label))
+  return {
+    mode: 'platform',
+    legacyFallback: false,
+    visibleItems,
+    deniedItems,
+    audit: { decision: 'allowed', flow: PLATFORM_NAVIGATION_FLOW, visibleItemCount: visibleItems.length, deniedItemCount: deniedItems.length },
+  }
+}
+
+async function applyAdapters(session: PlatformNavigationSession, adapters: readonly PlatformNavigationAdapter[]) {
+  const merged: PlatformNavigationSession = toClientSafeSession(session)
+  for (const adapter of adapters) {
+    let result: PlatformNavigationAdapterResult
+    try {
+      result = await adapter(toClientSafeSession(session))
+    } catch {
+      return { ok: false } as const
+    }
+    if (!result.ok) return { ok: false } as const
+    merged.contexts = [...merged.contexts, ...(result.contexts ?? [])]
+    merged.capabilities = [...merged.capabilities, ...(result.capabilities ?? [])]
+  }
+  return { ok: true, session: merged } as const
+}
+
+function resolveNavigationDefinition(definition: PlatformNavigationDefinition, session: PlatformNavigationSession) {
+  const matchingCapabilities = session.capabilities.filter((capability) => capability.key === definition.capability)
+  if (matchingCapabilities.length === 0) {
+    return { visibleItems: [], deniedItem: denyByCapability(definition, session, definition.fallbackScope) }
+  }
+
+  const visibleItems: PlatformNavigationItem[] = []
+  let deniedItem: PlatformNavigationDeniedItem | undefined
+  for (const capability of matchingCapabilities) {
+    const missingScopedId = capability.scopeType !== 'experience' && !capability.scopeId?.trim()
+    const capabilityResult = missingScopedId
+      ? { ok: false, reason: 'grant_scope_missing' as const }
+      : resolvePlatformCapability({
+        actor: toCapabilityActor(session),
+        flow: PLATFORM_NAVIGATION_FLOW,
+        required: { key: definition.capability, scope: toScopeInput(capability) },
+      })
+
+    if (capabilityResult.ok) {
+      visibleItems.push(toNavigationItem(definition, capability, session.contexts))
+    } else {
+      deniedItem = { id: definition.id, reason: capabilityResult.reason }
+    }
+  }
+
+  return { visibleItems, deniedItem: visibleItems.length > 0 ? undefined : deniedItem }
+}
+
+function denyByCapability(definition: PlatformNavigationDefinition, session: PlatformNavigationSession, scope: PlatformScopeInput): PlatformNavigationDeniedItem {
+  const result = resolvePlatformCapability({
+    actor: toCapabilityActor(session),
+    flow: PLATFORM_NAVIGATION_FLOW,
+    required: { key: definition.capability, scope },
+  })
+  return { id: definition.id, reason: result.ok ? 'missing_required_capability' : result.reason }
+}
+
+function legacyFallback(reason: PlatformNavigationFallbackReason): PlatformNavigationResolution {
+  const deniedItems = PLATFORM_NAVIGATION_DEFINITIONS.map((definition) => ({ id: definition.id, reason }))
+  return {
+    mode: 'legacy_fallback',
+    legacyFallback: true,
+    visibleItems: [],
+    deniedItems,
+    audit: { decision: 'denied', flow: PLATFORM_NAVIGATION_FLOW, reason, visibleItemCount: 0, deniedItemCount: deniedItems.length },
+  }
+}
+
+function toCapabilityActor(session: PlatformNavigationSession) {
+  return {
+    personaId: session.personaId,
+    allowedFlows: [PLATFORM_NAVIGATION_FLOW],
+    grants: session.capabilities.map(toCapabilityGrant),
+  }
+}
+
+function toCapabilityGrant(capability: PlatformSessionCapability): PlatformCapabilityGrantInput {
+  return { key: capability.key, scope: toScopeInput(capability), source: capability.source }
+}
+
+function toScopeInput(capability: PlatformSessionCapability): PlatformScopeInput {
+  return { experience: capability.experience, type: capability.scopeType, id: capability.scopeId }
+}
+
+function toNavigationItem(definition: PlatformNavigationDefinition, capability: PlatformSessionCapability, contexts: readonly PlatformSessionContext[]): PlatformNavigationItem {
+  return {
+    id: definition.id,
+    label: resolveLabel(definition, capability, contexts),
+    href: definition.href,
+    experience: definition.experience,
+    scope: { type: capability.scopeType, ...(capability.scopeId ? { id: capability.scopeId } : {}) },
+  }
+}
+
+function resolveLabel(definition: PlatformNavigationDefinition, capability: PlatformSessionCapability, contexts: readonly PlatformSessionContext[]): string {
+  const context = contexts.find((item) => item.experience === capability.experience && item.scopeType === capability.scopeType && item.scopeId === capability.scopeId)
+  if (context?.label.trim()) return context.label
+  if (definition.id === 'dps_team_service' && capability.scopeId === 'musica') return 'DPS Música'
+  return capability.scopeId ? `${definition.label} — ${capability.scopeId}` : definition.label
+}
+
+function toClientSafeSession(session: PlatformNavigationSession): PlatformNavigationSession {
+  return {
+    personaId: session.personaId,
+    subjectAuthId: session.subjectAuthId,
+    globalRoles: [...session.globalRoles],
+    contexts: [...session.contexts],
+    capabilities: [...session.capabilities],
+  }
+}

--- a/lib/platform/navigation.ts
+++ b/lib/platform/navigation.ts
@@ -59,6 +59,17 @@ type PlatformNavigationDefinition = {
   fallbackScope: PlatformScopeInput
 }
 
+const ONE_ON_ONE_THE_LIVING_ROOM_NAVIGATION = {
+  itemId: 'uno_a_uno_global',
+  capability: 'uno_a_uno.global.read',
+  label: '1:1 Global',
+  experience: 'the_living_room',
+} as const
+
+const PLATFORM_NAVIGATION_SCOPE_LABELS: Partial<Record<PlatformNavigationItemId, Readonly<Record<string, string>>>> = {
+  dps_team_service: { musica: 'DPS Música' },
+}
+
 const PLATFORM_NAVIGATION_DEFINITIONS = [
   { id: 'grupos_vida_stage', capability: 'grupos_vida.stage.read', label: 'Grupos de Vida', href: '/dashboard/grupos-vida', experience: 'grupos_vida', fallbackScope: { experience: 'grupos_vida', type: 'etapa', id: 'required' } },
   { id: 'dps_team_service', capability: 'dps.team.serve', label: 'DPS', href: '/dashboard/dps', experience: 'dps', fallbackScope: { experience: 'dps', type: 'equipo', id: 'required' } },
@@ -68,7 +79,7 @@ const PLATFORM_NAVIGATION_DEFINITIONS = [
   { id: 'dps_admin', capability: 'dps.admin.manage', label: 'Administración DPS', href: '/dashboard/dps/admin', experience: 'dps', fallbackScope: { experience: 'dps', type: 'equipo', id: 'global' } },
   { id: 'nextgen_admin', capability: 'nextgen.admin.manage', label: 'Administración NextGen', href: '/dashboard/nextgen/admin', experience: 'nextgen', fallbackScope: { experience: 'nextgen', type: 'experience' } },
   { id: 'talleres_admin', capability: 'talleres_crecimiento.admin.manage', label: 'Administración Talleres', href: '/dashboard/talleres/admin', experience: 'talleres_crecimiento', fallbackScope: { experience: 'talleres_crecimiento', type: 'taller', id: 'global' } },
-  { id: 'uno_a_uno_global', capability: 'uno_a_uno.global.read', label: '1:1 Global', href: '/dashboard/uno-a-uno', experience: 'uno_a_uno', fallbackScope: { experience: 'the_living_room', type: 'experience' } },
+  { id: ONE_ON_ONE_THE_LIVING_ROOM_NAVIGATION.itemId, capability: ONE_ON_ONE_THE_LIVING_ROOM_NAVIGATION.capability, label: ONE_ON_ONE_THE_LIVING_ROOM_NAVIGATION.label, href: '/dashboard/uno-a-uno', experience: ONE_ON_ONE_THE_LIVING_ROOM_NAVIGATION.experience, fallbackScope: { experience: ONE_ON_ONE_THE_LIVING_ROOM_NAVIGATION.experience, type: 'experience' } },
 ] satisfies readonly PlatformNavigationDefinition[]
 
 export async function resolvePlatformNavigation(input: PlatformNavigationResolverInput): Promise<PlatformNavigationResolution> {
@@ -190,8 +201,14 @@ function toNavigationItem(definition: PlatformNavigationDefinition, capability: 
 function resolveLabel(definition: PlatformNavigationDefinition, capability: PlatformSessionCapability, contexts: readonly PlatformSessionContext[]): string {
   const context = contexts.find((item) => item.experience === capability.experience && item.scopeType === capability.scopeType && item.scopeId === capability.scopeId)
   if (context?.label.trim()) return context.label
-  if (definition.id === 'dps_team_service' && capability.scopeId === 'musica') return 'DPS Música'
+  const explicitScopeLabel = resolveExplicitScopeLabel(definition.id, capability.scopeId)
+  if (explicitScopeLabel) return explicitScopeLabel
   return capability.scopeId ? `${definition.label} — ${capability.scopeId}` : definition.label
+}
+
+function resolveExplicitScopeLabel(itemId: PlatformNavigationItemId, scopeId: string | undefined): string | undefined {
+  if (!scopeId) return undefined
+  return PLATFORM_NAVIGATION_SCOPE_LABELS[itemId]?.[scopeId]
 }
 
 function toClientSafeSession(session: PlatformNavigationSession): PlatformNavigationSession {

--- a/openspec/changes/fase-01-platform-foundation/tasks.md
+++ b/openspec/changes/fase-01-platform-foundation/tasks.md
@@ -47,6 +47,7 @@ Chain strategy: stacked-to-main para PR1a; confirmar por slice futuro
   - PR #211 / issue #210: `lib/getUserWithRoles.ts` y `lib/auth/requireAuth.ts` exponen `platformSession` read-only con fallback legado.
   - Issue #212: `hooks/useCurrentUser.ts` expone `platformSession` client-safe de solo lectura (`personaId`, `subjectAuthId`, roles legados y arrays vacíos de contextos/capabilities), conserva roles/capabilities legacy, falla cerrado a `null` si no hay Persona vinculada y no cambia navegación/dashboard visible.
 - [ ] 3.2 Actualizar `lib/platform/navigation.ts`, `sidebar-moderna.tsx`, `header-movil.tsx`, `menu-inferior-movil.tsx` y dashboard con flag/kill switch.
+  - Issue #214: primer slice interno crea `lib/platform/navigation.ts` con resolver/modelo puro, flag/kill switch, fallback legado deny-by-default y tests; sin wiring visible de sidebar/header/mobile/dashboard.
 - [ ] 3.3 Verificar rutas directas denegadas, fallback legado si adapters fallan, y no mostrar DPS admin, NextGen, taller admin ni 1:1 global.
 
 ## Fase 4: Familia y menores


### PR DESCRIPTION
## Resumen
- Closes #214
- PR #215 crea el primer slice interno del resolver de navegación contextual basado en `platformSession` read-only.
- Mantiene el alcance sin wiring visible de `sidebar-moderna.tsx`, `header-movil.tsx`, `menu-inferior-movil.tsx` ni dashboard.
- Agrega cobertura de revisión para kill switch, scopes conflictivos con capability conocida y claridad de naming/mapeos de dominio.

## Qué Incluye
- Modelo puro de navegación contextual con adapters inyectables.
- Flag, kill switch y fallback legado deny-by-default para capacidades nuevas.
- Denegación cuando `platformSession` falta, un adapter falla o una capability conocida trae scope de experiencia/tipo incompatible.
- Mapping explícito para 1:1 como navegación `uno_a_uno_global` sobre experiencia canónica `the_living_room`.
- Mapping explícito de label para el caso de negocio `dps_team_service` + scope `musica` → `DPS Música`.

## Motivación / Por Qué
Preparar la base interna de menú/dashboard contextual sin cambiar navegación visible ni permisos legacy. El servidor/RPC/RLS siguen siendo la autoridad para acceso directo.

## Chain Context
Estrategia: `stacked-to-main` desde `main` actualizado.

```text
main (PR #213 merged)
└── PR #215 feat/214-platform-navigation-resolver  [current]
    └── next slice: visible nav/dashboard wiring for task 3.2
```

Start: `main` después del merge de PR #213.
End: resolver/modelo interno, tests y fixes de review; sin cambios visuales, sin authz de rutas, sin Supabase remoto, sin migraciones.
Rollback: revertir este PR elimina solo el resolver interno, su test y la nota de progreso OpenSpec.

## Evidencia Visual
No aplica: no hay cambios visibles de UI.

## Migraciones / Base de Datos
No aplica: no se ejecutaron migraciones, Supabase remoto ni mutaciones de datos.

## Impacto y Riesgos
- Compatibilidad: aditivo; no cambia Grupos de Vida, asistencia, líderes, directores, permissions ni route authorization.
- Seguridad: no expone PII cruda en el resultado del resolver; `subjectAuthId` se usa solo como input read-only de sesión.
- Rollout: protegido por flag y kill switch; fallback legado deny-by-default para capacidades nuevas.
- Revisión: 371 líneas cambiadas, bajo el presupuesto de 400.

## Checklist Autor
- [x] Cambio acotado al resolver interno y tests.
- [x] Sin wiring visible de navegación/dashboard.
- [x] Sin cambios de route auth behavior.
- [x] Sin migraciones, Supabase remoto ni mutaciones de datos.
- [x] Type-check y suites requeridas ejecutadas localmente.
- [x] Presupuesto de review bajo 400 líneas.

## Checklist Revisor
- [ ] Propósito claro
- [ ] Nombres descriptivos
- [ ] Sin lógica duplicada evidente
- [ ] Manejo adecuado de errores
- [ ] Cambios acotados al alcance
- [ ] Sin secretos / datos sensibles

## Pruebas Locales Realizadas
- `pnpm test -- __tests__/lib/platform/navigation.test.ts --runInBand`
- `pnpm test -- __tests__/lib/platform/experiences.test.ts __tests__/lib/platform/grupos-vida-adapter.test.ts __tests__/lib/platform/session.test.ts --runInBand`
- `pnpm test -- __tests__/lib/platform/navigation.test.ts __tests__/lib/platform/experiences.test.ts __tests__/lib/platform/grupos-vida-adapter.test.ts __tests__/lib/platform/session.test.ts __tests__/lib/auth/platform-session-auth-base.test.ts __tests__/hooks/useCurrentUser.test.tsx --runInBand`
- `npx tsc --noEmit`
- `pnpm test:ci`
- `git diff --check`

## Pendientes / Follow-up
- Wirear componentes visibles (`sidebar-moderna.tsx`, `header-movil.tsx`, `menu-inferior-movil.tsx`) y dashboard en slices posteriores de task 3.2.
- Mantener task 3.2 abierta hasta completar wiring visible y verificación de rutas/denegaciones.

## Notas Adicionales
PR type: feature. Agregar exactamente la etiqueta `type:feature`.
