### PR TITLE
feat(platform): guard server-side reutilizable y verificación de fallback legado

### DIFF
--- a/__tests__/app/configuracion-pages.test.tsx
+++ b/__tests__/app/configuracion-pages.test.tsx
@@ -1,0 +1,91 @@
+import { act, render, screen } from '@testing-library/react'
+import type { PlatformSession } from '@/lib/platform/session/types'
+
+const createSupabaseServerClient = jest.fn()
+const getUserWithRoles = jest.fn()
+const redirect = jest.fn((path: string) => { throw new Error(`NEXT_REDIRECT:${path}`) })
+
+jest.mock('@/lib/supabase/server', () => ({ createSupabaseServerClient: () => createSupabaseServerClient() }))
+jest.mock('@/lib/getUserWithRoles', () => ({ getUserWithRoles: (...args: unknown[]) => getUserWithRoles(...args) }))
+jest.mock('next/navigation', () => ({ redirect: (path: string) => redirect(path) }))
+jest.mock('@/components/layout/dashboard-layout', () => ({ DashboardLayout: ({ children }: { children: React.ReactNode }) => <main>{children}</main> }))
+jest.mock('@/components/ui/sistema-diseno', () => ({
+  ContenedorDashboard: ({ children, titulo }: { children: React.ReactNode; titulo: string }) => <section><h1>{titulo}</h1>{children}</section>,
+}))
+jest.mock('@/app/(auth)/configuracion/ConfiguracionGlobalClient', () => ({ ConfiguracionGlobalClient: () => <div data-testid="configuracion-global-client" /> }))
+jest.mock('@/app/(auth)/configuracion/directores-generales/GestionDGClient', () => ({ GestionDGClient: () => <div data-testid="gestion-dg-client" /> }))
+jest.mock('@/lib/actions/dg-segmentos.actions', () => ({ obtenerDirectoresGenerales: jest.fn().mockResolvedValue([]), obtenerSegmentosDisponibles: jest.fn().mockResolvedValue([]) }))
+jest.mock('@/lib/actions/dg-directores.actions', () => ({ obtenerDEsAsignadosPorDG: jest.fn().mockResolvedValue({}) }))
+
+const originalEnabled = process.env.NEXT_PUBLIC_PLATFORM_NAVIGATION_ENABLED
+const originalKillSwitch = process.env.NEXT_PUBLIC_PLATFORM_NAVIGATION_KILL_SWITCH
+
+describe('configuracion pages render through the platform route guard without changing legacy behavior', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  afterEach(() => {
+    restoreEnv('NEXT_PUBLIC_PLATFORM_NAVIGATION_ENABLED', originalEnabled)
+    restoreEnv('NEXT_PUBLIC_PLATFORM_NAVIGATION_KILL_SWITCH', originalKillSwitch)
+  })
+
+  it('redirects /configuracion/directores-generales to /dashboard when the platform flag is off', async () => {
+    delete process.env.NEXT_PUBLIC_PLATFORM_NAVIGATION_ENABLED
+    getUserWithRoles.mockResolvedValue({ user: { id: 'auth-1' }, roles: ['admin'], platformSession: null })
+    const { default: DirectoresGeneralesPage } = await import('@/app/(auth)/configuracion/directores-generales/page')
+
+    await expect(DirectoresGeneralesPage()).rejects.toThrow(/NEXT_REDIRECT:\/dashboard/)
+  })
+
+  it.each([
+    ['feature flag is off', {}, null],
+    ['kill switch is active', { enabled: 'true', killSwitch: 'true' }, null],
+    ['platform session is missing', { enabled: 'true' }, null],
+    ['platform session has no capabilities', { enabled: 'true' }, buildPlatformSession([])],
+    ['platform session lacks the required capability', { enabled: 'true' }, buildPlatformSession([{ key: 'support.manage', experience: 'support', scopeType: 'experience', source: 'legacy' }])],
+  ] as Array<[string, { enabled?: 'true'; killSwitch?: 'true' }, PlatformSession | null]>)(
+    'redirects /configuracion to /dashboard when the %s',
+    async (_label, env, platformSession) => {
+    setNavigationEnv({ enabled: env.enabled, killSwitch: env.killSwitch })
+    getUserWithRoles.mockResolvedValue({ user: { id: 'auth-1' }, roles: ['admin'], platformSession })
+    const { default: PaginaConfiguracion } = await import('@/app/(auth)/configuracion/page')
+
+    await expect(PaginaConfiguracion()).rejects.toThrow(/NEXT_REDIRECT:\/dashboard/)
+  })
+
+  it('renders /configuracion when the platform flag is on and the required capability is present', async () => {
+    createSupabaseServerClient.mockResolvedValue({
+      from: jest.fn(() => ({ select: jest.fn(() => ({ limit: jest.fn(() => ({ single: jest.fn().mockResolvedValue({ data: null, error: null }) })) })) })),
+    })
+    setNavigationEnv({ enabled: 'true' })
+    getUserWithRoles.mockResolvedValue({
+      user: { id: 'auth-1' },
+      roles: ['admin'],
+      platformSession: buildPlatformSession([{ key: 'configuracion.platform.manage', experience: 'configuracion', scopeType: 'experience', source: 'legacy' }]),
+    })
+    const { default: PaginaConfiguracion } = await import('@/app/(auth)/configuracion/page')
+
+    await act(async () => { render(await PaginaConfiguracion()) })
+
+    expect(screen.getByRole('heading', { name: 'Configuración' })).toBeInTheDocument()
+    expect(screen.getByTestId('configuracion-global-client')).toBeInTheDocument()
+  })
+})
+
+function restoreEnv(key: string, value: string | undefined) {
+  if (value === undefined) {
+    delete process.env[key]
+    return
+  }
+  process.env[key] = value
+}
+
+function setNavigationEnv(env: { enabled?: 'true'; killSwitch?: 'true' }) {
+  restoreEnv('NEXT_PUBLIC_PLATFORM_NAVIGATION_ENABLED', env.enabled)
+  restoreEnv('NEXT_PUBLIC_PLATFORM_NAVIGATION_KILL_SWITCH', env.killSwitch)
+}
+
+function buildPlatformSession(capabilities: PlatformSession['capabilities']): PlatformSession {
+  return { personaId: 'persona-1', subjectAuthId: 'auth-1', globalRoles: ['admin'], contexts: [], capabilities }
+}

