### PR TITLE
feat(platform): taxonomía familiar en lib/platform/family.ts

### DIFF
--- a/__tests__/lib/platform/family.test.ts
+++ b/__tests__/lib/platform/family.test.ts
@@ -1,0 +1,230 @@
+import {
+  PLATFORM_FAMILY_RELATION_TYPES,
+  PLATFORM_FUTURE_FAMILY_RELATION_TYPES,
+  PLATFORM_FAMILY_RELATION_LABELS,
+  type PlatformFamilyRelationType,
+  type PlatformAnyFamilyRelationType,
+  type PlatformFutureFamilyRelationType,
+  isPlatformFamilyRelationType,
+  isPlatformAnyFamilyRelationType,
+  isPlatformFutureFamilyRelationType,
+  normalizePlatformFamilyRelationType,
+  isPlatformReciprocalFamilyRelation,
+  invertPlatformFamilyRelation,
+} from '@/lib/platform/family'
+
+describe('lib/platform/family', () => {
+  describe('taxonomy constants', () => {
+    it('exposes the 6 current DB relation types in order', () => {
+      expect(PLATFORM_FAMILY_RELATION_TYPES).toEqual([
+        'conyuge',
+        'padre',
+        'hijo',
+        'tutor',
+        'hermano',
+        'otro_familiar',
+      ])
+    })
+
+    it('exposes the 2 future relation types', () => {
+      expect(PLATFORM_FUTURE_FAMILY_RELATION_TYPES).toEqual(['autorizado', 'contacto'])
+    })
+  })
+
+  describe('isPlatformFamilyRelationType', () => {
+    it.each(PLATFORM_FAMILY_RELATION_TYPES)('returns true for current type "%s"', (type) => {
+      expect(isPlatformFamilyRelationType(type)).toBe(true)
+    })
+
+    it.each(PLATFORM_FUTURE_FAMILY_RELATION_TYPES)('returns false for future type "%s"', (type) => {
+      expect(isPlatformFamilyRelationType(type)).toBe(false)
+    })
+
+    it('returns false for non-string values', () => {
+      const invalid = [null, undefined, '', 0, false, [], {}, '42', 'Padre', 'PADRE']
+      for (const value of invalid) {
+        expect(isPlatformFamilyRelationType(value)).toBe(false)
+      }
+    })
+
+    it('narrows type at compile time', () => {
+      const value: unknown = 'padre'
+      if (isPlatformFamilyRelationType(value)) {
+        const narrowed: PlatformFamilyRelationType = value
+        expect(narrowed).toBe('padre')
+      } else {
+        throw new Error('expected narrowing')
+      }
+    })
+  })
+
+  describe('isPlatformAnyFamilyRelationType', () => {
+    it.each([...PLATFORM_FAMILY_RELATION_TYPES, ...PLATFORM_FUTURE_FAMILY_RELATION_TYPES])('returns true for any known type "%s"', (type) => {
+      expect(isPlatformAnyFamilyRelationType(type)).toBe(true)
+    })
+
+    it('returns false for invalid values', () => {
+      const invalid = [null, undefined, '', 0, false, [], {}, 'desconocido', 'Padre', 'PADRE']
+      for (const value of invalid) {
+        expect(isPlatformAnyFamilyRelationType(value)).toBe(false)
+      }
+    })
+
+    it('narrows type at compile time', () => {
+      const value: unknown = 'contacto'
+      if (isPlatformAnyFamilyRelationType(value)) {
+        const narrowed: PlatformAnyFamilyRelationType = value
+        expect(narrowed).toBe('contacto')
+      } else {
+        throw new Error('expected narrowing')
+      }
+    })
+  })
+
+  describe('isPlatformFutureFamilyRelationType', () => {
+    it.each(PLATFORM_FUTURE_FAMILY_RELATION_TYPES)('returns true for future type "%s"', (type) => {
+      expect(isPlatformFutureFamilyRelationType(type)).toBe(true)
+    })
+
+    it.each(PLATFORM_FAMILY_RELATION_TYPES)('returns false for current type "%s"', (type) => {
+      expect(isPlatformFutureFamilyRelationType(type)).toBe(false)
+    })
+
+    it('returns false for non-string values', () => {
+      const invalid = [null, undefined, '', 0, false, [], {}, '42']
+      for (const value of invalid) {
+        expect(isPlatformFutureFamilyRelationType(value)).toBe(false)
+      }
+    })
+
+    it('returns false for mixed-case future inputs', () => {
+      expect(isPlatformFutureFamilyRelationType('Autorizado')).toBe(false)
+      expect(isPlatformFutureFamilyRelationType('CONTACTO')).toBe(false)
+      expect(isPlatformFutureFamilyRelationType('  autorizado  ')).toBe(false)
+    })
+
+    it('narrows type at compile time', () => {
+      const value: unknown = 'autorizado'
+      if (isPlatformFutureFamilyRelationType(value)) {
+        const narrowed: PlatformFutureFamilyRelationType = value
+        expect(narrowed).toBe('autorizado')
+      } else {
+        throw new Error('expected narrowing')
+      }
+    })
+  })
+
+  describe('normalizePlatformFamilyRelationType', () => {
+    it.each(PLATFORM_FAMILY_RELATION_TYPES)('returns "%s" for exact lowercase input', (type) => {
+      expect(normalizePlatformFamilyRelationType(type)).toBe(type)
+    })
+
+    it('normalizes mixed-case input to lowercase', () => {
+      expect(normalizePlatformFamilyRelationType('Padre')).toBe('padre')
+      expect(normalizePlatformFamilyRelationType('PADRE')).toBe('padre')
+      expect(normalizePlatformFamilyRelationType('Hermano')).toBe('hermano')
+      expect(normalizePlatformFamilyRelationType('CONYUGE')).toBe('conyuge')
+    })
+
+    it('trims whitespace before matching', () => {
+      expect(normalizePlatformFamilyRelationType('  padre  ')).toBe('padre')
+      expect(normalizePlatformFamilyRelationType('\thijo\n')).toBe('hijo')
+      expect(normalizePlatformFamilyRelationType('  Padre ')).toBe('padre')
+    })
+
+    it('returns undefined for whitespace-only input', () => {
+      expect(normalizePlatformFamilyRelationType('   ')).toBeUndefined()
+      expect(normalizePlatformFamilyRelationType('\t\n  ')).toBeUndefined()
+    })
+
+    it('returns undefined for future, unknown and non-string values', () => {
+      expect(normalizePlatformFamilyRelationType('autorizado')).toBeUndefined()
+      expect(normalizePlatformFamilyRelationType('contacto')).toBeUndefined()
+      expect(normalizePlatformFamilyRelationType('desconocido')).toBeUndefined()
+      expect(normalizePlatformFamilyRelationType(null)).toBeUndefined()
+      expect(normalizePlatformFamilyRelationType(undefined)).toBeUndefined()
+      expect(normalizePlatformFamilyRelationType('')).toBeUndefined()
+      expect(normalizePlatformFamilyRelationType(0)).toBeUndefined()
+      expect(normalizePlatformFamilyRelationType(false)).toBeUndefined()
+      expect(normalizePlatformFamilyRelationType([])).toBeUndefined()
+      expect(normalizePlatformFamilyRelationType({})).toBeUndefined()
+    })
+  })
+
+  describe('isPlatformReciprocalFamilyRelation', () => {
+    it('returns true for reciprocal relations', () => {
+      expect(isPlatformReciprocalFamilyRelation('conyuge')).toBe(true)
+      expect(isPlatformReciprocalFamilyRelation('hermano')).toBe(true)
+    })
+
+    it('returns false for non-reciprocal relations', () => {
+      expect(isPlatformReciprocalFamilyRelation('padre')).toBe(false)
+      expect(isPlatformReciprocalFamilyRelation('hijo')).toBe(false)
+      expect(isPlatformReciprocalFamilyRelation('tutor')).toBe(false)
+      expect(isPlatformReciprocalFamilyRelation('otro_familiar')).toBe(false)
+    })
+  })
+
+  describe('invertPlatformFamilyRelation', () => {
+    it('inverts parent/child relations', () => {
+      expect(invertPlatformFamilyRelation('padre')).toBe('hijo')
+      expect(invertPlatformFamilyRelation('hijo')).toBe('padre')
+    })
+
+    it('returns the same type for symmetric relations', () => {
+      expect(invertPlatformFamilyRelation('conyuge')).toBe('conyuge')
+      expect(invertPlatformFamilyRelation('hermano')).toBe('hermano')
+    })
+
+    it('returns null for relations with no symmetric DB term', () => {
+      expect(invertPlatformFamilyRelation('tutor')).toBeNull()
+      expect(invertPlatformFamilyRelation('otro_familiar')).toBeNull()
+    })
+
+    it.each([
+      ['conyuge', 'conyuge'],
+      ['padre', 'hijo'],
+      ['hijo', 'padre'],
+      ['hermano', 'hermano'],
+    ])('is involutive for symmetric/asymmetric type "%s"', (type, expected) => {
+      const once = invertPlatformFamilyRelation(type as PlatformFamilyRelationType)
+      expect(once).toBe(expected)
+      expect(invertPlatformFamilyRelation(once)).toBe(type)
+    })
+
+    it('round-trips asymmetric types through null', () => {
+      expect(invertPlatformFamilyRelation('tutor')).toBeNull()
+      expect(invertPlatformFamilyRelation(null)).toBeNull()
+      expect(invertPlatformFamilyRelation('otro_familiar')).toBeNull()
+      expect(invertPlatformFamilyRelation(null)).toBeNull()
+    })
+  })
+
+  describe('PLATFORM_FAMILY_RELATION_LABELS', () => {
+    it('has a non-empty Spanish label for every current and future type', () => {
+      const allTypes: PlatformAnyFamilyRelationType[] = [
+        ...PLATFORM_FAMILY_RELATION_TYPES,
+        ...PLATFORM_FUTURE_FAMILY_RELATION_TYPES,
+      ]
+      for (const type of allTypes) {
+        const label = PLATFORM_FAMILY_RELATION_LABELS[type]
+        expect(typeof label).toBe('string')
+        expect(label.trim().length).toBeGreaterThan(0)
+      }
+    })
+
+    it('uses reasonable Spanish labels for the 6 current types', () => {
+      expect(PLATFORM_FAMILY_RELATION_LABELS.conyuge).toBe('Cónyuge')
+      expect(PLATFORM_FAMILY_RELATION_LABELS.padre).toBe('Padre / Madre')
+      expect(PLATFORM_FAMILY_RELATION_LABELS.hijo).toBe('Hijo / Hija')
+      expect(PLATFORM_FAMILY_RELATION_LABELS.tutor).toBe('Tutor')
+      expect(PLATFORM_FAMILY_RELATION_LABELS.hermano).toBe('Hermano / Hermana')
+      expect(PLATFORM_FAMILY_RELATION_LABELS.otro_familiar).toBe('Otro familiar')
+    })
+
+    it('includes placeholder labels for future types', () => {
+      expect(PLATFORM_FAMILY_RELATION_LABELS.autorizado).toBe('Autorizado')
+      expect(PLATFORM_FAMILY_RELATION_LABELS.contacto).toBe('Contacto')
+    })
+  })
+})

