### PR TITLE
feat(platform): cablear navegación inferior contextual

### DIFF
--- a/__tests__/components/bottom-mobile-platform-navigation.test.tsx
+++ b/__tests__/components/bottom-mobile-platform-navigation.test.tsx
@@ -1,0 +1,223 @@
+import { act, render, screen, waitFor } from '@testing-library/react'
+
+import { MenuInferiorMovil } from '@/components/ui/menu-inferior-movil'
+import { resolvePlatformNavigation } from '@/lib/platform/navigation'
+import type { PlatformSession } from '@/lib/platform/session/types'
+
+let currentPathname = '/dashboard'
+let currentPlatformSession: PlatformSession | null = null
+let currentLoading = false
+
+jest.mock('next/navigation', () => ({
+  usePathname: () => currentPathname,
+}))
+
+jest.mock('@/hooks/useCurrentUser', () => ({
+  useCurrentUser: () => ({
+    usuario: null,
+    roles: ['miembro'],
+    supportCapabilities: [],
+    platformSession: currentPlatformSession,
+    loading: currentLoading,
+    error: null,
+  }),
+}))
+
+jest.mock('@/lib/platform/navigation', () => {
+  const actual = jest.requireActual('@/lib/platform/navigation')
+  return {
+    ...actual,
+    resolvePlatformNavigation: jest.fn(actual.resolvePlatformNavigation),
+  }
+})
+
+const resolvePlatformNavigationMock = jest.mocked(resolvePlatformNavigation)
+
+const basePlatformSession: PlatformSession = {
+  personaId: 'persona-1',
+  subjectAuthId: 'auth-1',
+  globalRoles: [],
+  contexts: [],
+  capabilities: [],
+}
+const originalPlatformNavigationEnabled = process.env.NEXT_PUBLIC_PLATFORM_NAVIGATION_ENABLED
+const originalPlatformNavigationKillSwitch = process.env.NEXT_PUBLIC_PLATFORM_NAVIGATION_KILL_SWITCH
+
+describe('MenuInferiorMovil platform navigation', () => {
+  beforeEach(() => {
+    currentPathname = '/dashboard'
+    currentPlatformSession = null
+    currentLoading = false
+    resolvePlatformNavigationMock.mockClear()
+    delete process.env.NEXT_PUBLIC_PLATFORM_NAVIGATION_ENABLED
+    delete process.env.NEXT_PUBLIC_PLATFORM_NAVIGATION_KILL_SWITCH
+  })
+
+  afterEach(() => {
+    restoreEnv('NEXT_PUBLIC_PLATFORM_NAVIGATION_ENABLED', originalPlatformNavigationEnabled)
+    restoreEnv('NEXT_PUBLIC_PLATFORM_NAVIGATION_KILL_SWITCH', originalPlatformNavigationKillSwitch)
+  })
+
+  it.each([
+    ['feature flag is off', undefined, undefined, withCapabilities([
+      { key: 'grupos_vida.stage.read', experience: 'grupos_vida', scopeType: 'etapa', scopeId: 'adultos', source: 'gdv' },
+    ])],
+    ['kill switch is active', 'true', 'true', withCapabilities([
+      { key: 'grupos_vida.stage.read', experience: 'grupos_vida', scopeType: 'etapa', scopeId: 'adultos', source: 'gdv' },
+    ])],
+    ['platform session is missing', 'true', undefined, null],
+  ] satisfies Array<[string, string | undefined, string | undefined, PlatformSession | null]>)('keeps legacy bottom navigation when the %s', (_label, enabled, killSwitch, platformSession) => {
+    if (enabled) process.env.NEXT_PUBLIC_PLATFORM_NAVIGATION_ENABLED = enabled
+    if (killSwitch) process.env.NEXT_PUBLIC_PLATFORM_NAVIGATION_KILL_SWITCH = killSwitch
+    currentPlatformSession = platformSession
+
+    render(<MenuInferiorMovil />)
+
+    expect(screen.getByLabelText('Navegar a Dashboard')).toHaveAttribute('href', '/dashboard')
+    expect(screen.getByLabelText('Navegar a Usuarios')).toHaveAttribute('href', '/users')
+    expect(screen.getByLabelText('Navegar a Grupos de Vida')).toHaveAttribute('href', '/grupos-vida')
+    expect(screen.getByLabelText('Navegar a Ayuda')).toHaveAttribute('href', '/ayuda')
+  })
+
+  it('does not show legacy bottom navigation while the user session is still loading with platform navigation enabled', () => {
+    process.env.NEXT_PUBLIC_PLATFORM_NAVIGATION_ENABLED = 'true'
+    currentLoading = true
+    currentPlatformSession = null
+
+    render(<MenuInferiorMovil />)
+
+    expect(screen.queryAllByRole('link')).toHaveLength(0)
+    expect(screen.queryByLabelText('Navegar a Dashboard')).not.toBeInTheDocument()
+    expect(screen.queryByLabelText('Navegar a Usuarios')).not.toBeInTheDocument()
+    expect(screen.queryByLabelText('Navegar a Grupos de Vida')).not.toBeInTheDocument()
+    expect(screen.queryByLabelText('Navegar a Ayuda')).not.toBeInTheDocument()
+  })
+
+  it('shows scoped platform navigation when the flag is on and the route is available', async () => {
+    process.env.NEXT_PUBLIC_PLATFORM_NAVIGATION_ENABLED = 'true'
+    currentPlatformSession = withCapabilities([
+      { key: 'grupos_vida.stage.read', experience: 'grupos_vida', scopeType: 'etapa', scopeId: 'adultos', source: 'gdv' },
+    ], [
+      { experience: 'grupos_vida', scopeType: 'etapa', scopeId: 'adultos', label: 'Grupos de Vida — Adultos' },
+    ])
+
+    render(<MenuInferiorMovil />)
+
+    expect(screen.queryByLabelText('Navegar a Dashboard')).not.toBeInTheDocument()
+    expect(screen.queryByLabelText('Navegar a Usuarios')).not.toBeInTheDocument()
+    expect(screen.queryByLabelText('Navegar a Grupos de Vida')).not.toBeInTheDocument()
+    expect(await screen.findByLabelText('Navegar a Grupos de Vida — Adultos')).toHaveAttribute('href', '/grupos-vida')
+    expect(screen.queryByLabelText('Navegar a Usuarios')).not.toBeInTheDocument()
+    expect(screen.queryByLabelText('Navegar a Ayuda')).not.toBeInTheDocument()
+  })
+
+  it('hides previously resolved platform links while the user session reloads', async () => {
+    process.env.NEXT_PUBLIC_PLATFORM_NAVIGATION_ENABLED = 'true'
+    currentPlatformSession = withCapabilities([
+      { key: 'grupos_vida.stage.read', experience: 'grupos_vida', scopeType: 'etapa', scopeId: 'adultos', source: 'gdv' },
+    ], [
+      { experience: 'grupos_vida', scopeType: 'etapa', scopeId: 'adultos', label: 'Grupos de Vida — Adultos' },
+    ])
+
+    const { rerender } = render(<MenuInferiorMovil />)
+    expect(await screen.findByLabelText('Navegar a Grupos de Vida — Adultos')).toHaveAttribute('href', '/grupos-vida')
+
+    currentLoading = true
+    rerender(<MenuInferiorMovil />)
+
+    expect(screen.queryAllByRole('link')).toHaveLength(0)
+    expect(screen.queryByLabelText('Navegar a Grupos de Vida — Adultos')).not.toBeInTheDocument()
+    expect(screen.queryByLabelText('Navegar a Dashboard')).not.toBeInTheDocument()
+    expect(screen.queryByLabelText('Navegar a Usuarios')).not.toBeInTheDocument()
+    expect(screen.queryByLabelText('Navegar a Ayuda')).not.toBeInTheDocument()
+  })
+
+  it('does not present unavailable and global platform entries in the bottom navigation', async () => {
+    process.env.NEXT_PUBLIC_PLATFORM_NAVIGATION_ENABLED = 'true'
+    currentPlatformSession = withCapabilities([
+      { key: 'grupos_vida.stage.read', experience: 'grupos_vida', scopeType: 'etapa', scopeId: 'adultos', source: 'gdv' },
+      { key: 'dps.team.serve', experience: 'dps', scopeType: 'equipo', scopeId: 'musica', source: 'dream-team' },
+      { key: 'ninos.room.read', experience: 'ninos', scopeType: 'salon', scopeId: 'waumbaland', source: 'family' },
+      { key: 'estudiantes.room.read', experience: 'estudiantes', scopeType: 'salon', scopeId: 'insideout', source: 'family' },
+      { key: 'talleres_crecimiento.participation.read', experience: 'talleres_crecimiento', scopeType: 'taller', scopeId: 'de-hombre-a-hombre', source: 'ledger' },
+      { key: 'dps.admin.manage', experience: 'dps', scopeType: 'equipo', scopeId: 'musica', source: 'unsafe' },
+      { key: 'nextgen.admin.manage', experience: 'nextgen', scopeType: 'experience', source: 'unsafe' },
+      { key: 'talleres_crecimiento.admin.manage', experience: 'talleres_crecimiento', scopeType: 'taller', scopeId: 'global', source: 'unsafe' },
+      { key: 'uno_a_uno.global.read', experience: 'the_living_room', scopeType: 'experience', source: 'unsafe' },
+    ], [
+      { experience: 'grupos_vida', scopeType: 'etapa', scopeId: 'adultos', label: 'Grupos de Vida — Adultos' },
+    ])
+
+    render(<MenuInferiorMovil />)
+
+    expect(await screen.findByLabelText('Navegar a Grupos de Vida — Adultos')).toHaveAttribute('href', '/grupos-vida')
+    await waitFor(() => expect(screen.queryByLabelText('Navegar a DPS Música')).not.toBeInTheDocument())
+    expect(screen.queryByLabelText('Navegar a Niños')).not.toBeInTheDocument()
+    expect(screen.queryByLabelText('Navegar a Estudiantes')).not.toBeInTheDocument()
+    expect(screen.queryByLabelText('Navegar a Talleres de Crecimiento')).not.toBeInTheDocument()
+    expect(screen.queryByLabelText('Navegar a Administración DPS')).not.toBeInTheDocument()
+    expect(screen.queryByLabelText('Navegar a Administración NextGen')).not.toBeInTheDocument()
+    expect(screen.queryByLabelText('Navegar a Administración Talleres')).not.toBeInTheDocument()
+    expect(screen.queryByLabelText('Navegar a 1:1 Global')).not.toBeInTheDocument()
+    expect(screen.queryByLabelText('Navegar a Usuarios')).not.toBeInTheDocument()
+  })
+
+  it('does not fall back to legacy global links when no platform route is available for the session', async () => {
+    process.env.NEXT_PUBLIC_PLATFORM_NAVIGATION_ENABLED = 'true'
+    currentPlatformSession = withCapabilities([
+      { key: 'dps.team.serve', experience: 'dps', scopeType: 'equipo', scopeId: 'musica', source: 'dream-team' },
+    ])
+
+    render(<MenuInferiorMovil />)
+
+    await waitForPlatformNavigationToSettle()
+    expect(screen.queryByRole('link')).not.toBeInTheDocument()
+    expect(screen.queryByLabelText('Navegar a Dashboard')).not.toBeInTheDocument()
+    expect(screen.queryByLabelText('Navegar a Usuarios')).not.toBeInTheDocument()
+    expect(screen.queryByLabelText('Navegar a Ayuda')).not.toBeInTheDocument()
+    expect(screen.queryByLabelText('Navegar a DPS Música')).not.toBeInTheDocument()
+  })
+
+  it('does not retain stale platform links while transitioning to a session with no visible items', async () => {
+    process.env.NEXT_PUBLIC_PLATFORM_NAVIGATION_ENABLED = 'true'
+    currentPlatformSession = withCapabilities([
+      { key: 'grupos_vida.stage.read', experience: 'grupos_vida', scopeType: 'etapa', scopeId: 'adultos', source: 'gdv' },
+    ], [
+      { experience: 'grupos_vida', scopeType: 'etapa', scopeId: 'adultos', label: 'Grupos de Vida — Adultos' },
+    ])
+
+    const { rerender } = render(<MenuInferiorMovil />)
+    expect(await screen.findByLabelText('Navegar a Grupos de Vida — Adultos')).toHaveAttribute('href', '/grupos-vida')
+
+    currentPlatformSession = withCapabilities([
+      { key: 'dps.team.serve', experience: 'dps', scopeType: 'equipo', scopeId: 'musica', source: 'dream-team' },
+    ])
+    rerender(<MenuInferiorMovil />)
+
+    await waitForPlatformNavigationToSettle(2)
+    expect(screen.queryAllByRole('link')).toHaveLength(0)
+    expect(screen.queryByLabelText('Navegar a Grupos de Vida — Adultos')).not.toBeInTheDocument()
+    expect(screen.queryByLabelText('Navegar a Usuarios')).not.toBeInTheDocument()
+    expect(screen.queryByLabelText('Navegar a DPS Música')).not.toBeInTheDocument()
+  })
+})
+
+function restoreEnv(key: string, value: string | undefined) {
+  if (value === undefined) {
+    delete process.env[key]
+    return
+  }
+  process.env[key] = value
+}
+
+function withCapabilities(capabilities: PlatformSession['capabilities'], contexts: PlatformSession['contexts'] = []): PlatformSession {
+  return { ...basePlatformSession, contexts, capabilities }
+}
+
+async function waitForPlatformNavigationToSettle(expectedCalls = 1) {
+  await waitFor(() => expect(resolvePlatformNavigationMock).toHaveBeenCalledTimes(expectedCalls))
+  await act(async () => {
+    await Promise.all(resolvePlatformNavigationMock.mock.results.map((result) => result.value))
+    await Promise.resolve()
+  })
+}