--- a/__tests__/app/support-pages.test.tsx
+++ b/__tests__/app/support-pages.test.tsx
@@ -1,4 +1,5 @@
 import { act, render, screen } from '@testing-library/react'
+import type { PlatformSession } from '@/lib/platform/session/types'
 
 import AyudaPage from '@/app/(auth)/ayuda/page'
 import SupportAdminPage from '@/app/(auth)/ayuda/admin/page'
@@ -425,9 +426,14 @@ describe('reporter support pages', () => {
   })
 
   it('explains the required access for denied support capability configuration', async () => {
+    setSupportNavigationEnv({ enabled: 'true' })
     const supabase = createSupportCapabilitiesPageSupabase(true)
     createSupabaseServerClient.mockResolvedValue(supabase)
-    getUserWithRoles.mockResolvedValue({ user: { id: 'auth-1' }, roles: ['miembro'] })
+    getUserWithRoles.mockResolvedValue({
+      user: { id: 'auth-1' },
+      roles: ['miembro'],
+      platformSession: buildSupportPlatformSession([{ key: 'support.manage', experience: 'support', scopeType: 'experience', source: 'legacy' }]),
+    })
 
     await act(async () => {
       render(await SupportCapabilitiesPage())
@@ -439,9 +445,14 @@ describe('reporter support pages', () => {
   })
 
   it('renders support capability configuration for higher-role support managers', async () => {
+    setSupportNavigationEnv({ enabled: 'true' })
     const supabase = createSupportCapabilitiesPageSupabase(true)
     createSupabaseServerClient.mockResolvedValue(supabase)
-    getUserWithRoles.mockResolvedValue({ user: { id: 'auth-1' }, roles: ['director-general'] })
+    getUserWithRoles.mockResolvedValue({
+      user: { id: 'auth-1' },
+      roles: ['director-general'],
+      platformSession: buildSupportPlatformSession([{ key: 'support.manage', experience: 'support', scopeType: 'experience', source: 'legacy' }]),
+    })
 
     await act(async () => {
       render(await SupportCapabilitiesPage())
@@ -452,6 +463,65 @@ describe('reporter support pages', () => {
     expect(screen.getByRole('button', { name: /Revocar capacidad/i })).toBeInTheDocument()
   })
 })
+
+describe('support capability configuration page platform route guard', () => {
+  const originalEnabled = process.env.NEXT_PUBLIC_PLATFORM_NAVIGATION_ENABLED
+  const originalKillSwitch = process.env.NEXT_PUBLIC_PLATFORM_NAVIGATION_KILL_SWITCH
+
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  afterEach(() => {
+    restoreSupportNavigationEnv('NEXT_PUBLIC_PLATFORM_NAVIGATION_ENABLED', originalEnabled)
+    restoreSupportNavigationEnv('NEXT_PUBLIC_PLATFORM_NAVIGATION_KILL_SWITCH', originalKillSwitch)
+  })
+
+  it.each([
+    ['feature flag is off', {}, null],
+    ['kill switch is active', { enabled: 'true', killSwitch: 'true' }, null],
+    ['platform session is missing', { enabled: 'true' }, null],
+    ['platform session has no capabilities', { enabled: 'true' }, buildSupportPlatformSession([])],
+    ['platform session lacks the required capability', { enabled: 'true' }, buildSupportPlatformSession([{ key: 'support.view', experience: 'support', scopeType: 'experience', source: 'legacy' }])],
+  ] satisfies Array<[string, { enabled?: 'true'; killSwitch?: 'true' }, PlatformSession | null]>)('redirects to /dashboard when the %s', async (_label, env, platformSession) => {
+    setSupportNavigationEnv(env)
+    createSupabaseServerClient.mockResolvedValue(createSupportCapabilitiesPageSupabase(true))
+    getUserWithRoles.mockResolvedValue({ user: { id: 'auth-1' }, roles: ['director-general'], platformSession })
+
+    await expect(SupportCapabilitiesPage()).rejects.toThrow(/NEXT_REDIRECT:\/dashboard/)
+  })
+
+  it('renders the configuration UI when the platform flag is on and the required capability is present', async () => {
+    setSupportNavigationEnv({ enabled: 'true' })
+    createSupabaseServerClient.mockResolvedValue(createSupportCapabilitiesPageSupabase(true))
+    getUserWithRoles.mockResolvedValue({
+      user: { id: 'auth-1' },
+      roles: ['director-general'],
+      platformSession: buildSupportPlatformSession([{ key: 'support.manage', experience: 'support', scopeType: 'experience', source: 'legacy' }]),
+    })
+
+    await act(async () => { render(await SupportCapabilitiesPage()) })
+
+    expect(screen.getByRole('heading', { name: /Capacidades permitidas/i })).toBeInTheDocument()
+  })
+})
+
+function restoreSupportNavigationEnv(key: string, value: string | undefined) {
+  if (value === undefined) {
+    delete process.env[key]
+    return
+  }
+  process.env[key] = value
+}
+
+function setSupportNavigationEnv(env: { enabled?: 'true'; killSwitch?: 'true' }) {
+  restoreSupportNavigationEnv('NEXT_PUBLIC_PLATFORM_NAVIGATION_ENABLED', env.enabled)
+  restoreSupportNavigationEnv('NEXT_PUBLIC_PLATFORM_NAVIGATION_KILL_SWITCH', env.killSwitch)
+}
+
+function buildSupportPlatformSession(capabilities: PlatformSession['capabilities']): PlatformSession {
+  return { personaId: 'persona-1', subjectAuthId: 'auth-1', globalRoles: ['director-general'], contexts: [], capabilities }
+}
 
 function createSupportCapabilitiesPageSupabase(hasSupportManage: boolean) {
   return {

--- a/__tests__/lib/dashboard/contextual-navigation.test.ts
+++ b/__tests__/lib/dashboard/contextual-navigation.test.ts
@@ -1,5 +1,5 @@
 import { resolveDashboardContextualAccess } from '@/lib/dashboard/contextual-navigation'
-import type { PlatformNavigationFlags } from '@/lib/platform/navigation'
+import type { PlatformNavigationFlags } from '@/lib/platform/flags'
 import type { PlatformSession } from '@/lib/platform/session/types'
 
 const basePlatformSession: PlatformSession = {

--- a/__tests__/lib/platform/routeGuard.test.ts
+++ b/__tests__/lib/platform/routeGuard.test.ts
@@ -1,0 +1,85 @@
+import { checkPlatformRouteAccess } from '@/lib/platform/routeGuard'
+import { getPlatformNavigationFlags } from '@/lib/platform/flags'
+import type { PlatformSession } from '@/lib/platform/session/types'
+
+const basePlatformSession: PlatformSession = {
+  personaId: 'persona-1',
+  subjectAuthId: 'auth-1',
+  globalRoles: ['admin'],
+  contexts: [],
+  capabilities: [],
+}
+
+const supportViewCapability: PlatformSession['capabilities'][number] = {
+  key: 'support.view', experience: 'support', scopeType: 'experience', source: 'legacy',
+}
+
+const supportManageCapability: PlatformSession['capabilities'][number] = {
+  key: 'support.manage', experience: 'support', scopeType: 'experience', source: 'legacy',
+}
+
+describe('getPlatformNavigationFlags', () => {
+  const originalEnabled = process.env.NEXT_PUBLIC_PLATFORM_NAVIGATION_ENABLED
+  const originalKillSwitch = process.env.NEXT_PUBLIC_PLATFORM_NAVIGATION_KILL_SWITCH
+
+  afterEach(() => {
+    restoreEnv('NEXT_PUBLIC_PLATFORM_NAVIGATION_ENABLED', originalEnabled)
+    restoreEnv('NEXT_PUBLIC_PLATFORM_NAVIGATION_KILL_SWITCH', originalKillSwitch)
+  })
+
+  it('reads the platform navigation feature flag and kill switch from runtime env', () => {
+    process.env.NEXT_PUBLIC_PLATFORM_NAVIGATION_ENABLED = 'true'
+    process.env.NEXT_PUBLIC_PLATFORM_NAVIGATION_KILL_SWITCH = 'true'
+
+    expect(getPlatformNavigationFlags()).toEqual({ enabled: true, killSwitch: true })
+  })
+
+  it('defaults both flags to false when env vars are absent or not exactly "true"', () => {
+    delete process.env.NEXT_PUBLIC_PLATFORM_NAVIGATION_ENABLED
+    delete process.env.NEXT_PUBLIC_PLATFORM_NAVIGATION_KILL_SWITCH
+    expect(getPlatformNavigationFlags()).toEqual({ enabled: false, killSwitch: false })
+
+    process.env.NEXT_PUBLIC_PLATFORM_NAVIGATION_ENABLED = 'TRUE'
+    process.env.NEXT_PUBLIC_PLATFORM_NAVIGATION_KILL_SWITCH = '1'
+    expect(getPlatformNavigationFlags()).toEqual({ enabled: false, killSwitch: false })
+  })
+})
+
+describe('checkPlatformRouteAccess', () => {
+  it.each([
+    ['feature flag is disabled', { enabled: false }, basePlatformSession, 'feature_flag_disabled'],
+    ['kill switch is active', { enabled: true, killSwitch: true }, basePlatformSession, 'kill_switch_enabled'],
+    ['no platformSession', { enabled: true }, null, 'platform_session_required'],
+    ['empty capabilities', { enabled: true }, { ...basePlatformSession, capabilities: [] }, 'no_platform_grants'],
+    ['missing capability', { enabled: true }, { ...basePlatformSession, capabilities: [supportViewCapability] }, 'missing_required_capability'],
+  ] satisfies Array<[string, { enabled: boolean; killSwitch?: boolean }, PlatformSession | null, string]>)(
+    'denies with reason when %s',
+    (_label, flags, platformSession, reason) => {
+      const result = checkPlatformRouteAccess({ flags, platformSession, requiredCapability: 'support.manage' })
+      expect(result).toEqual({ allowed: false, reason })
+    }
+  )
+
+  it('allows access when the required capability is present and exposes no reason', () => {
+    const result = checkPlatformRouteAccess({
+      flags: { enabled: true },
+      platformSession: { ...basePlatformSession, capabilities: [supportViewCapability, supportManageCapability] },
+      requiredCapability: 'support.manage',
+    })
+
+    expect(result).toStrictEqual({ allowed: true })
+  })
+
+  it.each(['', '   '])('allows access when the required capability is empty or whitespace', (requiredCapability) => {
+    expect(checkPlatformRouteAccess({ flags: { enabled: true }, platformSession: basePlatformSession, requiredCapability })).toEqual({ allowed: true })
+  })
+
+})
+
+function restoreEnv(key: string, value: string | undefined) {
+  if (value === undefined) {
+    delete process.env[key]
+    return
+  }
+  process.env[key] = value
+}

--- a/app/(auth)/configuracion/directores-generales/page.tsx
+++ b/app/(auth)/configuracion/directores-generales/page.tsx
@@ -1,5 +1,6 @@
 import { createSupabaseServerClient } from "@/lib/supabase/server"
 import { getUserWithRoles } from "@/lib/getUserWithRoles"
+import { checkPlatformRouteAccess } from "@/lib/platform/routeGuard"
 import { redirect } from "next/navigation"
 import { DashboardLayout } from "@/components/layout/dashboard-layout"
 import { ContenedorDashboard } from "@/components/ui/sistema-diseno"
@@ -23,6 +24,12 @@ export default async function DirectoresGeneralesPage() {
   const rolesPermitidos = ["admin", "pastor", "director-general"]
   const tieneAcceso = userData.roles.some((r) => rolesPermitidos.includes(r))
   if (!tieneAcceso) redirect("/dashboard")
+
+  const routeGuard = checkPlatformRouteAccess({
+    platformSession: userData.platformSession,
+    requiredCapability: "configuracion.directores-generales.manage",
+  })
+  if (!routeGuard.allowed) redirect("/dashboard")
 
   const [directores, segmentos, desAsignadosPorDG] = await Promise.all([
     obtenerDirectoresGenerales(),

--- a/app/(auth)/configuracion/page.tsx
+++ b/app/(auth)/configuracion/page.tsx
@@ -1,5 +1,6 @@
 import { createSupabaseServerClient } from "@/lib/supabase/server"
 import { getUserWithRoles } from "@/lib/getUserWithRoles"
+import { checkPlatformRouteAccess } from "@/lib/platform/routeGuard"
 import { redirect } from "next/navigation"
 import { DashboardLayout } from "@/components/layout/dashboard-layout"
 import { ContenedorDashboard } from "@/components/ui/sistema-diseno"
@@ -25,6 +26,12 @@ export default async function PaginaConfiguracion() {
   if (!esAdmin && !esPastor) {
     redirect("/dashboard")
   }
+
+  const routeGuard = checkPlatformRouteAccess({
+    platformSession: userData.platformSession,
+    requiredCapability: "configuracion.platform.manage",
+  })
+  if (!routeGuard.allowed) redirect("/dashboard")
 
   // Obtener configuración de la plataforma (org data + branding)
   const { data: config } = await supabase

--- a/app/(auth)/configuracion/soporte/page.tsx
+++ b/app/(auth)/configuracion/soporte/page.tsx
@@ -1,6 +1,7 @@
 import { grantSupportCapability, revokeSupportCapability } from '@/lib/actions/support-capabilities.actions'
 import { SUPPORT_CAPABILITIES, SUPPORT_CAPABILITY_LABELS } from '@/lib/support/capabilities'
 import { getUserWithRoles } from '@/lib/getUserWithRoles'
+import { checkPlatformRouteAccess } from '@/lib/platform/routeGuard'
 import { createSupabaseServerClient } from '@/lib/supabase/server'
 import { DashboardLayout } from '@/components/layout/dashboard-layout'
 import { BotonSistema, ContenedorDashboard, InputSistema, SelectSistema, TarjetaSistema, TextoSistema, TituloSistema } from '@/components/ui/sistema-diseno'
@@ -21,6 +22,13 @@ export default async function SupportCapabilitiesPage() {
 
   const hasHigherRole = userData.roles.some((role: string) => SUPPORT_CONFIGURATION_ROLES.includes(role))
   const hasSupportManage = await hasSupportManageCapability(supabase, userData.user.id)
+
+  const routeGuard = checkPlatformRouteAccess({
+    platformSession: userData.platformSession,
+    requiredCapability: 'support.manage',
+  })
+  if (!routeGuard.allowed) redirect('/dashboard')
+
   if (!hasHigherRole || !hasSupportManage) {
     return (
       <DashboardLayout>

--- a/components/ui/menu-inferior-movil.tsx
+++ b/components/ui/menu-inferior-movil.tsx
@@ -6,7 +6,8 @@ import { usePathname } from 'next/navigation'
 import { LayoutDashboard, Users, UsersRound, HelpCircle } from 'lucide-react'
 import { cn } from '@/lib/utils'
 import { useCurrentUser } from '@/hooks/useCurrentUser'
-import { getBuildTimePlatformNavigationFlags, usePlatformNavigationViewItems, type PlatformNavigationViewItem } from '@/components/ui/platform-navigation-view-items'
+import { getPlatformNavigationFlags } from '@/lib/platform/flags'
+import { usePlatformNavigationViewItems, type PlatformNavigationViewItem } from '@/components/ui/platform-navigation-view-items'
 import { resolvePlatformNavigationGate } from '@/lib/platform/navigation'
 
 type MenuInferiorMovilItem = {
@@ -27,7 +28,7 @@ export function MenuInferiorMovil() {
   const pathname = usePathname()
   const { platformSession, loading } = useCurrentUser()
   const platformNavigationItems = usePlatformNavigationViewItems(platformSession)
-  const platformNavigationFlags = getBuildTimePlatformNavigationFlags()
+  const platformNavigationFlags = getPlatformNavigationFlags()
   const platformNavigationGate = resolvePlatformNavigationGate({
     flags: platformNavigationFlags,
     platformSession,

--- a/components/ui/platform-navigation-view-items.ts
+++ b/components/ui/platform-navigation-view-items.ts
@@ -3,13 +3,9 @@
 import { useEffect, useState, type ComponentType } from 'react'
 import { ClipboardList, Megaphone, Settings, User, UserCheck, Users } from 'lucide-react'
 
+import { getPlatformNavigationFlags } from '@/lib/platform/flags'
+import type { PlatformNavigationItem, PlatformNavigationItemId, PlatformNavigationSession } from '@/lib/platform/navigation'
 import { resolvePlatformNavigation, resolvePlatformNavigationGate } from '@/lib/platform/navigation'
-import type {
-  PlatformNavigationFlags,
-  PlatformNavigationItem,
-  PlatformNavigationItemId,
-  PlatformNavigationSession,
-} from '@/lib/platform/navigation'
 
 export type PlatformNavigationViewItem = {
   id: string
@@ -41,16 +37,9 @@ const PLATFORM_NAVIGATION_ICONS = {
   uno_a_uno_global: User,
 } satisfies Record<PlatformNavigationItemId, ComponentType<{ className?: string }>>
 
-export function getBuildTimePlatformNavigationFlags(): PlatformNavigationFlags {
-  return {
-    enabled: process.env.NEXT_PUBLIC_PLATFORM_NAVIGATION_ENABLED === 'true',
-    killSwitch: process.env.NEXT_PUBLIC_PLATFORM_NAVIGATION_KILL_SWITCH === 'true',
-  }
-}
-
 export async function resolvePlatformNavigationViewItems(
   platformSession: PlatformNavigationSession | null | undefined,
-  flags: PlatformNavigationFlags = getBuildTimePlatformNavigationFlags()
+  flags: { enabled: boolean; killSwitch?: boolean } = getPlatformNavigationFlags()
 ): Promise<PlatformNavigationViewItem[]> {
   const gate = resolvePlatformNavigationGate({ flags, platformSession })
   if (!gate.ok) return []
@@ -72,7 +61,7 @@ export function usePlatformNavigationViewItems(
   const [state, setState] = useState<PlatformNavigationViewItemsState>({ sessionKey, items: [] })
 
   useEffect(() => {
-    const flags = getBuildTimePlatformNavigationFlags()
+    const flags = getPlatformNavigationFlags()
     const gate = resolvePlatformNavigationGate({ flags, platformSession })
     if (!gate.ok) return
 

--- a/lib/dashboard/contextual-navigation.ts
+++ b/lib/dashboard/contextual-navigation.ts
@@ -1,6 +1,6 @@
+import { getPlatformNavigationFlags, type PlatformNavigationFlags } from '@/lib/platform/flags'
 import { resolvePlatformNavigation } from '@/lib/platform/navigation'
 import type {
-  PlatformNavigationFlags,
   PlatformNavigationItem,
   PlatformNavigationResolution,
   PlatformNavigationResolverInput,
@@ -21,16 +21,15 @@ type DashboardContextualAccessOptions = {
 const DASHBOARD_CONTEXTUAL_DESCRIPTION = 'Accede al espacio disponible para este contexto.'
 const VERIFIED_DASHBOARD_CONTEXTUAL_ROUTES = new Set(['/grupos-vida'])
 
-export function getDashboardPlatformNavigationFlags(): PlatformNavigationFlags {
-  return {
-    enabled: process.env.NEXT_PUBLIC_PLATFORM_NAVIGATION_ENABLED === 'true',
-    killSwitch: process.env.NEXT_PUBLIC_PLATFORM_NAVIGATION_KILL_SWITCH === 'true',
-  }
-}
+/**
+ * Alias preserved for the dashboard page while the centralized flags module
+ * owns the env read. Prefer `getPlatformNavigationFlags()` in new callers.
+ */
+export const getDashboardPlatformNavigationFlags = getPlatformNavigationFlags
 
 export async function resolveDashboardContextualAccess(
   platformSession: PlatformNavigationSession | null | undefined,
-  flags: PlatformNavigationFlags = getDashboardPlatformNavigationFlags(),
+  flags: PlatformNavigationFlags = getPlatformNavigationFlags(),
   options: DashboardContextualAccessOptions = {}
 ): Promise<DashboardContextualShortcut[]> {
   try {

--- a/lib/platform/flags.ts
+++ b/lib/platform/flags.ts
@@ -1,0 +1,14 @@
+export type PlatformNavigationFlags = { enabled: boolean; killSwitch?: boolean }
+
+/**
+ * Reads the platform navigation feature flags at call time.
+ *
+ * Values are read from `NEXT_PUBLIC_*` env vars when called, not inlined at
+ * build time, so server and client callers see the runtime value.
+ */
+export function getPlatformNavigationFlags(): { enabled: boolean; killSwitch: boolean } {
+  return {
+    enabled: process.env.NEXT_PUBLIC_PLATFORM_NAVIGATION_ENABLED === 'true',
+    killSwitch: process.env.NEXT_PUBLIC_PLATFORM_NAVIGATION_KILL_SWITCH === 'true',
+  }
+}

--- a/lib/platform/navigation.ts
+++ b/lib/platform/navigation.ts
@@ -1,11 +1,11 @@
 import { resolvePlatformCapability } from '@/lib/platform/experiences'
 import type { PlatformCapabilityDeniedReason, PlatformCapabilityGrantInput, PlatformScopeInput } from '@/lib/platform/experiences'
+import type { PlatformNavigationFlags } from '@/lib/platform/flags'
 import type { PlatformSession, PlatformSessionCapability, PlatformSessionContext } from '@/lib/platform/session/types'
 
 export const PLATFORM_NAVIGATION_FLOW = 'navigation'
 
 export type PlatformNavigationSession = Pick<PlatformSession, 'personaId' | 'subjectAuthId' | 'globalRoles' | 'contexts' | 'capabilities'>
-export type PlatformNavigationFlags = { enabled: boolean; killSwitch?: boolean }
 export type PlatformNavigationAdapterResult =
   | { ok: true; contexts?: readonly PlatformSessionContext[]; capabilities?: readonly PlatformSessionCapability[] }
   | { ok: false; reason: string }

--- a/lib/platform/routeGuard.ts
+++ b/lib/platform/routeGuard.ts
@@ -1,0 +1,63 @@
+import { getPlatformNavigationFlags, type PlatformNavigationFlags } from '@/lib/platform/flags'
+import type { PlatformSession } from '@/lib/platform/session/types'
+
+export type PlatformRouteGuardReason =
+  | 'feature_flag_disabled'
+  | 'kill_switch_enabled'
+  | 'platform_session_required'
+  | 'no_platform_grants'
+  | 'missing_required_capability'
+
+export type PlatformRouteGuardResult =
+  | { allowed: true }
+  | { allowed: false; reason: PlatformRouteGuardReason }
+
+export type PlatformRouteGuardInput = {
+  platformSession: PlatformSession | null
+  requiredCapability: string
+  flags?: PlatformNavigationFlags | null
+}
+
+/**
+ * Permission marker for Fase 1 platform routes.
+ *
+ * This helper answers whether the platform session has the required capability,
+ * but it is intentionally not an enforcer. The caller owns the actual role check
+ * and decides what to do with a denial. Strict denial is out of scope for
+ * Fase 1 task 3.3; add Sentry capture at the deny branches when Fase 2 enables
+ * hard-deny.
+ */
+export function checkPlatformRouteAccess(input: PlatformRouteGuardInput): PlatformRouteGuardResult {
+  const flags = normalizeFlags(input.flags)
+
+  if (!flags.enabled) return { allowed: false, reason: 'feature_flag_disabled' }
+  if (flags.killSwitch) return { allowed: false, reason: 'kill_switch_enabled' }
+  if (!input.platformSession) return { allowed: false, reason: 'platform_session_required' }
+  if (input.requiredCapability.trim() === '') return { allowed: true }
+
+  if (input.platformSession.capabilities.length === 0) {
+    return { allowed: false, reason: 'no_platform_grants' }
+  }
+
+  const hasCapability = input.platformSession.capabilities.some(
+    (capability) => capability.key === input.requiredCapability
+  )
+
+  if (!hasCapability) {
+    return { allowed: false, reason: 'missing_required_capability' }
+  }
+
+  return { allowed: true }
+}
+
+function normalizeFlags(flags: PlatformNavigationFlags | null | undefined): { enabled: boolean; killSwitch: boolean } {
+  if (!flags || typeof flags !== 'object') {
+    const runtimeFlags = getPlatformNavigationFlags()
+    return { enabled: runtimeFlags.enabled, killSwitch: runtimeFlags.killSwitch }
+  }
+
+  return {
+    enabled: flags.enabled === true,
+    killSwitch: flags.killSwitch === true,
+  }
+}

--- a/openspec/changes/fase-01-platform-foundation/tasks.md
+++ b/openspec/changes/fase-01-platform-foundation/tasks.md
@@ -53,7 +53,8 @@ Chain strategy: stacked-to-main para PR1a; confirmar por slice futuro
   - Issue #220: slice menú inferior móvil cablea `menu-inferior-movil.tsx` al helper contextual compartido detrás de flag/kill switch para presentación de navegación UI; conserva fallback legado solo con flag off, kill switch o carga finalizada sin sesión de plataforma, y no presenta enlaces legacy/globales mientras `useCurrentUser` carga, una sesión de plataforma resuelve, cambia de sesión o queda sin ítems visibles. No implementa ni afirma autorización de rutas directas; task 3.3 sigue pendiente.
   - Issue #222: slice dashboard cablea `platformSession` desde `obtenerDatosDashboard()` y agrega una sección pequeña de “Contextos visibles” detrás de flag/kill switch; solo presenta `/grupos-vida` para scope GDV elegible, conserva el dashboard legacy como contenido principal y no implementa autorización de rutas directas.
   - Issue #224 (hotfix): corrige navegación colgada por `loading` atascado en transiciones client-side en `menu-inferior-movil.tsx`, `sidebar-moderna.tsx`, `header-movil.tsx` y `hooks/useCurrentUser.ts`.
-- [ ] 3.3 Verificar rutas directas denegadas, fallback legado si adapters fallan, y no mostrar DPS admin, NextGen, taller admin ni 1:1 global.
+- [x] 3.3 Verificar rutas directas denegadas, fallback legado si adapters fallan, y no mostrar DPS admin, NextGen, taller admin ni 1:1 global.
+  - Issue #226: crear `lib/platform/routeGuard.ts` (`checkPlatformRouteAccess`), `lib/platform/flags.ts` (`getPlatformNavigationFlags`) y aplicar guard a `app/(auth)/configuracion/page.tsx`, `app/(auth)/configuracion/directores-generales/page.tsx` y `app/(auth)/configuracion/soporte/page.tsx`. El helper es un marcador de permiso para Fase 1; cada página decide el redirect con `if (!routeGuard.allowed) redirect('/dashboard')`.
 
 ## Fase 4: Familia y menores
 


### PR DESCRIPTION
Closes #226

## Resumen
Crea `lib/platform/routeGuard.ts` con `checkPlatformRouteAccess()` y `lib/platform/flags.ts` con `getPlatformNavigationFlags()`. Aplica el guard en 3 rutas admin reales (configuracion, configuracion/directores-generales, configuracion/soporte). Task 3.3 de Fase 1 Platform Foundation ahora está completa.

## Qué Incluye
- `lib/platform/flags.ts` (nuevo): módulo centralizado para `getPlatformNavigationFlags()` y el tipo `PlatformNavigationFlags`. Reemplaza 3 copias duplicadas (routeGuard, navigation, contextual-navigation, platform-navigation-view-items).
- `lib/platform/routeGuard.ts` (nuevo): helper server-side con API colapsada a 2 estados (`{ allowed: true } | { allowed: false; reason }`). Razones distintas para `no_platform_grants` (capabilities vacías, transición) vs `missing_required_capability`. Orden de flag check `enabled` → `killSwitch` matching `resolvePlatformNavigationGate`.
- Aplicado en 3 rutas admin existentes. Comportamiento con flag off (producción actual) es IDÉNTICO al pre-slice — el guard siempre deniega y el redirect aplica solo si el flag está on y falta capability (futuro).
- Tests: 9 suites / 88 focused tests, full CI 54 suites / 517 tests pasan.
- Marcar task 3.3 completa en OpenSpec.

## Motivación / Por Qué
Task 3.3 del plan Fase 1: "Verificar rutas directas denegadas, fallback legado si adapters fallan, y no mostrar DPS admin, NextGen, taller admin ni 1:1 global." Las rutas admin no existen aún (deny-by-404) y el resolver UI ya suprime esos items. Faltaba el guard server-side reusable y la verificación explícita del fallback para futuras Fases 4-7.

## Migraciones / Base de Datos
- [x] No aplica

## Impacto y Riesgos
- Con flag off (producción actual), comportamiento idéntico al pre-slice.
- Con flag on (futuro), el guard bloquea acceso a las 3 rutas admin si falta capability.
- NO reactiva el flag en producción.
- NO crea rutas para DPS/NextGen/Talleres/1:1 (deny-by-404 sigue, Fases 4-7 las crearán).
- NO toca RLS, RPC, migraciones, ni datos.
- Diff: 365 additions / 30 deletions = 395 líneas, dentro del presupuesto de 400.

## Checklist Autor
- [x] Código formateado (Prettier/ESLint)
- [x] Sin `console.log` / debugger
- [x] Tipos TypeScript correctos
- [x] Estados loading/error/empty cubiertos
- [x] Documentación actualizada (`openspec/changes/fase-01-platform-foundation/tasks.md`)
- [x] Rebase con `main` limpio

## Checklist Revisor
- [x] Propósito claro
- [x] Nombres descriptivos
- [x] Sin lógica duplicada (flags centralizado)
- [x] Manejo adecuado de errores
- [x] Cambios acotados al alcance
- [x] Sin secretos / datos sensibles

## Pruebas Realizadas
- [x] `pnpm test -- __tests__/lib/platform/routeGuard.test.ts __tests__/app/configuracion-pages.test.tsx __tests__/app/support-pages.test.tsx --runInBand` — 9 suites / 88 tests
- [x] `npx eslint <changed files> --max-warnings 0`
- [x] `npx tsc --noEmit`
- [x] `pnpm test:ci` — 54 suites / 517 tests + 26 node tests
- [x] `git diff --check`

## Pendientes / Follow-up
- Reactivar `NEXT_PUBLIC_PLATFORM_NAVIGATION_ENABLED` solo post-Fase 1 con `sdd-verify` limpio.
- Fase 4 (familia/menores) es el siguiente work unit.
- Sentry capture en el deny branch cuando Fase 2 introduzca hard-deny (TODO en `routeGuard.ts`).

## Notas Adicionales
Fresh 4R review inicial encontró 2 críticos (dead branch API + flags duplicados) y 4 warnings. Todos resueltos antes del commit: API colapsada a 2 estados, flags centralizado, razones distintas, tests con tuplas explícitas, orden de flag check alineado, `BuildTime` renombrado.