--- a/lib/platform/family.ts
+++ b/lib/platform/family.ts
@@ -1,0 +1,107 @@
+// Taxonomía de relaciones familiares a nivel de plataforma.
+// Separa los tipos actuales persistidos en DB (enum_tipo_relacion) de los
+// conceptos futuros (autorizado/contacto) que aún no tienen representación
+// de esquema y no deben inferirse desde los tipos existentes.
+
+/** Tipos de relación familiar actuales, alineados con `enum_tipo_relacion`. */
+export const PLATFORM_FAMILY_RELATION_TYPES = [
+  'conyuge',
+  'padre',
+  'hijo',
+  'tutor',
+  'hermano',
+  'otro_familiar',
+] as const
+
+export type PlatformFamilyRelationType = (typeof PLATFORM_FAMILY_RELATION_TYPES)[number]
+
+/** Tipos de relación futuros. Aún no existen en DB; son forward-compat. */
+export const PLATFORM_FUTURE_FAMILY_RELATION_TYPES = [
+  'autorizado',
+  'contacto',
+] as const
+
+export type PlatformFutureFamilyRelationType = (typeof PLATFORM_FUTURE_FAMILY_RELATION_TYPES)[number]
+
+/** Unión de tipos actuales y futuros. */
+export type PlatformAnyFamilyRelationType = PlatformFamilyRelationType | PlatformFutureFamilyRelationType
+
+/** Conjunto de búsqueda O(1) para tipos actuales. */
+const PLATFORM_FAMILY_RELATION_TYPE_SET = new Set<string>(PLATFORM_FAMILY_RELATION_TYPES)
+
+/** Conjunto de búsqueda O(1) para tipos actuales + futuros. */
+const PLATFORM_ANY_FAMILY_RELATION_TYPE_SET = new Set<string>([
+  ...PLATFORM_FAMILY_RELATION_TYPES,
+  ...PLATFORM_FUTURE_FAMILY_RELATION_TYPES,
+])
+
+/** Conjunto de búsqueda O(1) para tipos futuros. */
+const PLATFORM_FUTURE_FAMILY_RELATION_TYPE_SET = new Set<string>(PLATFORM_FUTURE_FAMILY_RELATION_TYPES)
+
+/** Verifica si un valor es uno de los 6 tipos actuales de relación familiar. */
+export function isPlatformFamilyRelationType(value: unknown): value is PlatformFamilyRelationType {
+  return typeof value === 'string' && PLATFORM_FAMILY_RELATION_TYPE_SET.has(value)
+}
+
+/** Verifica si un valor es cualquier tipo de relación familiar conocido (8 en total). */
+export function isPlatformAnyFamilyRelationType(value: unknown): value is PlatformAnyFamilyRelationType {
+  return typeof value === 'string' && PLATFORM_ANY_FAMILY_RELATION_TYPE_SET.has(value)
+}
+
+/** Verifica si un valor es uno de los 2 tipos futuros de relación familiar. */
+export function isPlatformFutureFamilyRelationType(value: unknown): value is PlatformFutureFamilyRelationType {
+  return typeof value === 'string' && PLATFORM_FUTURE_FAMILY_RELATION_TYPE_SET.has(value)
+}
+
+/**
+ * Normaliza un valor al tipo de relación familiar actual.
+ * Recorta espacios, convierte a minúsculas y solo acepta los 6 tipos de DB.
+ * Los tipos futuros y valores desconocidos devuelven `undefined`.
+ */
+export function normalizePlatformFamilyRelationType(value: unknown): PlatformFamilyRelationType | undefined {
+  if (typeof value !== 'string') return undefined
+  const normalized = value.trim().toLowerCase()
+  if (isPlatformFamilyRelationType(normalized)) return normalized
+  return undefined
+}
+
+/** Indica si una relación es recíproca por naturaleza (mismo término en ambos sentidos). */
+export function isPlatformReciprocalFamilyRelation(type: PlatformFamilyRelationType): boolean {
+  return type === 'conyuge' || type === 'hermano'
+}
+
+/**
+ * Devuelve el tipo inverso de una relación familiar.
+ * `tutor` y `otro_familiar` devuelven `null` porque no tienen término simétrico
+ * en `enum_tipo_relacion`.
+ */
+export function invertPlatformFamilyRelation(type: PlatformFamilyRelationType | null): PlatformFamilyRelationType | null {
+  if (type === null) return null
+  switch (type) {
+    case 'padre':
+      return 'hijo'
+    case 'hijo':
+      return 'padre'
+    case 'conyuge':
+      return 'conyuge'
+    case 'hermano':
+      return 'hermano'
+    case 'tutor':
+    case 'otro_familiar':
+      return null
+    default:
+      return null
+  }
+}
+
+/** Etiquetas en español para cada tipo de relación (plataforma, no UI). */
+export const PLATFORM_FAMILY_RELATION_LABELS = {
+  conyuge: 'Cónyuge',
+  padre: 'Padre / Madre',
+  hijo: 'Hijo / Hija',
+  tutor: 'Tutor',
+  hermano: 'Hermano / Hermana',
+  otro_familiar: 'Otro familiar',
+  autorizado: 'Autorizado',
+  contacto: 'Contacto',
+} satisfies Record<PlatformAnyFamilyRelationType, string>

