### PR TITLE
feat(platform): cablea navegación contextual en sidebar

### DIFF
--- a/__tests__/components/sidebar-platform-navigation.test.tsx
+++ b/__tests__/components/sidebar-platform-navigation.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from '@testing-library/react'
+import { render, screen, waitFor } from '@testing-library/react'
 
 import { SidebarModerna } from '@/components/ui/sidebar-moderna'
 import type { PlatformSession } from '@/lib/platform/session/types'
@@ -53,16 +53,38 @@ describe('SidebarModerna platform navigation', () => {
     expect(screen.queryByRole('link', { name: 'DPS Música' })).not.toBeInTheDocument()
   })
 
-  it('shows scoped platform navigation when the flag is on and scope is allowed', async () => {
+  it('shows scoped platform navigation when the flag is on and the route is available', async () => {
     process.env.NEXT_PUBLIC_PLATFORM_NAVIGATION_ENABLED = 'true'
     currentPlatformSession = withCapabilities([
-      { key: 'dps.team.serve', experience: 'dps', scopeType: 'equipo', scopeId: 'musica', source: 'dream-team' },
+      { key: 'grupos_vida.stage.read', experience: 'grupos_vida', scopeType: 'etapa', scopeId: 'adultos', source: 'gdv' },
+    ], [
+      { experience: 'grupos_vida', scopeType: 'etapa', scopeId: 'adultos', label: 'Grupos de Vida — Adultos' },
     ])
 
     render(<SidebarModerna />)
 
-    expect(await screen.findByRole('link', { name: 'DPS Música' })).toHaveAttribute('href', '/dashboard/dps')
+    expect(await screen.findByRole('link', { name: 'Grupos de Vida — Adultos' })).toHaveAttribute('href', '/grupos-vida')
     expect(screen.queryByRole('link', { name: 'Usuarios' })).not.toBeInTheDocument()
+  })
+
+  it('does not render platform links for dashboard child routes that do not exist', async () => {
+    process.env.NEXT_PUBLIC_PLATFORM_NAVIGATION_ENABLED = 'true'
+    currentPlatformSession = withCapabilities([
+      { key: 'grupos_vida.stage.read', experience: 'grupos_vida', scopeType: 'etapa', scopeId: 'adultos', source: 'gdv' },
+      { key: 'dps.team.serve', experience: 'dps', scopeType: 'equipo', scopeId: 'musica', source: 'dream-team' },
+      { key: 'ninos.room.read', experience: 'ninos', scopeType: 'salon', scopeId: 'waumbaland', source: 'family' },
+      { key: 'estudiantes.room.read', experience: 'estudiantes', scopeType: 'salon', scopeId: 'insideout', source: 'family' },
+      { key: 'talleres_crecimiento.participation.read', experience: 'talleres_crecimiento', scopeType: 'taller', scopeId: 'de-hombre-a-hombre', source: 'ledger' },
+    ], [
+      { experience: 'grupos_vida', scopeType: 'etapa', scopeId: 'adultos', label: 'Grupos de Vida — Adultos' },
+    ])
+
+    render(<SidebarModerna />)
+
+    expect(await screen.findByRole('link', { name: 'Grupos de Vida — Adultos' })).toHaveAttribute('href', '/grupos-vida')
+    await waitFor(() => expect(screen.queryByRole('link', { name: 'DPS Música' })).not.toBeInTheDocument())
+    const dashboardChildLinks = screen.getAllByRole('link').filter((link) => link.getAttribute('href')?.startsWith('/dashboard/'))
+    expect(dashboardChildLinks).toHaveLength(0)
   })
 
   it('keeps legacy sidebar behavior when the kill switch is active', () => {
@@ -82,16 +104,20 @@ describe('SidebarModerna platform navigation', () => {
   it('does not show global platform access without explicit allowed scope', async () => {
     process.env.NEXT_PUBLIC_PLATFORM_NAVIGATION_ENABLED = 'true'
     currentPlatformSession = withCapabilities([
+      { key: 'grupos_vida.stage.read', experience: 'grupos_vida', scopeType: 'etapa', scopeId: 'adultos', source: 'gdv' },
       { key: 'dps.team.serve', experience: 'dps', scopeType: 'equipo', scopeId: 'musica', source: 'dream-team' },
       { key: 'dps.admin.manage', experience: 'dps', scopeType: 'equipo', scopeId: 'musica', source: 'unsafe' },
       { key: 'nextgen.admin.manage', experience: 'nextgen', scopeType: 'experience', source: 'unsafe' },
       { key: 'talleres_crecimiento.admin.manage', experience: 'talleres_crecimiento', scopeType: 'taller', scopeId: 'global', source: 'unsafe' },
       { key: 'uno_a_uno.global.read', experience: 'the_living_room', scopeType: 'experience', source: 'unsafe' },
+    ], [
+      { experience: 'grupos_vida', scopeType: 'etapa', scopeId: 'adultos', label: 'Grupos de Vida — Adultos' },
     ])
 
     render(<SidebarModerna />)
 
-    expect(await screen.findByRole('link', { name: 'DPS Música' })).toHaveAttribute('href', '/dashboard/dps')
+    expect(await screen.findByRole('link', { name: 'Grupos de Vida — Adultos' })).toHaveAttribute('href', '/grupos-vida')
+    expect(screen.queryByRole('link', { name: 'DPS Música' })).not.toBeInTheDocument()
     expect(screen.queryByRole('link', { name: 'Administración DPS' })).not.toBeInTheDocument()
     expect(screen.queryByRole('link', { name: 'Administración NextGen' })).not.toBeInTheDocument()
     expect(screen.queryByRole('link', { name: 'Administración Talleres' })).not.toBeInTheDocument()
@@ -99,6 +125,6 @@ describe('SidebarModerna platform navigation', () => {
   })
 })
 
-function withCapabilities(capabilities: PlatformSession['capabilities']): PlatformSession {
-  return { ...basePlatformSession, capabilities }
+function withCapabilities(capabilities: PlatformSession['capabilities'], contexts: PlatformSession['contexts'] = []): PlatformSession {
+  return { ...basePlatformSession, contexts, capabilities }
 }

--- a/__tests__/components/sidebar-platform-navigation.test.tsx
+++ b/__tests__/components/sidebar-platform-navigation.test.tsx
@@ -1,0 +1,104 @@
+import { render, screen } from '@testing-library/react'
+
+import { SidebarModerna } from '@/components/ui/sidebar-moderna'
+import type { PlatformSession } from '@/lib/platform/session/types'
+
+let currentRoles = ['miembro']
+let currentPlatformSession: PlatformSession | null = null
+
+jest.mock('next/navigation', () => ({
+  usePathname: () => '/dashboard',
+  useRouter: () => ({ push: jest.fn() }),
+}))
+jest.mock('@/hooks/useCurrentUser', () => ({
+  useCurrentUser: () => ({
+    usuario: null,
+    roles: currentRoles,
+    supportCapabilities: [],
+    platformSession: currentPlatformSession,
+    loading: false,
+    error: null,
+  }),
+}))
+jest.mock('@/hooks/useBranding', () => ({ useBranding: () => ({ logoLightUrl: null, logoDarkUrl: null }) }))
+jest.mock('@/hooks/useCampus', () => ({ useCampus: () => ({ campusActivo: null, localidadActiva: null, campusDisponibles: [], localidadesDisponibles: [], campusId: null, localidadId: null, esSuperadmin: false, loading: false, seleccionarCampus: jest.fn(), seleccionarLocalidad: jest.fn() }) }))
+jest.mock('@/lib/actions/auth.actions', () => ({ logout: jest.fn() }))
+jest.mock('next-themes', () => ({ useTheme: () => ({ theme: 'light', setTheme: jest.fn() }) }))
+
+const basePlatformSession: PlatformSession = {
+  personaId: 'persona-1',
+  subjectAuthId: 'auth-1',
+  globalRoles: [],
+  contexts: [],
+  capabilities: [],
+}
+
+describe('SidebarModerna platform navigation', () => {
+  beforeEach(() => {
+    currentRoles = ['miembro']
+    currentPlatformSession = null
+    delete process.env.NEXT_PUBLIC_PLATFORM_NAVIGATION_ENABLED
+    delete process.env.NEXT_PUBLIC_PLATFORM_NAVIGATION_KILL_SWITCH
+  })
+
+  it('keeps legacy sidebar behavior when the platform navigation flag is off', () => {
+    currentRoles = ['admin']
+    currentPlatformSession = withCapabilities([
+      { key: 'dps.team.serve', experience: 'dps', scopeType: 'equipo', scopeId: 'musica', source: 'dream-team' },
+    ])
+
+    render(<SidebarModerna />)
+
+    expect(screen.getByRole('link', { name: 'Usuarios' })).toHaveAttribute('href', '/users')
+    expect(screen.queryByRole('link', { name: 'DPS Música' })).not.toBeInTheDocument()
+  })
+
+  it('shows scoped platform navigation when the flag is on and scope is allowed', async () => {
+    process.env.NEXT_PUBLIC_PLATFORM_NAVIGATION_ENABLED = 'true'
+    currentPlatformSession = withCapabilities([
+      { key: 'dps.team.serve', experience: 'dps', scopeType: 'equipo', scopeId: 'musica', source: 'dream-team' },
+    ])
+
+    render(<SidebarModerna />)
+
+    expect(await screen.findByRole('link', { name: 'DPS Música' })).toHaveAttribute('href', '/dashboard/dps')
+    expect(screen.queryByRole('link', { name: 'Usuarios' })).not.toBeInTheDocument()
+  })
+
+  it('keeps legacy sidebar behavior when the kill switch is active', () => {
+    process.env.NEXT_PUBLIC_PLATFORM_NAVIGATION_ENABLED = 'true'
+    process.env.NEXT_PUBLIC_PLATFORM_NAVIGATION_KILL_SWITCH = 'true'
+    currentRoles = ['admin']
+    currentPlatformSession = withCapabilities([
+      { key: 'dps.team.serve', experience: 'dps', scopeType: 'equipo', scopeId: 'musica', source: 'dream-team' },
+    ])
+
+    render(<SidebarModerna />)
+
+    expect(screen.getByRole('link', { name: 'Usuarios' })).toHaveAttribute('href', '/users')
+    expect(screen.queryByRole('link', { name: 'DPS Música' })).not.toBeInTheDocument()
+  })
+
+  it('does not show global platform access without explicit allowed scope', async () => {
+    process.env.NEXT_PUBLIC_PLATFORM_NAVIGATION_ENABLED = 'true'
+    currentPlatformSession = withCapabilities([
+      { key: 'dps.team.serve', experience: 'dps', scopeType: 'equipo', scopeId: 'musica', source: 'dream-team' },
+      { key: 'dps.admin.manage', experience: 'dps', scopeType: 'equipo', scopeId: 'musica', source: 'unsafe' },
+      { key: 'nextgen.admin.manage', experience: 'nextgen', scopeType: 'experience', source: 'unsafe' },
+      { key: 'talleres_crecimiento.admin.manage', experience: 'talleres_crecimiento', scopeType: 'taller', scopeId: 'global', source: 'unsafe' },
+      { key: 'uno_a_uno.global.read', experience: 'the_living_room', scopeType: 'experience', source: 'unsafe' },
+    ])
+
+    render(<SidebarModerna />)
+
+    expect(await screen.findByRole('link', { name: 'DPS Música' })).toHaveAttribute('href', '/dashboard/dps')
+    expect(screen.queryByRole('link', { name: 'Administración DPS' })).not.toBeInTheDocument()
+    expect(screen.queryByRole('link', { name: 'Administración NextGen' })).not.toBeInTheDocument()
+    expect(screen.queryByRole('link', { name: 'Administración Talleres' })).not.toBeInTheDocument()
+    expect(screen.queryByRole('link', { name: '1:1 Global' })).not.toBeInTheDocument()
+  })
+})
+
+function withCapabilities(capabilities: PlatformSession['capabilities']): PlatformSession {
+  return { ...basePlatformSession, capabilities }
+}

--- a/__tests__/lib/platform/navigation.test.ts
+++ b/__tests__/lib/platform/navigation.test.ts
@@ -72,10 +72,37 @@ describe('Platform navigation resolver', () => {
     expect(gdvAdapter).toHaveBeenCalledWith(baseSessionShape(session))
     expect(result).toMatchObject({ mode: 'platform', legacyFallback: false, audit: { decision: 'allowed', flow: PLATFORM_NAVIGATION_FLOW } })
     expect(result.visibleItems).toEqual([
-      { id: 'dps_team_service', label: 'DPS Música', href: '/dashboard/dps', experience: 'dps', scope: { type: 'equipo', id: 'musica' } },
-      { id: 'grupos_vida_stage', label: 'Grupos de Vida — Adultos', href: '/dashboard/grupos-vida', experience: 'grupos_vida', scope: { type: 'etapa', id: 'segmento-adultos' } },
+      { id: 'grupos_vida_stage', label: 'Grupos de Vida — Adultos', href: '/grupos-vida', experience: 'grupos_vida', scope: { type: 'etapa', id: 'segmento-adultos' } },
     ])
+    expect(deniedReasons(result)).toMatchObject({ dps_team_service: 'route_unavailable' })
     expect(JSON.stringify(result)).not.toContain('auth-1')
+  })
+
+  it('suppresses scoped navigation items when their routes are not available locally', async () => {
+    const session: PlatformSession = {
+      ...baseSession,
+      contexts: [
+        { experience: 'grupos_vida', scopeType: 'etapa', scopeId: 'adultos', label: 'Grupos de Vida — Adultos' },
+      ],
+      capabilities: [
+        { key: 'grupos_vida.stage.read', experience: 'grupos_vida', scopeType: 'etapa', scopeId: 'adultos', source: 'gdv' },
+        { key: 'dps.team.serve', experience: 'dps', scopeType: 'equipo', scopeId: 'musica', source: 'dream-team' },
+        { key: 'ninos.room.read', experience: 'ninos', scopeType: 'salon', scopeId: 'waumbaland', source: 'family' },
+        { key: 'estudiantes.room.read', experience: 'estudiantes', scopeType: 'salon', scopeId: 'insideout', source: 'family' },
+        { key: 'talleres_crecimiento.participation.read', experience: 'talleres_crecimiento', scopeType: 'taller', scopeId: 'de-hombre-a-hombre', source: 'ledger' },
+      ],
+    }
+
+    const result = await resolvePlatformNavigation({ flags: { enabled: true }, platformSession: session })
+
+    expect(result.visibleItems.map((item) => item.href)).toEqual(['/grupos-vida'])
+    expect(result.visibleItems.map((item) => item.label)).toEqual(['Grupos de Vida — Adultos'])
+    expect(deniedReasons(result)).toMatchObject({
+      dps_team_service: 'route_unavailable',
+      ninos_room_context: 'route_unavailable',
+      estudiantes_room_context: 'route_unavailable',
+      talleres_participation: 'route_unavailable',
+    })
   })
 
   it('denies known capability keys when the capability scope conflicts with its catalog definition', async () => {

--- a/components/ui/sidebar-moderna.tsx
+++ b/components/ui/sidebar-moderna.tsx
@@ -31,6 +31,8 @@ import { useCurrentUser } from '@/hooks/useCurrentUser'
 import { logout } from '@/lib/actions/auth.actions'
 import { ThemeToggle } from './theme-toggle'
 import { useBranding } from '@/hooks/useBranding'
+import { resolvePlatformNavigation } from '@/lib/platform/navigation'
+import type { PlatformNavigationFlags, PlatformNavigationItem, PlatformNavigationItemId } from '@/lib/platform/navigation'
 
 interface SidebarModernaProps {
   className?: string
@@ -63,6 +65,18 @@ interface MenuItem {
 }
 
 const SUPPORT_CONFIGURATION_ROLES = ['admin', 'pastor', 'director-general']
+
+const PLATFORM_NAVIGATION_ICONS = {
+  grupos_vida_stage: UserCheck,
+  dps_team_service: Megaphone,
+  ninos_room_context: Users,
+  estudiantes_room_context: Users,
+  talleres_participation: ClipboardList,
+  dps_admin: Settings,
+  nextgen_admin: Settings,
+  talleres_admin: Settings,
+  uno_a_uno_global: User,
+} satisfies Record<PlatformNavigationItemId, React.ComponentType<{ className?: string }>>
 
 const menuItems: MenuItem[] = [
   {
@@ -124,6 +138,22 @@ const footerItems: MenuItem[] = [
   },
 ]
 
+function getPlatformNavigationFlags(): PlatformNavigationFlags {
+  return {
+    enabled: process.env.NEXT_PUBLIC_PLATFORM_NAVIGATION_ENABLED === 'true',
+    killSwitch: process.env.NEXT_PUBLIC_PLATFORM_NAVIGATION_KILL_SWITCH === 'true',
+  }
+}
+
+function toPlatformMenuItem(item: PlatformNavigationItem): MenuItem {
+  return {
+    id: `platform-${item.id}-${item.scope.type}-${item.scope.id ?? 'global'}`,
+    label: item.label,
+    icon: PLATFORM_NAVIGATION_ICONS[item.id],
+    href: item.href,
+  }
+}
+
 /**
  * Sidebar principal con navegación, submenús colapsables, selector de campus.
  * Incluye modal de confirmación de logout y tooltips en modo colapsado.
@@ -134,10 +164,12 @@ export function SidebarModerna({ className }: SidebarModernaProps) {
   const [showLogoutModal, setShowLogoutModal] = useState(false)
   const [isMobile, setIsMobile] = useState(false)
   const [tooltip, setTooltip] = useState<{ label: string; top: number } | null>(null)
+  const [platformNavigationItems, setPlatformNavigationItems] = useState<MenuItem[]>([])
   const router = useRouter()
   const pathname = usePathname()
-  const { usuario, roles, supportCapabilities = [], loading } = useCurrentUser()
+  const { usuario, roles, supportCapabilities = [], platformSession, loading } = useCurrentUser()
   const branding = useBranding()
+  const primaryMenuItems = [...menuItems, ...platformNavigationItems]
 
 
   // ─── Tooltip hover handlers (collapsed mode) ───
@@ -168,6 +200,36 @@ export function SidebarModerna({ className }: SidebarModernaProps) {
       return merged
     })
   }, [pathname])
+
+  useEffect(() => {
+    const flags = getPlatformNavigationFlags()
+    if (!flags.enabled || flags.killSwitch || !platformSession) {
+      if (platformNavigationItems.length > 0) setPlatformNavigationItems([])
+      return
+    }
+
+    let isCurrent = true
+
+    resolvePlatformNavigation({
+      flags,
+      platformSession,
+    })
+      .then((resolution) => {
+        if (!isCurrent) return
+        setPlatformNavigationItems(
+          resolution.mode === 'platform'
+            ? resolution.visibleItems.map(toPlatformMenuItem)
+            : []
+        )
+      })
+      .catch(() => {
+        if (isCurrent) setPlatformNavigationItems([])
+      })
+
+    return () => {
+      isCurrent = false
+    }
+  }, [platformSession, platformNavigationItems.length])
 
   // Formatear roles para mostrar
   const formatearRoles = (roles: string[]): string => {
@@ -354,7 +416,7 @@ export function SidebarModerna({ className }: SidebarModernaProps) {
         {/* Navegación */}
         <nav className="flex-1 px-3 py-2 overflow-y-auto" aria-label="Navegación principal">
           <ul className="space-y-0.5">
-            {menuItems
+            {primaryMenuItems
               .filter(canAccess)
               .map((item) => {
                 const Icon = item.icon

--- a/components/ui/sidebar-moderna.tsx
+++ b/components/ui/sidebar-moderna.tsx
@@ -31,7 +31,7 @@ import { useCurrentUser } from '@/hooks/useCurrentUser'
 import { logout } from '@/lib/actions/auth.actions'
 import { ThemeToggle } from './theme-toggle'
 import { useBranding } from '@/hooks/useBranding'
-import { resolvePlatformNavigation } from '@/lib/platform/navigation'
+import { resolvePlatformNavigation, resolvePlatformNavigationGate } from '@/lib/platform/navigation'
 import type { PlatformNavigationFlags, PlatformNavigationItem, PlatformNavigationItemId } from '@/lib/platform/navigation'
 
 interface SidebarModernaProps {
@@ -138,11 +138,15 @@ const footerItems: MenuItem[] = [
   },
 ]
 
-function getPlatformNavigationFlags(): PlatformNavigationFlags {
+function getBuildTimePlatformNavigationFlags(): PlatformNavigationFlags {
   return {
     enabled: process.env.NEXT_PUBLIC_PLATFORM_NAVIGATION_ENABLED === 'true',
     killSwitch: process.env.NEXT_PUBLIC_PLATFORM_NAVIGATION_KILL_SWITCH === 'true',
   }
+}
+
+function clearPlatformNavigationItems(setItems: React.Dispatch<React.SetStateAction<MenuItem[]>>) {
+  setItems((current) => (current.length > 0 ? [] : current))
 }
 
 function toPlatformMenuItem(item: PlatformNavigationItem): MenuItem {
@@ -202,9 +206,10 @@ export function SidebarModerna({ className }: SidebarModernaProps) {
   }, [pathname])
 
   useEffect(() => {
-    const flags = getPlatformNavigationFlags()
-    if (!flags.enabled || flags.killSwitch || !platformSession) {
-      if (platformNavigationItems.length > 0) setPlatformNavigationItems([])
+    const flags = getBuildTimePlatformNavigationFlags()
+    const gate = resolvePlatformNavigationGate({ flags, platformSession })
+    if (!gate.ok) {
+      clearPlatformNavigationItems(setPlatformNavigationItems)
       return
     }
 
@@ -212,7 +217,7 @@ export function SidebarModerna({ className }: SidebarModernaProps) {
 
     resolvePlatformNavigation({
       flags,
-      platformSession,
+      platformSession: gate.platformSession,
     })
       .then((resolution) => {
         if (!isCurrent) return
@@ -229,7 +234,7 @@ export function SidebarModerna({ className }: SidebarModernaProps) {
     return () => {
       isCurrent = false
     }
-  }, [platformSession, platformNavigationItems.length])
+  }, [platformSession])
 
   // Formatear roles para mostrar
   const formatearRoles = (roles: string[]): string => {

--- a/lib/platform/navigation.ts
+++ b/lib/platform/navigation.ts
@@ -11,7 +11,8 @@ export type PlatformNavigationAdapterResult =
   | { ok: false; reason: string }
 export type PlatformNavigationAdapter = (session: PlatformNavigationSession) => Promise<PlatformNavigationAdapterResult>
 export type PlatformNavigationFallbackReason = 'feature_flag_disabled' | 'kill_switch_enabled' | 'platform_session_required' | 'adapter_failed'
-export type PlatformNavigationDeniedReason = PlatformNavigationFallbackReason | PlatformCapabilityDeniedReason
+export type PlatformNavigationRouteDeniedReason = 'route_unavailable'
+export type PlatformNavigationDeniedReason = PlatformNavigationFallbackReason | PlatformCapabilityDeniedReason | PlatformNavigationRouteDeniedReason
 export type PlatformNavigationItemId =
   | 'grupos_vida_stage'
   | 'dps_team_service'
@@ -49,12 +50,15 @@ export type PlatformNavigationResolverInput = {
   platformSession: PlatformNavigationSession | null | undefined
   adapters?: readonly PlatformNavigationAdapter[]
 }
+export type PlatformNavigationGate =
+  | { ok: true; platformSession: PlatformNavigationSession }
+  | { ok: false; reason: PlatformNavigationFallbackReason }
 
 type PlatformNavigationDefinition = {
   id: PlatformNavigationItemId
   capability: string
   label: string
-  href: string
+  availableHref?: string
   experience: string
   fallbackScope: PlatformScopeInput
 }
@@ -71,23 +75,22 @@ const PLATFORM_NAVIGATION_SCOPE_LABELS: Partial<Record<PlatformNavigationItemId,
 }
 
 const PLATFORM_NAVIGATION_DEFINITIONS = [
-  { id: 'grupos_vida_stage', capability: 'grupos_vida.stage.read', label: 'Grupos de Vida', href: '/dashboard/grupos-vida', experience: 'grupos_vida', fallbackScope: { experience: 'grupos_vida', type: 'etapa', id: 'required' } },
-  { id: 'dps_team_service', capability: 'dps.team.serve', label: 'DPS', href: '/dashboard/dps', experience: 'dps', fallbackScope: { experience: 'dps', type: 'equipo', id: 'required' } },
-  { id: 'ninos_room_context', capability: 'ninos.room.read', label: 'Niños', href: '/dashboard/ninos', experience: 'ninos', fallbackScope: { experience: 'ninos', type: 'salon', id: 'required' } },
-  { id: 'estudiantes_room_context', capability: 'estudiantes.room.read', label: 'Estudiantes', href: '/dashboard/estudiantes', experience: 'estudiantes', fallbackScope: { experience: 'estudiantes', type: 'salon', id: 'required' } },
-  { id: 'talleres_participation', capability: 'talleres_crecimiento.participation.read', label: 'Talleres de Crecimiento', href: '/dashboard/talleres', experience: 'talleres_crecimiento', fallbackScope: { experience: 'talleres_crecimiento', type: 'taller', id: 'required' } },
-  { id: 'dps_admin', capability: 'dps.admin.manage', label: 'Administración DPS', href: '/dashboard/dps/admin', experience: 'dps', fallbackScope: { experience: 'dps', type: 'equipo', id: 'global' } },
-  { id: 'nextgen_admin', capability: 'nextgen.admin.manage', label: 'Administración NextGen', href: '/dashboard/nextgen/admin', experience: 'nextgen', fallbackScope: { experience: 'nextgen', type: 'experience' } },
-  { id: 'talleres_admin', capability: 'talleres_crecimiento.admin.manage', label: 'Administración Talleres', href: '/dashboard/talleres/admin', experience: 'talleres_crecimiento', fallbackScope: { experience: 'talleres_crecimiento', type: 'taller', id: 'global' } },
-  { id: ONE_ON_ONE_THE_LIVING_ROOM_NAVIGATION.itemId, capability: ONE_ON_ONE_THE_LIVING_ROOM_NAVIGATION.capability, label: ONE_ON_ONE_THE_LIVING_ROOM_NAVIGATION.label, href: '/dashboard/uno-a-uno', experience: ONE_ON_ONE_THE_LIVING_ROOM_NAVIGATION.experience, fallbackScope: { experience: ONE_ON_ONE_THE_LIVING_ROOM_NAVIGATION.experience, type: 'experience' } },
+  { id: 'grupos_vida_stage', capability: 'grupos_vida.stage.read', label: 'Grupos de Vida', availableHref: '/grupos-vida', experience: 'grupos_vida', fallbackScope: { experience: 'grupos_vida', type: 'etapa', id: 'required' } },
+  { id: 'dps_team_service', capability: 'dps.team.serve', label: 'DPS', experience: 'dps', fallbackScope: { experience: 'dps', type: 'equipo', id: 'required' } },
+  { id: 'ninos_room_context', capability: 'ninos.room.read', label: 'Niños', experience: 'ninos', fallbackScope: { experience: 'ninos', type: 'salon', id: 'required' } },
+  { id: 'estudiantes_room_context', capability: 'estudiantes.room.read', label: 'Estudiantes', experience: 'estudiantes', fallbackScope: { experience: 'estudiantes', type: 'salon', id: 'required' } },
+  { id: 'talleres_participation', capability: 'talleres_crecimiento.participation.read', label: 'Talleres de Crecimiento', experience: 'talleres_crecimiento', fallbackScope: { experience: 'talleres_crecimiento', type: 'taller', id: 'required' } },
+  { id: 'dps_admin', capability: 'dps.admin.manage', label: 'Administración DPS', experience: 'dps', fallbackScope: { experience: 'dps', type: 'equipo', id: 'global' } },
+  { id: 'nextgen_admin', capability: 'nextgen.admin.manage', label: 'Administración NextGen', experience: 'nextgen', fallbackScope: { experience: 'nextgen', type: 'experience' } },
+  { id: 'talleres_admin', capability: 'talleres_crecimiento.admin.manage', label: 'Administración Talleres', experience: 'talleres_crecimiento', fallbackScope: { experience: 'talleres_crecimiento', type: 'taller', id: 'global' } },
+  { id: ONE_ON_ONE_THE_LIVING_ROOM_NAVIGATION.itemId, capability: ONE_ON_ONE_THE_LIVING_ROOM_NAVIGATION.capability, label: ONE_ON_ONE_THE_LIVING_ROOM_NAVIGATION.label, experience: ONE_ON_ONE_THE_LIVING_ROOM_NAVIGATION.experience, fallbackScope: { experience: ONE_ON_ONE_THE_LIVING_ROOM_NAVIGATION.experience, type: 'experience' } },
 ] satisfies readonly PlatformNavigationDefinition[]
 
 export async function resolvePlatformNavigation(input: PlatformNavigationResolverInput): Promise<PlatformNavigationResolution> {
-  if (!input.flags.enabled) return legacyFallback('feature_flag_disabled')
-  if (input.flags.killSwitch) return legacyFallback('kill_switch_enabled')
-  if (!input.platformSession?.personaId.trim() || !input.platformSession.subjectAuthId.trim()) return legacyFallback('platform_session_required')
+  const gate = resolvePlatformNavigationGate(input)
+  if (!gate.ok) return legacyFallback(gate.reason)
 
-  const adapterState = await applyAdapters(input.platformSession, input.adapters ?? [])
+  const adapterState = await applyAdapters(gate.platformSession, input.adapters ?? [])
   if (!adapterState.ok) return legacyFallback('adapter_failed')
 
   const visibleItems: PlatformNavigationItem[] = []
@@ -106,6 +109,15 @@ export async function resolvePlatformNavigation(input: PlatformNavigationResolve
     deniedItems,
     audit: { decision: 'allowed', flow: PLATFORM_NAVIGATION_FLOW, visibleItemCount: visibleItems.length, deniedItemCount: deniedItems.length },
   }
+}
+
+export function resolvePlatformNavigationGate(input: Pick<PlatformNavigationResolverInput, 'flags' | 'platformSession'>): PlatformNavigationGate {
+  if (!input.flags.enabled) return { ok: false, reason: 'feature_flag_disabled' }
+  if (input.flags.killSwitch) return { ok: false, reason: 'kill_switch_enabled' }
+  if (!input.platformSession?.personaId.trim() || !input.platformSession.subjectAuthId.trim()) {
+    return { ok: false, reason: 'platform_session_required' }
+  }
+  return { ok: true, platformSession: input.platformSession }
 }
 
 async function applyAdapters(session: PlatformNavigationSession, adapters: readonly PlatformNavigationAdapter[]) {
@@ -143,7 +155,12 @@ function resolveNavigationDefinition(definition: PlatformNavigationDefinition, s
       })
 
     if (capabilityResult.ok) {
-      visibleItems.push(toNavigationItem(definition, capability, session.contexts))
+      const visibleItem = toNavigationItem(definition, capability, session.contexts)
+      if (visibleItem) {
+        visibleItems.push(visibleItem)
+      } else {
+        deniedItem = { id: definition.id, reason: 'route_unavailable' }
+      }
     } else {
       deniedItem = { id: definition.id, reason: capabilityResult.reason }
     }
@@ -188,11 +205,12 @@ function toScopeInput(capability: PlatformSessionCapability): PlatformScopeInput
   return { experience: capability.experience, type: capability.scopeType, id: capability.scopeId }
 }
 
-function toNavigationItem(definition: PlatformNavigationDefinition, capability: PlatformSessionCapability, contexts: readonly PlatformSessionContext[]): PlatformNavigationItem {
+function toNavigationItem(definition: PlatformNavigationDefinition, capability: PlatformSessionCapability, contexts: readonly PlatformSessionContext[]): PlatformNavigationItem | undefined {
+  if (!definition.availableHref) return undefined
   return {
     id: definition.id,
     label: resolveLabel(definition, capability, contexts),
-    href: definition.href,
+    href: definition.availableHref,
     experience: definition.experience,
     scope: { type: capability.scopeType, ...(capability.scopeId ? { id: capability.scopeId } : {}) },
   }

--- a/openspec/changes/fase-01-platform-foundation/tasks.md
+++ b/openspec/changes/fase-01-platform-foundation/tasks.md
@@ -48,6 +48,7 @@ Chain strategy: stacked-to-main para PR1a; confirmar por slice futuro
   - Issue #212: `hooks/useCurrentUser.ts` expone `platformSession` client-safe de solo lectura (`personaId`, `subjectAuthId`, roles legados y arrays vacíos de contextos/capabilities), conserva roles/capabilities legacy, falla cerrado a `null` si no hay Persona vinculada y no cambia navegación/dashboard visible.
 - [ ] 3.2 Actualizar `lib/platform/navigation.ts`, `sidebar-moderna.tsx`, `header-movil.tsx`, `menu-inferior-movil.tsx` y dashboard con flag/kill switch.
   - Issue #214: primer slice interno crea `lib/platform/navigation.ts` con resolver/modelo puro, flag/kill switch, fallback legado deny-by-default y tests; sin wiring visible de sidebar/header/mobile/dashboard.
+  - Issue #216: slice sidebar-only cablea `sidebar-moderna.tsx` al resolver contextual detrás de flag/kill switch, conserva fallback legado y agrega tests de scope permitido/denegaciones globales; header/mobile/dashboard siguen pendientes.
 - [ ] 3.3 Verificar rutas directas denegadas, fallback legado si adapters fallan, y no mostrar DPS admin, NextGen, taller admin ni 1:1 global.
 
 ## Fase 4: Familia y menores


### PR DESCRIPTION
## Tipo de PR
- [x] New feature

## Resumen
Closes #216

PR #217 cablea la navegación contextual de Platform Foundation en el sidebar desktop usando el resolver interno de PR #215, y corrige los hallazgos confirmados de review: el sidebar ya no expone enlaces a rutas `/dashboard/*` inexistentes, la compuerta de fallback queda centralizada y el efecto de navegación ya no depende de su propio estado mutado.

## Qué Incluye
- `SidebarModerna` usa una compuerta compartida del resolver antes de intentar navegación contextual.
- El resolver solo emite rutas verificadas localmente: `grupos_vida_stage` apunta a `/grupos-vida`; las rutas platform sin página local disponible quedan suprimidas con `route_unavailable`.
- Tests del sidebar prueban que, con flag encendido, no se renderizan links a `/dashboard/*` inexistentes.
- Tests del resolver cubren rutas disponibles vs. rutas suprimidas.
- El flag/kill switch actual sigue siendo `NEXT_PUBLIC_*` y por lo tanto build-time/inlined; este PR no reclama rollback runtime operacional.
- Nota de progreso en task 3.2 sin marcarla completa.

## Motivación / Por Qué
PR #215 dejó listo el resolver puro. PR #217 conecta solo el sidebar para avanzar task 3.2 sin tocar header, mobile, dashboard, permisos legados ni autorización de rutas. El review detectó que los items visibles podían llevar a páginas no creadas; este fix falla cerrado y conserva alcance.

## Chain Context
- Strategy: `stacked-to-main` from updated `main` after PR #215 merge.
- Dependency diagram:
  - `main` includes PR #215 internal resolver
  - 📍 PR #217 / issue #216 sidebar platform navigation wiring
  - Follow-up: header/mobile/dashboard slices for remaining task 3.2
- Start: `main` at `8df7bac`.
- End: sidebar-only contextual navigation wiring, route-availability suppression and tests.
- Out of scope: header/mobile/dashboard, route guards, backend auth, runtime config API, Supabase migrations/data, GDV/asistencia/líderes/directores permission flow changes.
- Review budget: 265 additions + 22 deletions = 287 changed lines, under 400.

## Evidencia Visual (si aplica)
No aplica; cambio protegido por feature flag build-time y cubierto por tests de comportamiento.

## Migraciones / Base de Datos
- [x] No aplica
- [ ] Sí (orden exacto):
```
N/A
```
Notas: no hay cambios de esquema, datos ni Supabase remoto.

## Impacto y Riesgos
- Compatibilidad: fallback legado se conserva cuando el flag está apagado, el kill switch build-time está activo o no hay `platformSession` válida.
- Seguridad: no cambia autorización de rutas ni backend/RLS; el sidebar solo oculta/muestra navegación.
- Resiliencia: las rutas platform sin página local disponible quedan suprimidas; no se crean rutas nuevas en este PR.
- Limitación explícita: `NEXT_PUBLIC_PLATFORM_NAVIGATION_KILL_SWITCH` no es rollback runtime operacional; requiere rebuild/redeploy como cualquier variable pública inlined por Next.js.

## Checklist Autor
- [x] Código formateado (Prettier/ESLint no configurado; `git diff --check` OK)
- [x] Sin `console.log` / debugger
- [x] Validaciones con zod para entradas nuevas (no aplica: no hay entrada persistida/API)
- [x] Estados loading/error/empty cubiertos por fallback legado del resolver/sidebar
- [x] Tipos TypeScript correctos (`npx tsc --noEmit`)
- [x] Migraciones probadas local (no aplica)
- [x] Documentación actualizada (PR body y `openspec/.../tasks.md`)
- [x] Variables de entorno documentadas como build-time en este PR
- [x] Rebase con `main` limpio

## Checklist Revisor
- [x] Propósito claro
- [x] Nombres descriptivos
- [x] Sin lógica duplicada evidente
- [x] Manejo adecuado de errores
- [x] Cambios acotados al alcance
- [x] Sin secretos / datos sensibles

## Pruebas Manuales Realizadas
- `pnpm test -- __tests__/components/sidebar-platform-navigation.test.tsx __tests__/lib/platform/navigation.test.ts --runInBand`
- `pnpm test -- __tests__/components/sidebar-platform-navigation.test.tsx __tests__/components/support-navigation.test.tsx __tests__/lib/platform/navigation.test.ts --runInBand`
- `npx tsc --noEmit`
- `pnpm test:ci`
- `git diff --check`

## Pendientes / Follow-up (opcional)
- Completar task 3.2 con slices separados para `header-movil.tsx`, `menu-inferior-movil.tsx` y dashboard.
- Si se requiere rollback operacional real, diseñar un runtime config path en otro PR con alcance explícito.
- Task 3.3 debe verificar rutas directas denegadas y fallback legado de adapters.

## Notas Adicionales
Task 3.2 permanece abierta porque este PR solo cubre el sidebar desktop.