### PR TITLE
feat(platform): cablea navegación contextual móvil

### DIFF
--- a/__tests__/components/mobile-platform-navigation.test.tsx
+++ b/__tests__/components/mobile-platform-navigation.test.tsx
@@ -1,0 +1,111 @@
+import { render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+
+import { HeaderMovil } from '@/components/ui/header-movil'
+import type { PlatformSession } from '@/lib/platform/session/types'
+
+let currentRoles = ['miembro']
+let currentPlatformSession: PlatformSession | null = null
+
+jest.mock('next/navigation', () => ({
+  usePathname: () => '/dashboard',
+}))
+jest.mock('@/hooks/useCurrentUser', () => ({
+  useCurrentUser: () => ({
+    usuario: null,
+    roles: currentRoles,
+    supportCapabilities: [],
+    platformSession: currentPlatformSession,
+    loading: false,
+    error: null,
+  }),
+}))
+jest.mock('@/hooks/useBranding', () => ({ useBranding: () => ({ logoLightUrl: null, logoDarkUrl: null }) }))
+jest.mock('@/hooks/use-notificaciones', () => ({ useNotificaciones: () => ({ info: jest.fn() }) }))
+jest.mock('@/hooks/useCampus', () => ({ useCampus: () => ({ campusActivo: null, localidadActiva: null, campusDisponibles: [], localidadesDisponibles: [], campusId: null, localidadId: null, esSuperadmin: false, loading: false, seleccionarCampus: jest.fn(), seleccionarLocalidad: jest.fn() }) }))
+jest.mock('@/lib/actions/auth.actions', () => ({ logout: jest.fn() }))
+jest.mock('next-themes', () => ({ useTheme: () => ({ theme: 'light', setTheme: jest.fn() }) }))
+
+const basePlatformSession: PlatformSession = {
+  personaId: 'persona-1',
+  subjectAuthId: 'auth-1',
+  globalRoles: [],
+  contexts: [],
+  capabilities: [],
+}
+
+describe('HeaderMovil platform navigation', () => {
+  beforeEach(() => {
+    currentRoles = ['miembro']
+    currentPlatformSession = null
+    delete process.env.NEXT_PUBLIC_PLATFORM_NAVIGATION_ENABLED
+    delete process.env.NEXT_PUBLIC_PLATFORM_NAVIGATION_KILL_SWITCH
+  })
+
+  it.each([
+    ['feature flag is off', undefined, undefined],
+    ['kill switch is active', 'true', 'true'],
+  ])('keeps legacy mobile drawer behavior when the %s', async (_label, enabled, killSwitch) => {
+    if (enabled) process.env.NEXT_PUBLIC_PLATFORM_NAVIGATION_ENABLED = enabled
+    if (killSwitch) process.env.NEXT_PUBLIC_PLATFORM_NAVIGATION_KILL_SWITCH = killSwitch
+    currentRoles = ['admin']
+    currentPlatformSession = withCapabilities([
+      { key: 'dps.team.serve', experience: 'dps', scopeType: 'equipo', scopeId: 'musica', source: 'dream-team' },
+    ])
+
+    render(<HeaderMovil />)
+    await userEvent.click(screen.getByLabelText('Abrir menú'))
+
+    expect(screen.getByRole('link', { name: 'Usuarios' })).toHaveAttribute('href', '/users')
+    expect(screen.queryByRole('link', { name: 'DPS Música' })).not.toBeInTheDocument()
+  })
+
+  it('shows scoped platform navigation in the mobile drawer when the flag is on and the route is available', async () => {
+    process.env.NEXT_PUBLIC_PLATFORM_NAVIGATION_ENABLED = 'true'
+    currentPlatformSession = withCapabilities([
+      { key: 'grupos_vida.stage.read', experience: 'grupos_vida', scopeType: 'etapa', scopeId: 'adultos', source: 'gdv' },
+    ], [
+      { experience: 'grupos_vida', scopeType: 'etapa', scopeId: 'adultos', label: 'Grupos de Vida — Adultos' },
+    ])
+
+    render(<HeaderMovil />)
+    await userEvent.click(screen.getByLabelText('Abrir menú'))
+
+    expect(await screen.findByRole('link', { name: 'Grupos de Vida — Adultos' })).toHaveAttribute('href', '/grupos-vida')
+    expect(screen.queryByRole('link', { name: 'Usuarios' })).not.toBeInTheDocument()
+  })
+
+  it('suppresses unavailable and global platform access in the mobile drawer', async () => {
+    process.env.NEXT_PUBLIC_PLATFORM_NAVIGATION_ENABLED = 'true'
+    currentPlatformSession = withCapabilities([
+      { key: 'grupos_vida.stage.read', experience: 'grupos_vida', scopeType: 'etapa', scopeId: 'adultos', source: 'gdv' },
+      { key: 'dps.team.serve', experience: 'dps', scopeType: 'equipo', scopeId: 'musica', source: 'dream-team' },
+      { key: 'ninos.room.read', experience: 'ninos', scopeType: 'salon', scopeId: 'waumbaland', source: 'family' },
+      { key: 'estudiantes.room.read', experience: 'estudiantes', scopeType: 'salon', scopeId: 'insideout', source: 'family' },
+      { key: 'talleres_crecimiento.participation.read', experience: 'talleres_crecimiento', scopeType: 'taller', scopeId: 'de-hombre-a-hombre', source: 'ledger' },
+      { key: 'dps.admin.manage', experience: 'dps', scopeType: 'equipo', scopeId: 'musica', source: 'unsafe' },
+      { key: 'nextgen.admin.manage', experience: 'nextgen', scopeType: 'experience', source: 'unsafe' },
+      { key: 'talleres_crecimiento.admin.manage', experience: 'talleres_crecimiento', scopeType: 'taller', scopeId: 'global', source: 'unsafe' },
+      { key: 'uno_a_uno.global.read', experience: 'the_living_room', scopeType: 'experience', source: 'unsafe' },
+    ], [
+      { experience: 'grupos_vida', scopeType: 'etapa', scopeId: 'adultos', label: 'Grupos de Vida — Adultos' },
+    ])
+
+    render(<HeaderMovil />)
+    await userEvent.click(screen.getByLabelText('Abrir menú'))
+
+    expect(await screen.findByRole('link', { name: 'Grupos de Vida — Adultos' })).toHaveAttribute('href', '/grupos-vida')
+    await waitFor(() => expect(screen.queryByRole('link', { name: 'DPS Música' })).not.toBeInTheDocument())
+    expect(screen.queryByRole('link', { name: 'Niños' })).not.toBeInTheDocument()
+    expect(screen.queryByRole('link', { name: 'Estudiantes' })).not.toBeInTheDocument()
+    expect(screen.queryByRole('link', { name: 'Talleres de Crecimiento' })).not.toBeInTheDocument()
+    expect(screen.queryByRole('link', { name: 'Administración DPS' })).not.toBeInTheDocument()
+    expect(screen.queryByRole('link', { name: 'Administración NextGen' })).not.toBeInTheDocument()
+    expect(screen.queryByRole('link', { name: 'Administración Talleres' })).not.toBeInTheDocument()
+    expect(screen.queryByRole('link', { name: '1:1 Global' })).not.toBeInTheDocument()
+  })
+})
+
+function withCapabilities(capabilities: PlatformSession['capabilities'], contexts: PlatformSession['contexts'] = []): PlatformSession {
+  return { ...basePlatformSession, contexts, capabilities }
+}

--- a/__tests__/components/platform-navigation-view-items.test.ts
+++ b/__tests__/components/platform-navigation-view-items.test.ts
@@ -1,0 +1,47 @@
+import { UserCheck } from 'lucide-react'
+
+import { resolvePlatformNavigationViewItems } from '@/components/ui/platform-navigation-view-items'
+import type { PlatformSession } from '@/lib/platform/session/types'
+
+const basePlatformSession: PlatformSession = {
+  personaId: 'persona-1',
+  subjectAuthId: 'auth-1',
+  globalRoles: [],
+  contexts: [],
+  capabilities: [],
+}
+
+describe('platform navigation view items', () => {
+  it('maps available platform navigation to reusable view items', async () => {
+    const platformSession = withCapabilities([
+      { key: 'grupos_vida.stage.read', experience: 'grupos_vida', scopeType: 'etapa', scopeId: 'adultos', source: 'gdv' },
+    ], [
+      { experience: 'grupos_vida', scopeType: 'etapa', scopeId: 'adultos', label: 'Grupos de Vida — Adultos' },
+    ])
+
+    const items = await resolvePlatformNavigationViewItems(platformSession, { enabled: true })
+
+    expect(items).toEqual([
+      {
+        id: 'platform-grupos_vida_stage-etapa-adultos',
+        label: 'Grupos de Vida — Adultos',
+        icon: UserCheck,
+        href: '/grupos-vida',
+      },
+    ])
+  })
+
+  it.each([
+    ['feature flag is off', { enabled: false }, basePlatformSession],
+    ['kill switch is active', { enabled: true, killSwitch: true }, basePlatformSession],
+    ['platform session is missing', { enabled: true }, null],
+  ] satisfies Array<[string, { enabled: boolean; killSwitch?: boolean }, PlatformSession | null]>)('returns no view items when the %s', async (_label, flags, platformSession) => {
+    const items = await resolvePlatformNavigationViewItems(platformSession, flags)
+
+    expect(items).toEqual([])
+  })
+})
+
+function withCapabilities(capabilities: PlatformSession['capabilities'], contexts: PlatformSession['contexts'] = []): PlatformSession {
+  return { ...basePlatformSession, contexts, capabilities }
+}

--- a/components/ui/header-movil.tsx
+++ b/components/ui/header-movil.tsx
@@ -18,6 +18,8 @@ import { useCurrentUser } from '@/hooks/useCurrentUser'
 import { cn } from '@/lib/utils'
 import { useBranding } from '@/hooks/useBranding'
 import { useNotificaciones } from '@/hooks/use-notificaciones'
+import { resolvePlatformNavigation, resolvePlatformNavigationGate } from '@/lib/platform/navigation'
+import type { PlatformNavigationFlags, PlatformNavigationItem, PlatformNavigationItemId } from '@/lib/platform/navigation'
 
 // ── SubItem type ──
 interface SubItem {
@@ -41,6 +43,18 @@ interface MobileMenuItem {
 }
 
 const SUPPORT_CONFIGURATION_ROLES = ['admin', 'pastor', 'director-general']
+
+const PLATFORM_NAVIGATION_ICONS = {
+  grupos_vida_stage: UserCheck,
+  dps_team_service: Megaphone,
+  ninos_room_context: Users,
+  estudiantes_room_context: Users,
+  talleres_participation: ClipboardList,
+  dps_admin: Settings,
+  nextgen_admin: Settings,
+  talleres_admin: Settings,
+  uno_a_uno_global: User,
+} satisfies Record<PlatformNavigationItemId, React.ComponentType<{ className?: string }>>
 
 const mainMenuItems: MobileMenuItem[] = [
   { id: 'dashboard', label: 'Dashboard', icon: Home, href: '/dashboard' },
@@ -81,9 +95,6 @@ const footerMenuItems: MobileMenuItem[] = [
   { id: 'ayuda', label: 'Ayuda', icon: HelpCircle, href: '/ayuda' },
 ]
 
-// All items combined for title resolution
-const allMenuItems: MobileMenuItem[] = [...mainMenuItems, ...footerMenuItems]
-
 function formatearRol(roles: string[]): string {
   if (!roles || roles.length === 0) return 'Usuario'
   const map: Record<string, string> = {
@@ -92,6 +103,26 @@ function formatearRol(roles: string[]): string {
     miembro: 'Miembro',
   }
   return map[roles[0]] ?? roles[0].charAt(0).toUpperCase() + roles[0].slice(1)
+}
+
+function getBuildTimePlatformNavigationFlags(): PlatformNavigationFlags {
+  return {
+    enabled: process.env.NEXT_PUBLIC_PLATFORM_NAVIGATION_ENABLED === 'true',
+    killSwitch: process.env.NEXT_PUBLIC_PLATFORM_NAVIGATION_KILL_SWITCH === 'true',
+  }
+}
+
+function clearPlatformNavigationItems(setItems: React.Dispatch<React.SetStateAction<MobileMenuItem[]>>) {
+  setItems((current) => (current.length > 0 ? [] : current))
+}
+
+function toPlatformMobileMenuItem(item: PlatformNavigationItem): MobileMenuItem {
+  return {
+    id: `platform-${item.id}-${item.scope.type}-${item.scope.id ?? 'global'}`,
+    label: item.label,
+    icon: PLATFORM_NAVIGATION_ICONS[item.id],
+    href: item.href,
+  }
 }
 
 // ════════════════════════════════════════
@@ -109,17 +140,19 @@ export function HeaderMovil({ titulo }: HeaderMovilProps) {
   const [drawerOpen, setDrawerOpen] = useState(false)
   const [userMenuOpen, setUserMenuOpen] = useState(false)
   const [openSubmenus, setOpenSubmenus] = useState<Set<string>>(new Set())
+  const [platformNavigationItems, setPlatformNavigationItems] = useState<MobileMenuItem[]>([])
   const pathname = usePathname()
-  const { usuario, roles, supportCapabilities = [], loading } = useCurrentUser()
+  const { usuario, roles, supportCapabilities = [], platformSession, loading } = useCurrentUser()
   const branding = useBranding()
   const toast = useNotificaciones()
   const { theme, setTheme } = useTheme()
   const userMenuRef = useRef<HTMLDivElement>(null)
+  const primaryMenuItems = [...mainMenuItems, ...platformNavigationItems]
 
   // Auto-expand submenus when a child route is active
   useEffect(() => {
     const newOpen = new Set<string>()
-    for (const item of allMenuItems) {
+    for (const item of [...mainMenuItems, ...platformNavigationItems, ...footerMenuItems]) {
       if (item.children) {
         const isChildActive = item.children.some(child =>
           pathname === child.href || pathname?.startsWith(child.href + '/')
@@ -134,7 +167,38 @@ export function HeaderMovil({ titulo }: HeaderMovilProps) {
       newOpen.forEach(id => merged.add(id))
       return merged
     })
-  }, [pathname])
+  }, [pathname, platformNavigationItems])
+
+  useEffect(() => {
+    const flags = getBuildTimePlatformNavigationFlags()
+    const gate = resolvePlatformNavigationGate({ flags, platformSession })
+    if (!gate.ok) {
+      clearPlatformNavigationItems(setPlatformNavigationItems)
+      return
+    }
+
+    let isCurrent = true
+
+    resolvePlatformNavigation({
+      flags,
+      platformSession: gate.platformSession,
+    })
+      .then((resolution) => {
+        if (!isCurrent) return
+        setPlatformNavigationItems(
+          resolution.mode === 'platform'
+            ? resolution.visibleItems.map(toPlatformMobileMenuItem)
+            : []
+        )
+      })
+      .catch(() => {
+        if (isCurrent) setPlatformNavigationItems([])
+      })
+
+    return () => {
+      isCurrent = false
+    }
+  }, [platformSession])
 
   const toggleSubmenu = (id: string) => {
     setOpenSubmenus(prev => {
@@ -247,7 +311,8 @@ export function HeaderMovil({ titulo }: HeaderMovilProps) {
     }
 
     // Fallback: top-level menu items
-    return allMenuItems.find(it => path.startsWith(it.href) && it.href !== '/dashboard')?.label ?? 'Global'
+    const titleItems = [...primaryMenuItems, ...footerMenuItems]
+    return titleItems.find(it => path.startsWith(it.href) && it.href !== '/dashboard')?.label ?? 'Global'
   }
 
   return (
@@ -454,7 +519,7 @@ export function HeaderMovil({ titulo }: HeaderMovilProps) {
         {/* ── Main Navigation with Submenus ── */}
         <nav className="flex-1 overflow-y-auto px-3 py-1">
           <ul className="space-y-0.5">
-            {mainMenuItems
+            {primaryMenuItems
               .filter(canAccess)
               .map(item => {
               const Icon = item.icon

--- a/components/ui/header-movil.tsx
+++ b/components/ui/header-movil.tsx
@@ -18,8 +18,7 @@ import { useCurrentUser } from '@/hooks/useCurrentUser'
 import { cn } from '@/lib/utils'
 import { useBranding } from '@/hooks/useBranding'
 import { useNotificaciones } from '@/hooks/use-notificaciones'
-import { resolvePlatformNavigation, resolvePlatformNavigationGate } from '@/lib/platform/navigation'
-import type { PlatformNavigationFlags, PlatformNavigationItem, PlatformNavigationItemId } from '@/lib/platform/navigation'
+import { usePlatformNavigationViewItems } from '@/components/ui/platform-navigation-view-items'
 
 // ── SubItem type ──
 interface SubItem {
@@ -43,18 +42,6 @@ interface MobileMenuItem {
 }
 
 const SUPPORT_CONFIGURATION_ROLES = ['admin', 'pastor', 'director-general']
-
-const PLATFORM_NAVIGATION_ICONS = {
-  grupos_vida_stage: UserCheck,
-  dps_team_service: Megaphone,
-  ninos_room_context: Users,
-  estudiantes_room_context: Users,
-  talleres_participation: ClipboardList,
-  dps_admin: Settings,
-  nextgen_admin: Settings,
-  talleres_admin: Settings,
-  uno_a_uno_global: User,
-} satisfies Record<PlatformNavigationItemId, React.ComponentType<{ className?: string }>>
 
 const mainMenuItems: MobileMenuItem[] = [
   { id: 'dashboard', label: 'Dashboard', icon: Home, href: '/dashboard' },
@@ -105,26 +92,6 @@ function formatearRol(roles: string[]): string {
   return map[roles[0]] ?? roles[0].charAt(0).toUpperCase() + roles[0].slice(1)
 }
 
-function getBuildTimePlatformNavigationFlags(): PlatformNavigationFlags {
-  return {
-    enabled: process.env.NEXT_PUBLIC_PLATFORM_NAVIGATION_ENABLED === 'true',
-    killSwitch: process.env.NEXT_PUBLIC_PLATFORM_NAVIGATION_KILL_SWITCH === 'true',
-  }
-}
-
-function clearPlatformNavigationItems(setItems: React.Dispatch<React.SetStateAction<MobileMenuItem[]>>) {
-  setItems((current) => (current.length > 0 ? [] : current))
-}
-
-function toPlatformMobileMenuItem(item: PlatformNavigationItem): MobileMenuItem {
-  return {
-    id: `platform-${item.id}-${item.scope.type}-${item.scope.id ?? 'global'}`,
-    label: item.label,
-    icon: PLATFORM_NAVIGATION_ICONS[item.id],
-    href: item.href,
-  }
-}
-
 // ════════════════════════════════════════
 // Mobile Header + Drawer
 // ════════════════════════════════════════
@@ -140,9 +107,9 @@ export function HeaderMovil({ titulo }: HeaderMovilProps) {
   const [drawerOpen, setDrawerOpen] = useState(false)
   const [userMenuOpen, setUserMenuOpen] = useState(false)
   const [openSubmenus, setOpenSubmenus] = useState<Set<string>>(new Set())
-  const [platformNavigationItems, setPlatformNavigationItems] = useState<MobileMenuItem[]>([])
   const pathname = usePathname()
   const { usuario, roles, supportCapabilities = [], platformSession, loading } = useCurrentUser()
+  const platformNavigationItems = usePlatformNavigationViewItems(platformSession)
   const branding = useBranding()
   const toast = useNotificaciones()
   const { theme, setTheme } = useTheme()
@@ -168,37 +135,6 @@ export function HeaderMovil({ titulo }: HeaderMovilProps) {
       return merged
     })
   }, [pathname, platformNavigationItems])
-
-  useEffect(() => {
-    const flags = getBuildTimePlatformNavigationFlags()
-    const gate = resolvePlatformNavigationGate({ flags, platformSession })
-    if (!gate.ok) {
-      clearPlatformNavigationItems(setPlatformNavigationItems)
-      return
-    }
-
-    let isCurrent = true
-
-    resolvePlatformNavigation({
-      flags,
-      platformSession: gate.platformSession,
-    })
-      .then((resolution) => {
-        if (!isCurrent) return
-        setPlatformNavigationItems(
-          resolution.mode === 'platform'
-            ? resolution.visibleItems.map(toPlatformMobileMenuItem)
-            : []
-        )
-      })
-      .catch(() => {
-        if (isCurrent) setPlatformNavigationItems([])
-      })
-
-    return () => {
-      isCurrent = false
-    }
-  }, [platformSession])
 
   const toggleSubmenu = (id: string) => {
     setOpenSubmenus(prev => {

--- a/components/ui/platform-navigation-view-items.ts
+++ b/components/ui/platform-navigation-view-items.ts
@@ -1,0 +1,105 @@
+"use client"
+
+import { useEffect, useState, type ComponentType, type Dispatch, type SetStateAction } from 'react'
+import { ClipboardList, Megaphone, Settings, User, UserCheck, Users } from 'lucide-react'
+
+import { resolvePlatformNavigation, resolvePlatformNavigationGate } from '@/lib/platform/navigation'
+import type {
+  PlatformNavigationFlags,
+  PlatformNavigationItem,
+  PlatformNavigationItemId,
+  PlatformNavigationSession,
+} from '@/lib/platform/navigation'
+
+export type PlatformNavigationViewItem = {
+  id: string
+  label: string
+  icon: ComponentType<{ className?: string }>
+  href: string
+  children?: never
+  roles?: never
+  capabilities?: never
+  badge?: never
+  badgeVariant?: never
+  className?: never
+}
+
+const PLATFORM_NAVIGATION_ICONS = {
+  grupos_vida_stage: UserCheck,
+  dps_team_service: Megaphone,
+  ninos_room_context: Users,
+  estudiantes_room_context: Users,
+  talleres_participation: ClipboardList,
+  dps_admin: Settings,
+  nextgen_admin: Settings,
+  talleres_admin: Settings,
+  uno_a_uno_global: User,
+} satisfies Record<PlatformNavigationItemId, ComponentType<{ className?: string }>>
+
+export function getBuildTimePlatformNavigationFlags(): PlatformNavigationFlags {
+  return {
+    enabled: process.env.NEXT_PUBLIC_PLATFORM_NAVIGATION_ENABLED === 'true',
+    killSwitch: process.env.NEXT_PUBLIC_PLATFORM_NAVIGATION_KILL_SWITCH === 'true',
+  }
+}
+
+export async function resolvePlatformNavigationViewItems(
+  platformSession: PlatformNavigationSession | null | undefined,
+  flags: PlatformNavigationFlags = getBuildTimePlatformNavigationFlags()
+): Promise<PlatformNavigationViewItem[]> {
+  const gate = resolvePlatformNavigationGate({ flags, platformSession })
+  if (!gate.ok) return []
+
+  const resolution = await resolvePlatformNavigation({
+    flags,
+    platformSession: gate.platformSession,
+  })
+
+  return resolution.mode === 'platform'
+    ? resolution.visibleItems.map(toPlatformNavigationViewItem)
+    : []
+}
+
+export function usePlatformNavigationViewItems(
+  platformSession: PlatformNavigationSession | null | undefined
+): PlatformNavigationViewItem[] {
+  const [items, setItems] = useState<PlatformNavigationViewItem[]>([])
+
+  useEffect(() => {
+    const flags = getBuildTimePlatformNavigationFlags()
+    const gate = resolvePlatformNavigationGate({ flags, platformSession })
+    if (!gate.ok) {
+      clearPlatformNavigationViewItems(setItems)
+      return
+    }
+
+    let isCurrent = true
+
+    resolvePlatformNavigationViewItems(gate.platformSession, flags)
+      .then((resolvedItems) => {
+        if (isCurrent) setItems(resolvedItems)
+      })
+      .catch(() => {
+        if (isCurrent) setItems([])
+      })
+
+    return () => {
+      isCurrent = false
+    }
+  }, [platformSession])
+
+  return items
+}
+
+function clearPlatformNavigationViewItems(setItems: Dispatch<SetStateAction<PlatformNavigationViewItem[]>>) {
+  setItems((current) => (current.length > 0 ? [] : current))
+}
+
+function toPlatformNavigationViewItem(item: PlatformNavigationItem): PlatformNavigationViewItem {
+  return {
+    id: `platform-${item.id}-${item.scope.type}-${item.scope.id ?? 'global'}`,
+    label: item.label,
+    icon: PLATFORM_NAVIGATION_ICONS[item.id],
+    href: item.href,
+  }
+}

--- a/components/ui/sidebar-moderna.tsx
+++ b/components/ui/sidebar-moderna.tsx
@@ -31,8 +31,7 @@ import { useCurrentUser } from '@/hooks/useCurrentUser'
 import { logout } from '@/lib/actions/auth.actions'
 import { ThemeToggle } from './theme-toggle'
 import { useBranding } from '@/hooks/useBranding'
-import { resolvePlatformNavigation, resolvePlatformNavigationGate } from '@/lib/platform/navigation'
-import type { PlatformNavigationFlags, PlatformNavigationItem, PlatformNavigationItemId } from '@/lib/platform/navigation'
+import { usePlatformNavigationViewItems } from '@/components/ui/platform-navigation-view-items'
 
 interface SidebarModernaProps {
   className?: string
@@ -65,18 +64,6 @@ interface MenuItem {
 }
 
 const SUPPORT_CONFIGURATION_ROLES = ['admin', 'pastor', 'director-general']
-
-const PLATFORM_NAVIGATION_ICONS = {
-  grupos_vida_stage: UserCheck,
-  dps_team_service: Megaphone,
-  ninos_room_context: Users,
-  estudiantes_room_context: Users,
-  talleres_participation: ClipboardList,
-  dps_admin: Settings,
-  nextgen_admin: Settings,
-  talleres_admin: Settings,
-  uno_a_uno_global: User,
-} satisfies Record<PlatformNavigationItemId, React.ComponentType<{ className?: string }>>
 
 const menuItems: MenuItem[] = [
   {
@@ -138,26 +125,6 @@ const footerItems: MenuItem[] = [
   },
 ]
 
-function getBuildTimePlatformNavigationFlags(): PlatformNavigationFlags {
-  return {
-    enabled: process.env.NEXT_PUBLIC_PLATFORM_NAVIGATION_ENABLED === 'true',
-    killSwitch: process.env.NEXT_PUBLIC_PLATFORM_NAVIGATION_KILL_SWITCH === 'true',
-  }
-}
-
-function clearPlatformNavigationItems(setItems: React.Dispatch<React.SetStateAction<MenuItem[]>>) {
-  setItems((current) => (current.length > 0 ? [] : current))
-}
-
-function toPlatformMenuItem(item: PlatformNavigationItem): MenuItem {
-  return {
-    id: `platform-${item.id}-${item.scope.type}-${item.scope.id ?? 'global'}`,
-    label: item.label,
-    icon: PLATFORM_NAVIGATION_ICONS[item.id],
-    href: item.href,
-  }
-}
-
 /**
  * Sidebar principal con navegación, submenús colapsables, selector de campus.
  * Incluye modal de confirmación de logout y tooltips en modo colapsado.
@@ -168,10 +135,10 @@ export function SidebarModerna({ className }: SidebarModernaProps) {
   const [showLogoutModal, setShowLogoutModal] = useState(false)
   const [isMobile, setIsMobile] = useState(false)
   const [tooltip, setTooltip] = useState<{ label: string; top: number } | null>(null)
-  const [platformNavigationItems, setPlatformNavigationItems] = useState<MenuItem[]>([])
   const router = useRouter()
   const pathname = usePathname()
   const { usuario, roles, supportCapabilities = [], platformSession, loading } = useCurrentUser()
+  const platformNavigationItems = usePlatformNavigationViewItems(platformSession)
   const branding = useBranding()
   const primaryMenuItems = [...menuItems, ...platformNavigationItems]
 
@@ -204,37 +171,6 @@ export function SidebarModerna({ className }: SidebarModernaProps) {
       return merged
     })
   }, [pathname])
-
-  useEffect(() => {
-    const flags = getBuildTimePlatformNavigationFlags()
-    const gate = resolvePlatformNavigationGate({ flags, platformSession })
-    if (!gate.ok) {
-      clearPlatformNavigationItems(setPlatformNavigationItems)
-      return
-    }
-
-    let isCurrent = true
-
-    resolvePlatformNavigation({
-      flags,
-      platformSession: gate.platformSession,
-    })
-      .then((resolution) => {
-        if (!isCurrent) return
-        setPlatformNavigationItems(
-          resolution.mode === 'platform'
-            ? resolution.visibleItems.map(toPlatformMenuItem)
-            : []
-        )
-      })
-      .catch(() => {
-        if (isCurrent) setPlatformNavigationItems([])
-      })
-
-    return () => {
-      isCurrent = false
-    }
-  }, [platformSession])
 
   // Formatear roles para mostrar
   const formatearRoles = (roles: string[]): string => {

--- a/openspec/changes/fase-01-platform-foundation/tasks.md
+++ b/openspec/changes/fase-01-platform-foundation/tasks.md
@@ -49,6 +49,7 @@ Chain strategy: stacked-to-main para PR1a; confirmar por slice futuro
 - [ ] 3.2 Actualizar `lib/platform/navigation.ts`, `sidebar-moderna.tsx`, `header-movil.tsx`, `menu-inferior-movil.tsx` y dashboard con flag/kill switch.
   - Issue #214: primer slice interno crea `lib/platform/navigation.ts` con resolver/modelo puro, flag/kill switch, fallback legado deny-by-default y tests; sin wiring visible de sidebar/header/mobile/dashboard.
   - Issue #216: slice sidebar-only cablea `sidebar-moderna.tsx` al resolver contextual detrás de flag/kill switch, conserva fallback legado y agrega tests de scope permitido/denegaciones globales; header/mobile/dashboard siguen pendientes.
+  - Issue #218: slice header mobile cablea `header-movil.tsx` al resolver contextual detrás de flag/kill switch; conserva fallback legado y prueba scope permitido, kill switch y supresión de rutas no disponibles/accesos globales. `menu-inferior-movil.tsx` y dashboard siguen pendientes.
 - [ ] 3.3 Verificar rutas directas denegadas, fallback legado si adapters fallan, y no mostrar DPS admin, NextGen, taller admin ni 1:1 global.
 
 ## Fase 4: Familia y menores


### PR DESCRIPTION
# feat(platform): cablea navegación contextual móvil

## Resumen
Closes #218

- Cablea el drawer de `HeaderMovil` al resolver contextual de plataforma detrás de feature flag / kill switch.
- Extrae un helper client-safe compartido para mapear navegación contextual en vistas móviles/desktop sin duplicar íconos, flags, fallback gate ni resolución.
- Mantiene el fallback legado cuando el flag está apagado, el kill switch está activo o no hay PlatformSession válida.
- No toca dashboard, bottom nav, route guards, permisos legacy, Supabase ni migraciones.

## Qué Incluye
- `header-movil.tsx` consume el helper compartido y agrega items contextuales móviles solo cuando el resolver permite rutas disponibles.
- `sidebar-moderna.tsx` reutiliza el mismo helper para evitar una segunda ruta de mantenimiento del patrón platform-navigation.
- Test de comportamiento para fallback, scope permitido y supresión de DPS/NextGen/talleres/1:1 global o rutas no disponibles.
- Test unitario del helper compartido para mapear items de vista y fallback gate.
- Nota de progreso en OpenSpec task 3.2 sin marcarla como completa.

## Motivación / Por Qué
Este slice habilita navegación contextual móvil revisable sin cambiar autorización real: la UI solo muestra enlaces ya disponibles y el backend/RLS siguen siendo autoridad para acceso directo. El refactor mantiene una sola ruta obvia para reutilizar el mapeo de navegación contextual en futuros slices de bottom nav/dashboard.

## Chain Context
- Strategy: `stacked-to-main`
- Base: updated `main` after PR #217 merged.
- Current PR boundary: PR #219 / issue #218 — mobile header drawer plus shared platform-navigation view helper.
- Current changed lines: 275 additions + 74 deletions = 349 changed lines, under 400.
- Follow-up work: `menu-inferior-movil.tsx` and dashboard remain pending in task 3.2.

```text
main (includes PR #217 sidebar navigation)
└── 📍 PR #219 / issue #218 mobile header platform navigation
    └── later slices: bottom mobile nav / dashboard
```

## Evidencia Visual (si aplica)
| Antes | Después |
|-------|---------|
| N/A | N/A — behavior covered by component tests |

## Migraciones / Base de Datos
- [x] No aplica
- [ ] Sí (orden exacto):
```
N/A
```
Notas: no database, RLS, remote Supabase, or migration changes.

## Impacto y Riesgos
- Compatibility: legacy mobile drawer remains unchanged unless `NEXT_PUBLIC_PLATFORM_NAVIGATION_ENABLED=true` and kill switch is off.
- Security: no route authorization or backend auth changes; unavailable/global platform access remains hidden.
- Maintainability: shared helper centralizes platform-navigation view mapping for header/sidebar and future UI slices.
- Rollback: revert this PR or use the existing build-time kill switch / flag fallback.
- Review budget: 275 additions + 74 deletions = 349 changed lines, under 400.

## Checklist Autor
- [x] Código formateado (Prettier/ESLint style)
- [x] Sin `console.log` / debugger
- [x] Validaciones con zod para entradas nuevas — N/A, no new external inputs
- [x] Estados loading/error/empty cubiertos — fallback behavior covered
- [x] Tipos TypeScript correctos
- [x] Migraciones probadas local — N/A, no migrations
- [x] Documentación actualizada (`docs/` o README) — OpenSpec task progress updated
- [x] Variables de entorno documentadas — N/A, reused existing platform navigation vars
- [x] Rebase con `main` limpio

## Checklist Revisor
- [x] Propósito claro
- [x] Nombres descriptivos
- [x] Sin lógica duplicada evidente
- [x] Manejo adecuado de errores
- [x] Cambios acotados al alcance
- [x] Sin secretos / datos sensibles

## Pruebas Manuales Realizadas
- [x] `pnpm test -- __tests__/components/platform-navigation-view-items.test.ts --runInBand`
- [x] `pnpm test -- __tests__/components/mobile-platform-navigation.test.tsx __tests__/components/sidebar-platform-navigation.test.tsx __tests__/components/platform-navigation-view-items.test.ts __tests__/lib/platform/navigation.test.ts --runInBand`
- [x] `npx tsc --noEmit`
- [x] `pnpm test:ci`
- [x] `git diff --check`

## Pendientes / Follow-up (opcional)
- `menu-inferior-movil.tsx` platform wiring.
- Dashboard contextual wiring.
- Task 3.3 direct-route verification.

## Notas Adicionales
This PR intentionally does not mark task 3.2 complete because bottom mobile navigation and dashboard are still out of scope.