--- a/openspec/changes/fase-01-platform-foundation/tasks.md
+++ b/openspec/changes/fase-01-platform-foundation/tasks.md
@@ -58,7 +58,9 @@ Chain strategy: stacked-to-main para PR1a; confirmar por slice futuro
 
 ## Fase 4: Familia y menores
 
-- [ ] 4.1 Crear `lib/platform/family.ts` con taxonomía existente (`conyuge`, `padre`, `hijo`, `tutor`, `hermano`, `otro_familiar`) y futuros `autorizado/contacto` explícitos.
+- [x] 4.1 Crear `lib/platform/family.ts` con taxonomía existente (`conyuge`, `padre`, `hijo`, `tutor`, `hermano`, `otro_familiar`) y futuros `autorizado/contacto` explícitos.
+  - Issue #228: `lib/platform/family.ts` + `__tests__/lib/platform/family.test.ts` en rama `feat/228-family-taxonomy`.
+  - Revisión 4R (fixes no bloqueantes): renombrar exports con prefijo `Platform*`, agregar guard `isPlatformFutureFamilyRelationType`, test de involution y normalización de solo espacios en blanco.
 - [ ] 4.2 Probar tutor denegado, menor sin auth, permiso familiar insuficiente y no exposición de datos sensibles por backend/RLS.
 
 ## Fase 5: Ledger longitudinal y `uno_a_uno` preflight