--- a/components/ui/menu-inferior-movil.tsx
+++ b/components/ui/menu-inferior-movil.tsx
@@ -1,12 +1,22 @@
 "use client"
 
-import React from 'react'
+import { type ComponentType } from 'react'
 import Link from 'next/link'
 import { usePathname } from 'next/navigation'
 import { LayoutDashboard, Users, UsersRound, HelpCircle } from 'lucide-react'
 import { cn } from '@/lib/utils'
+import { useCurrentUser } from '@/hooks/useCurrentUser'
+import { getBuildTimePlatformNavigationFlags, usePlatformNavigationViewItems, type PlatformNavigationViewItem } from '@/components/ui/platform-navigation-view-items'
+import { resolvePlatformNavigationGate } from '@/lib/platform/navigation'
 
-const elementosMenu = [
+type MenuInferiorMovilItem = {
+  nombre: string
+  icono: ComponentType<{ className?: string }>
+  enlace: string
+  id: string
+}
+
+const elementosMenu: MenuInferiorMovilItem[] = [
   { nombre: "Dashboard", icono: LayoutDashboard, enlace: "/dashboard", id: "dashboard" },
   { nombre: "Usuarios", icono: Users, enlace: "/users", id: "users" },
   { nombre: "Grupos de Vida", icono: UsersRound, enlace: "/grupos-vida", id: "grupos-vida" },
@@ -15,11 +25,29 @@ const elementosMenu = [
 
 export function MenuInferiorMovil() {
   const pathname = usePathname()
+  const { platformSession, loading } = useCurrentUser()
+  const platformNavigationItems = usePlatformNavigationViewItems(platformSession)
+  const platformNavigationFlags = getBuildTimePlatformNavigationFlags()
+  const platformNavigationGate = resolvePlatformNavigationGate({
+    flags: platformNavigationFlags,
+    platformSession,
+  })
+  const shouldRenderLegacyNavigation = !platformNavigationFlags.enabled ||
+    platformNavigationFlags.killSwitch ||
+    (!loading && !platformNavigationGate.ok)
+  const shouldSuppressNavigationWhileLoading = platformNavigationFlags.enabled &&
+    !platformNavigationFlags.killSwitch &&
+    loading
+  const navigationItems = shouldSuppressNavigationWhileLoading
+    ? []
+    : shouldRenderLegacyNavigation
+      ? elementosMenu
+      : toMenuInferiorMovilItems(platformNavigationItems)
 
   return (
     <nav aria-label="Navegación inferior" className="md:hidden fixed bottom-0 left-0 right-0 z-50 bg-white/60 dark:bg-[rgba(35,35,45,0.60)] backdrop-blur-[40px] [-webkit-backdrop-filter:blur(40px)] backdrop-saturate-[1.8] border-t border-[var(--glass-border)] shadow-[var(--glass-shadow)] [transform:translateZ(0)] touch-manipulation">
       <div className="flex items-center justify-around px-2 py-2 safe-area-pb">
-        {elementosMenu.map((elemento) => {
+        {navigationItems.map((elemento) => {
           const Icono = elemento.icono
 
           const esActivo = pathname === elemento.enlace ||
@@ -54,4 +82,13 @@ export function MenuInferiorMovil() {
       </div>
     </nav>
   )
+}
+
+function toMenuInferiorMovilItems(items: PlatformNavigationViewItem[]): MenuInferiorMovilItem[] {
+  return items.map((item) => ({
+    nombre: item.label,
+    icono: item.icon,
+    enlace: item.href,
+    id: item.id,
+  }))
 }

--- a/components/ui/platform-navigation-view-items.ts
+++ b/components/ui/platform-navigation-view-items.ts
@@ -1,6 +1,6 @@
 "use client"
 
-import { useEffect, useState, type ComponentType, type Dispatch, type SetStateAction } from 'react'
+import { useEffect, useState, type ComponentType } from 'react'
 import { ClipboardList, Megaphone, Settings, User, UserCheck, Users } from 'lucide-react'
 
 import { resolvePlatformNavigation, resolvePlatformNavigationGate } from '@/lib/platform/navigation'
@@ -22,6 +22,11 @@ export type PlatformNavigationViewItem = {
   badge?: never
   badgeVariant?: never
   className?: never
+}
+
+type PlatformNavigationViewItemsState = {
+  sessionKey: string
+  items: PlatformNavigationViewItem[]
 }
 
 const PLATFORM_NAVIGATION_ICONS = {
@@ -63,36 +68,71 @@ export async function resolvePlatformNavigationViewItems(
 export function usePlatformNavigationViewItems(
   platformSession: PlatformNavigationSession | null | undefined
 ): PlatformNavigationViewItem[] {
-  const [items, setItems] = useState<PlatformNavigationViewItem[]>([])
+  const sessionKey = getPlatformNavigationSessionKey(platformSession)
+  const [state, setState] = useState<PlatformNavigationViewItemsState>({ sessionKey, items: [] })
 
   useEffect(() => {
     const flags = getBuildTimePlatformNavigationFlags()
     const gate = resolvePlatformNavigationGate({ flags, platformSession })
-    if (!gate.ok) {
-      clearPlatformNavigationViewItems(setItems)
-      return
-    }
+    if (!gate.ok) return
 
     let isCurrent = true
 
     resolvePlatformNavigationViewItems(gate.platformSession, flags)
       .then((resolvedItems) => {
-        if (isCurrent) setItems(resolvedItems)
+        if (!isCurrent) return
+        setState((current) => toPlatformNavigationViewItemsState(current, sessionKey, resolvedItems))
       })
       .catch(() => {
-        if (isCurrent) setItems([])
+        if (!isCurrent) return
+        setState((current) => toPlatformNavigationViewItemsState(current, sessionKey, []))
       })
 
     return () => {
       isCurrent = false
     }
-  }, [platformSession])
+  }, [platformSession, sessionKey])
 
-  return items
+  return state.sessionKey === sessionKey ? state.items : []
 }
 
-function clearPlatformNavigationViewItems(setItems: Dispatch<SetStateAction<PlatformNavigationViewItem[]>>) {
-  setItems((current) => (current.length > 0 ? [] : current))
+function toPlatformNavigationViewItemsState(
+  current: PlatformNavigationViewItemsState,
+  sessionKey: string,
+  items: PlatformNavigationViewItem[]
+): PlatformNavigationViewItemsState {
+  if (current.sessionKey === sessionKey && arePlatformNavigationViewItemsEqual(current.items, items)) {
+    return current
+  }
+
+  return { sessionKey, items }
+}
+
+function arePlatformNavigationViewItemsEqual(
+  currentItems: PlatformNavigationViewItem[],
+  nextItems: PlatformNavigationViewItem[]
+): boolean {
+  if (currentItems.length !== nextItems.length) return false
+  return currentItems.every((currentItem, index) => {
+    const nextItem = nextItems[index]
+    return currentItem.id === nextItem.id &&
+      currentItem.label === nextItem.label &&
+      currentItem.href === nextItem.href &&
+      currentItem.icon === nextItem.icon
+  })
+}
+
+function getPlatformNavigationSessionKey(session: PlatformNavigationSession | null | undefined): string {
+  if (!session) return 'platform-session:none'
+
+  const contextsKey = session.contexts
+    .map((context) => [context.experience, context.scopeType, context.scopeId ?? '', context.label].join(':'))
+    .join('|')
+  const capabilitiesKey = session.capabilities
+    .map((capability) => [capability.key, capability.experience, capability.scopeType, capability.scopeId ?? '', capability.source].join(':'))
+    .join('|')
+
+  return [session.personaId, session.subjectAuthId, session.globalRoles.join(','), contextsKey, capabilitiesKey].join('::')
 }
 
 function toPlatformNavigationViewItem(item: PlatformNavigationItem): PlatformNavigationViewItem {

--- a/openspec/changes/fase-01-platform-foundation/tasks.md
+++ b/openspec/changes/fase-01-platform-foundation/tasks.md
@@ -50,6 +50,7 @@ Chain strategy: stacked-to-main para PR1a; confirmar por slice futuro
   - Issue #214: primer slice interno crea `lib/platform/navigation.ts` con resolver/modelo puro, flag/kill switch, fallback legado deny-by-default y tests; sin wiring visible de sidebar/header/mobile/dashboard.
   - Issue #216: slice sidebar-only cablea `sidebar-moderna.tsx` al resolver contextual detrás de flag/kill switch, conserva fallback legado y agrega tests de scope permitido/denegaciones globales; header/mobile/dashboard siguen pendientes.
   - Issue #218: slice header mobile cablea `header-movil.tsx` al resolver contextual detrás de flag/kill switch; conserva fallback legado y prueba scope permitido, kill switch y supresión de rutas no disponibles/accesos globales. `menu-inferior-movil.tsx` y dashboard siguen pendientes.
+  - Issue #220: slice menú inferior móvil cablea `menu-inferior-movil.tsx` al helper contextual compartido detrás de flag/kill switch para presentación de navegación UI; conserva fallback legado solo con flag off, kill switch o carga finalizada sin sesión de plataforma, y no presenta enlaces legacy/globales mientras `useCurrentUser` carga, una sesión de plataforma resuelve, cambia de sesión o queda sin ítems visibles. No implementa ni afirma autorización de rutas directas; dashboard y task 3.3 siguen pendientes.
 - [ ] 3.3 Verificar rutas directas denegadas, fallback legado si adapters fallan, y no mostrar DPS admin, NextGen, taller admin ni 1:1 global.
 
 ## Fase 4: Familia y menores


### PR DESCRIPTION
Closes #220

## Resumen
Cablea el menú inferior móvil a la navegación contextual platform existente, reutilizando el helper compartido y manteniendo el alcance de task 3.2 como UI de navegación solamente.

## Qué Incluye
- `menu-inferior-movil.tsx` consume `useCurrentUser`, el gate de navegación platform y `usePlatformNavigationViewItems`.
- Fallback legacy solo cuando el flag está apagado, el kill switch está activo o la carga confirma que no hay platform session.
- Supresión fail-closed durante loading, sesión platform activa sin ítems visibles y transiciones de sesión para evitar links legacy/globales o stale.
- Tests enfocados para flag off, kill switch, missing session, loading, GDV permitido, rutas no disponibles/globales y transiciones stale.
- OpenSpec task 3.2 actualizado como slice de presentación UI; dashboard y task 3.3 siguen pendientes.

## Motivación / Por Qué
Avanza Fase 1 Platform Foundation task 3.2 después del resolver, sidebar y header móvil, sin ampliar permisos ni route guards.

## Evidencia Visual (si aplica)
| Antes | Después |
|-------|---------|
| No aplica | No aplica |

## Migraciones / Base de Datos
- [x] No aplica

Notas: sin Supabase remoto, migraciones, RLS/RPC ni mutaciones de datos.

## Impacto y Riesgos
- No rompe compatibilidad: el fallback legacy se conserva cuando Platform Navigation está deshabilitado o sin platform session.
- El flag/kill switch es build-time/inlined por `NEXT_PUBLIC_*`, no rollback runtime operacional.
- No implementa autorización de rutas directas; eso queda pendiente para task 3.3.
- Diff: 316 additions / 15 deletions, bajo el presupuesto de 400 líneas.

## Checklist Autor
- [x] Código formateado (Prettier/ESLint)
- [x] Sin `console.log` / debugger
- [x] Validaciones con zod para entradas nuevas — no aplica
- [x] Estados loading/error/empty cubiertos
- [x] Tipos TypeScript correctos
- [x] Migraciones probadas local — no aplica
- [x] Documentación actualizada (`openspec/changes/fase-01-platform-foundation/tasks.md`)
- [x] Variables de entorno documentadas — no aplica
- [x] Rebase con `main` limpio

## Checklist Revisor
- [x] Propósito claro
- [x] Nombres descriptivos
- [x] Sin lógica duplicada evidente
- [x] Manejo adecuado de errores
- [x] Cambios acotados al alcance
- [x] Sin secretos / datos sensibles

## Pruebas Manuales Realizadas
- [x] `pnpm test -- __tests__/components/bottom-mobile-platform-navigation.test.tsx --runInBand`
- [x] `pnpm test -- __tests__/components/bottom-mobile-platform-navigation.test.tsx __tests__/components/platform-navigation-view-items.test.ts __tests__/components/mobile-platform-navigation.test.tsx __tests__/components/sidebar-platform-navigation.test.tsx __tests__/lib/platform/navigation.test.ts __tests__/components/support-navigation.test.tsx --runInBand`
- [x] `npx eslint components/ui/platform-navigation-view-items.ts components/ui/menu-inferior-movil.tsx __tests__/components/bottom-mobile-platform-navigation.test.tsx --max-warnings 0`
- [x] `npx tsc --noEmit`
- [x] `pnpm test:ci`
- [x] `git diff --check`

## Pendientes / Follow-up (opcional)
- Dashboard slice de task 3.2.
- Task 3.3: rutas directas denegadas, fallback legacy si adapters fallan y verificación de no accesos globales sin grants.

## Notas Adicionales
Fresh 4R review final sobre el working tree quedó sin findings BLOCKER/CRITICAL/WARNING antes del commit.