### PR DESCRIPTION
Closes #228

## Resumen
Crea `lib/platform/family.ts` con la taxonomía de relaciones familiares como módulo platform puro: 6 tipos actuales (`conyuge`, `padre`, `hijo`, `tutor`, `hermano`, `otro_familiar`) + 2 futuros (`autorizado`, `contacto`) como forward-compat. Helpers de type guard, normalización, reciprocidad, inversión, y etiquetas en español. NO toca DB, RPC, RLS, UI, navegación, sesión, ni autorización — eso queda para 4.2 (denegaciones) y Fases futuras.

## Qué Incluye
- Constantes tipadas con `as const` para taxonomía actual y futura.
- `Platform*` naming consistente con `lib/platform/` (navigation, routeGuard, flags, experiences, persona).
- Type guards: `isPlatformFamilyRelationType`, `isPlatformFutureFamilyRelationType`, `isPlatformAnyFamilyRelationType`.
- `normalizePlatformFamilyRelationType` con trim + lowercase; rechaza futuros y unknown devolviendo `undefined` (no auto-inferencia).
- `isPlatformReciprocalFamilyRelation` (conyuge/hermano simétricos; resto no).
- `invertPlatformFamilyRelation` (padre↔hijo, conyuge/hermano sí mismos, tutor/otro_familiar → null).
- `PLATFORM_FAMILY_RELATION_LABELS` con etiquetas en español para los 8 tipos.
- Tests exhaustivos: 56/56 pasan, full CI 55 suites / 573 tests.

## Motivación / Por Qué
Fase 4 task 4.1: modelar relaciones como contexto, no permisos amplios. La taxonomía actual vive en DB enum + UI labels; falta una capa platform explícita que la represente sin auto-inferir `autorizado`/`contacto` desde tipos existentes.

## Migraciones / Base de Datos
- [x] No aplica

## Impacto y Riesgos
- Sin cambios de comportamiento: el módulo no es consumido aún. La integración con `PlatformSession`, adaptadores, autorización y UI queda para Fase 4 task 4.2 y futuras.
- 340 líneas, dentro del presupuesto de 400.

## Checklist Autor
- [x] Código formateado (Prettier/ESLint)
- [x] Sin `console.log` / debugger
- [x] Tipos TypeScript correctos
- [x] Sin PII ni datos sensibles
- [x] Documentación actualizada (`openspec/changes/fase-01-platform-foundation/tasks.md`)
- [x] Rebase con `main` limpio

## Checklist Revisor
- [x] Propósito claro
- [x] Nombres descriptivos (prefijo `Platform*` consistente con `lib/platform/`)
- [x] Sin lógica duplicada
- [x] Manejo adecuado de errores (futuros y unknown → `undefined`, asimétricos → `null`)
- [x] Cambios acotados al alcance
- [x] Sin secretos / datos sensibles

## Pruebas Realizadas
- [x] `pnpm test -- __tests__/lib/platform/family.test.ts --runInBand` — 56/56
- [x] `npx eslint lib/platform/family.ts __tests__/lib/platform/family.test.ts --max-warnings 0`
- [x] `npx tsc --noEmit`
- [x] `pnpm test:ci` — 55 suites / 573 tests + 26 node tests
- [x] `git diff --check`

## Pendientes / Follow-up
- Task 4.2: tests de denegación (tutor, menor sin auth, permiso familiar insuficiente, no exposición de datos sensibles). Esto requerirá adapter familiar y posiblemente integración con `checkPlatformRouteAccess`.
- Sentry observability para denegaciones de familia (Fase 6, auditoría general).
- Consolidación futura con `lib/config/relaciones-familiares.ts` si conviene.

## Notas Adicionales
Fresh 4R review final sin críticos. Warnings R2 (Platform* prefix) y SUGGESTIONs R3 (involution, whitespace-only) y R4 (isFuture guard) aplicados antes del commit.
