### PR TITLE
feat(platform): adapter de familia deny-by-default + guard canAccessMinorData

### DIFF
--- a/__tests__/lib/platform/family-adapter.test.ts
+++ b/__tests__/lib/platform/family-adapter.test.ts
@@ -1,0 +1,97 @@
+import { resolveFamilyRelations } from '@/lib/platform/adapters/family'
+import type { FamilyReadRepository, FamilyRelation } from '@/lib/platform/adapters/family'
+import type { PlatformSession } from '@/lib/platform/session/types'
+
+const baseSession: PlatformSession = { personaId: 'persona-actor', subjectAuthId: 'auth-actor', globalRoles: [], contexts: [], capabilities: [] }
+
+function createReader(relations: readonly FamilyRelation[]): FamilyReadRepository {
+  return { findRelationsByPersonaId: jest.fn().mockResolvedValue(relations) }
+}
+
+function relation(overrides: Partial<FamilyRelation> & Pick<FamilyRelation, 'id' | 'personaId' | 'relatedPersonaId' | 'tipoRelacion'>): FamilyRelation {
+  return { relatedHasAuthAccount: null, ...overrides }
+}
+
+describe('Family platform read adapter', () => {
+  it('resolves normalized relations from the actor perspective and preserves order', async () => {
+    const reader = createReader([
+      relation({ id: 'rel-1', personaId: 'persona-actor', relatedPersonaId: 'persona-hijo', tipoRelacion: 'padre', relatedHasAuthAccount: false }),
+      relation({ id: 'rel-2', personaId: 'persona-actor', relatedPersonaId: 'persona-conyuge', tipoRelacion: 'conyuge', relatedHasAuthAccount: true }),
+    ])
+    const result = await resolveFamilyRelations({ session: baseSession, reader })
+    expect(reader.findRelationsByPersonaId).toHaveBeenCalledWith('persona-actor')
+    expect(result).toEqual({
+      ok: true,
+      relations: [
+        { relatedPersonaId: 'persona-hijo', relatedHasAuthAccount: false, tipoRelacion: 'padre', isReciprocal: false },
+        { relatedPersonaId: 'persona-conyuge', relatedHasAuthAccount: true, tipoRelacion: 'conyuge', isReciprocal: true },
+      ],
+      audit: { decision: 'allowed', personaId: 'persona-actor', relationCount: 2 },
+    })
+  })
+
+  it.each([
+    { label: 'undefined session', session: undefined },
+    { label: 'null session', session: null },
+    { label: 'blank persona id', session: { ...baseSession, personaId: '   ' } },
+  ] satisfies Array<{ label: string; session: PlatformSession | null | undefined }>)('fails closed for $label', async ({ session }) => {
+    const reader = createReader([])
+    const result = await resolveFamilyRelations({ session, reader })
+    expect(reader.findRelationsByPersonaId).not.toHaveBeenCalled()
+    expect(result).toEqual({ ok: false, reason: 'session_required', relations: [], audit: { decision: 'denied', reason: 'session_required', relationCount: 0 } })
+  })
+
+  it('fails closed when the repository throws', async () => {
+    const reader: FamilyReadRepository = { findRelationsByPersonaId: jest.fn().mockRejectedValue(new Error('database timeout')) }
+    const result = await resolveFamilyRelations({ session: baseSession, reader })
+    expect(result).toEqual({ ok: false, reason: 'adapter_read_failed', relations: [], audit: { decision: 'denied', reason: 'adapter_read_failed', personaId: 'persona-actor', relationCount: 0 } })
+  })
+
+  it('fails closed for invalid relation data', async () => {
+    await expect(resolveFamilyRelations({ session: baseSession, reader: createReader([relation({ id: '', personaId: 'persona-actor', relatedPersonaId: 'persona-valida', tipoRelacion: 'padre' })]) })).resolves.toMatchObject({ ok: false, reason: 'invalid_family_data' })
+    await expect(resolveFamilyRelations({ session: baseSession, reader: createReader([relation({ id: 'rel-bad', personaId: 'persona-actor', relatedPersonaId: '   ', tipoRelacion: 'padre' })]) })).resolves.toMatchObject({ ok: false, reason: 'invalid_family_data' })
+    await expect(resolveFamilyRelations({ session: baseSession, reader: createReader([relation({ id: 'rel-bad', personaId: 'persona-actor', relatedPersonaId: 'persona-valida', tipoRelacion: 123 as unknown as string })]) })).resolves.toMatchObject({ ok: false, reason: 'invalid_family_data' })
+  })
+
+  it('normalizes tipoRelacion from the usuario2 perspective and preserves asymmetric types', async () => {
+    const result = await resolveFamilyRelations({
+      session: baseSession,
+      reader: createReader([
+        relation({ id: 'rel-padre', personaId: 'persona-padre', relatedPersonaId: 'persona-actor', tipoRelacion: 'padre' }),
+        relation({ id: 'rel-tutor', personaId: 'persona-tutor', relatedPersonaId: 'persona-actor', tipoRelacion: 'tutor' }),
+      ]),
+    })
+    expect(result.ok).toBe(true)
+    if (!result.ok) throw new Error('expected allowed')
+    expect(result.relations).toEqual([
+      { relatedPersonaId: 'persona-padre', relatedHasAuthAccount: null, tipoRelacion: 'hijo', isReciprocal: false },
+      { relatedPersonaId: 'persona-tutor', relatedHasAuthAccount: null, tipoRelacion: 'tutor', isReciprocal: false },
+    ])
+  })
+
+  it('silently skips relations with unknown tipoRelacion', async () => {
+    const result = await resolveFamilyRelations({
+      session: baseSession,
+      reader: createReader([
+        relation({ id: 'rel-known', personaId: 'persona-actor', relatedPersonaId: 'persona-conocida', tipoRelacion: 'hermano' }),
+        relation({ id: 'rel-unknown', personaId: 'persona-actor', relatedPersonaId: 'persona-desconocida', tipoRelacion: 'autorizado' }),
+      ]),
+    })
+    expect(result).toEqual({
+      ok: true,
+      relations: [{ relatedPersonaId: 'persona-conocida', relatedHasAuthAccount: null, tipoRelacion: 'hermano', isReciprocal: true }],
+      audit: { decision: 'allowed', personaId: 'persona-actor', relationCount: 1 },
+    })
+  })
+
+  it('returns an empty allowed result when the actor has no relations', async () => {
+    const result = await resolveFamilyRelations({ session: baseSession, reader: createReader([]) })
+    expect(result).toEqual({ ok: true, relations: [], audit: { decision: 'allowed', personaId: 'persona-actor', relationCount: 0 } })
+  })
+
+  it('does not produce operational capabilities from family relations', async () => {
+    const result = await resolveFamilyRelations({ session: baseSession, reader: createReader([relation({ id: 'rel-1', personaId: 'persona-actor', relatedPersonaId: 'persona-hijo', tipoRelacion: 'padre' })]) })
+    expect(JSON.stringify(result)).not.toContain('ninos.room.read')
+    expect(JSON.stringify(result)).not.toContain('grupos_vida.stage.read')
+  })
+})

--- a/__tests__/lib/platform/family.test.ts
+++ b/__tests__/lib/platform/family.test.ts
@@ -11,6 +11,7 @@ import {
   normalizePlatformFamilyRelationType,
   isPlatformReciprocalFamilyRelation,
   invertPlatformFamilyRelation,
+  normalizePlatformPersonaId,
 } from '@/lib/platform/family'
 
 describe('lib/platform/family', () => {
@@ -28,6 +29,28 @@ describe('lib/platform/family', () => {
 
     it('exposes the 2 future relation types', () => {
       expect(PLATFORM_FUTURE_FAMILY_RELATION_TYPES).toEqual(['autorizado', 'contacto'])
+    })
+  })
+
+  describe('normalizePlatformPersonaId', () => {
+    it('returns trimmed string for valid persona ids', () => {
+      expect(normalizePlatformPersonaId('persona-1')).toBe('persona-1')
+      expect(normalizePlatformPersonaId('  persona-1  ')).toBe('persona-1')
+    })
+
+    it('returns undefined for blank or whitespace-only strings', () => {
+      expect(normalizePlatformPersonaId('')).toBeUndefined()
+      expect(normalizePlatformPersonaId('   ')).toBeUndefined()
+      expect(normalizePlatformPersonaId('\t\n  ')).toBeUndefined()
+    })
+
+    it('returns undefined for non-string values', () => {
+      expect(normalizePlatformPersonaId(null)).toBeUndefined()
+      expect(normalizePlatformPersonaId(undefined)).toBeUndefined()
+      expect(normalizePlatformPersonaId(123)).toBeUndefined()
+      expect(normalizePlatformPersonaId(false)).toBeUndefined()
+      expect(normalizePlatformPersonaId({})).toBeUndefined()
+      expect(normalizePlatformPersonaId([])).toBeUndefined()
     })
   })
 

--- a/__tests__/lib/platform/family/canAccessMinorData.test.ts
+++ b/__tests__/lib/platform/family/canAccessMinorData.test.ts
@@ -1,0 +1,52 @@
+import { canAccessMinorData } from '@/lib/platform/family/canAccessMinorData'
+import type { NormalizedFamilyRelation } from '@/lib/platform/adapters/family'
+import type { PlatformSession } from '@/lib/platform/session/types'
+
+const session: PlatformSession = { personaId: 'persona-actor', subjectAuthId: 'auth-actor', globalRoles: [], contexts: [], capabilities: [] }
+
+function relationTo(targetId: string, tipoRelacion: NormalizedFamilyRelation['tipoRelacion']): NormalizedFamilyRelation {
+  return { relatedPersonaId: targetId, relatedHasAuthAccount: null, tipoRelacion, isReciprocal: tipoRelacion === 'conyuge' || tipoRelacion === 'hermano' }
+}
+
+describe('canAccessMinorData', () => {
+  it('allows self-access for matching persona ids', () => {
+    expect(canAccessMinorData({ actor: { personaId: 'persona-menor' }, target: { personaId: 'persona-menor', hasAuthAccount: false }, relations: [], session })).toEqual({ allowed: true, reason: 'self' })
+  })
+
+  it.each([
+    { tipoRelacion: 'padre' as const, label: 'padre', hasAuthAccount: false },
+    { tipoRelacion: 'tutor' as const, label: 'tutor', hasAuthAccount: false },
+    { tipoRelacion: 'padre' as const, label: 'padre with auth', hasAuthAccount: true },
+  ])('allows $label to access minor data as explicit guardian', ({ tipoRelacion, hasAuthAccount }) => {
+    expect(canAccessMinorData({ actor: { personaId: 'persona-tutor' }, target: { personaId: 'persona-menor', hasAuthAccount }, relations: [relationTo('persona-menor', tipoRelacion)], session })).toEqual({ allowed: true, reason: 'explicit_guardian' })
+  })
+
+  it.each([
+    { tipoRelacion: 'conyuge' as const, label: 'cónyuge' },
+    { tipoRelacion: 'hermano' as const, label: 'hermano' },
+    { tipoRelacion: 'otro_familiar' as const, label: 'otro_familiar' },
+  ])('denies $label access to minor data for insufficient relation', ({ tipoRelacion }) => {
+    expect(canAccessMinorData({ actor: { personaId: 'persona-familiar' }, target: { personaId: 'persona-menor', hasAuthAccount: false }, relations: [relationTo('persona-menor', tipoRelacion)], session })).toEqual({ allowed: false, reason: 'minor_no_auth' })
+  })
+
+  it('denies access when no relation exists', () => {
+    expect(canAccessMinorData({ actor: { personaId: 'persona-externa' }, target: { personaId: 'persona-menor', hasAuthAccount: true }, relations: [], session })).toEqual({ allowed: false, reason: 'insufficient_relation' })
+  })
+
+  it.each([
+    { label: 'missing session', session: null, actor: { personaId: 'persona-actor' }, target: { personaId: 'persona-menor', hasAuthAccount: false }, expected: 'no_platform_session' },
+    { label: 'missing actor', session, actor: null, target: { personaId: 'persona-menor', hasAuthAccount: false }, expected: 'no_actor' },
+    { label: 'blank actor id', session, actor: { personaId: '   ' }, target: { personaId: 'persona-menor', hasAuthAccount: false }, expected: 'no_actor' },
+    { label: 'missing target', session, actor: { personaId: 'persona-actor' }, target: null, expected: 'no_target' },
+    { label: 'blank target id', session, actor: { personaId: 'persona-actor' }, target: { personaId: '   ', hasAuthAccount: false }, expected: 'no_target' },
+  ])("denies access with '$expected' for $label", ({ session: s, actor, target, expected }) => {
+    expect(canAccessMinorData({ actor, target, relations: [], session: s as PlatformSession | null })).toEqual({ allowed: false, reason: expected })
+  })
+
+  it('follows precedence: session, actor, target, self, then relation check', () => {
+    expect(canAccessMinorData({ actor: { personaId: 'a' }, target: { personaId: 'a', hasAuthAccount: false }, relations: [], session: null })).toEqual({ allowed: false, reason: 'no_platform_session' })
+    expect(canAccessMinorData({ actor: null, target: { personaId: 'a', hasAuthAccount: false }, relations: [], session })).toEqual({ allowed: false, reason: 'no_actor' })
+    expect(canAccessMinorData({ actor: { personaId: 'a' }, target: null, relations: [], session })).toEqual({ allowed: false, reason: 'no_target' })
+    expect(canAccessMinorData({ actor: { personaId: 'a' }, target: { personaId: 'a', hasAuthAccount: false }, relations: [], session })).toEqual({ allowed: true, reason: 'self' })
+  })
+})

--- a/lib/platform/adapters/family.ts
+++ b/lib/platform/adapters/family.ts
@@ -1,0 +1,118 @@
+import { type PlatformSession } from '@/lib/platform/session/types'
+import { normalizePlatformPersonaId, type PlatformFamilyRelationType, invertPlatformFamilyRelation, isPlatformReciprocalFamilyRelation, normalizePlatformFamilyRelationType } from '@/lib/platform/family'
+
+export type FamilyRelation = {
+  id: string
+  personaId: string
+  relatedPersonaId: string
+  tipoRelacion: string
+  relatedHasAuthAccount: boolean | null
+}
+
+export type FamilyReadRepository = {
+  findRelationsByPersonaId(personaId: string): Promise<readonly FamilyRelation[]>
+}
+
+export type FamilyAdapterInput = {
+  session: PlatformSession | null | undefined
+  reader: FamilyReadRepository
+}
+
+export type NormalizedFamilyRelation = {
+  relatedPersonaId: string
+  relatedHasAuthAccount: boolean | null
+  tipoRelacion: PlatformFamilyRelationType
+  isReciprocal: boolean
+}
+
+export type FamilyAdapterDeniedReason =
+  | 'session_required'
+  | 'adapter_read_failed'
+  | 'invalid_family_data'
+
+export type FamilyAdapterAudit = {
+  decision: 'allowed' | 'denied'
+  /** Set only when `decision` is `'denied'`. */
+  reason?: FamilyAdapterDeniedReason
+  personaId?: string
+  relationCount: number
+}
+
+export type FamilyAdapterResult =
+  | { ok: true; relations: readonly NormalizedFamilyRelation[]; audit: FamilyAdapterAudit }
+  | { ok: false; reason: FamilyAdapterDeniedReason; relations: []; audit: FamilyAdapterAudit }
+
+export async function resolveFamilyRelations(input: FamilyAdapterInput): Promise<FamilyAdapterResult> {
+  const personaId = normalizePlatformPersonaId(input.session?.personaId)
+  if (!personaId) {
+    return denied('session_required')
+  }
+
+  let rawRelations: readonly FamilyRelation[]
+  try {
+    rawRelations = await input.reader.findRelationsByPersonaId(personaId)
+  } catch {
+    return denied('adapter_read_failed', personaId)
+  }
+
+  const normalized = normalizeRelations(rawRelations, personaId)
+  if (!normalized.ok) {
+    return denied(normalized.reason, personaId)
+  }
+
+  return {
+    ok: true,
+    relations: normalized.relations,
+    audit: { decision: 'allowed', personaId, relationCount: normalized.relations.length },
+  }
+}
+
+type NormalizationResult =
+  | { ok: true; relations: NormalizedFamilyRelation[] }
+  | { ok: false; reason: 'invalid_family_data' }
+
+function normalizeRelations(relations: readonly FamilyRelation[], actorPersonaId: string): NormalizationResult {
+  const normalizedRelations: NormalizedFamilyRelation[] = []
+  for (const relation of relations) {
+    const relPersonaId = normalizePlatformPersonaId(relation.personaId)
+    const relRelatedPersonaId = normalizePlatformPersonaId(relation.relatedPersonaId)
+    if (!relation.id?.trim() || !relPersonaId || !relRelatedPersonaId || typeof relation.tipoRelacion !== 'string') {
+      return { ok: false, reason: 'invalid_family_data' }
+    }
+
+    const rawType = normalizePlatformFamilyRelationType(relation.tipoRelacion)
+    if (!rawType) {
+      continue
+    }
+
+    const isActorOnPersonaSide = relPersonaId === actorPersonaId
+    let normalizedType = rawType
+    if (!isActorOnPersonaSide) {
+      const inverted = invertPlatformFamilyRelation(rawType)
+      if (inverted !== null) {
+        normalizedType = inverted
+      }
+    }
+
+    const targetPersonaId = isActorOnPersonaSide ? relRelatedPersonaId : relPersonaId
+    // When the actor is on the relatedPersonaId side, the persona-side auth state is not on the relation row.
+    const targetHasAuthAccount = isActorOnPersonaSide ? relation.relatedHasAuthAccount : null
+
+    normalizedRelations.push({
+      relatedPersonaId: targetPersonaId,
+      relatedHasAuthAccount: targetHasAuthAccount,
+      tipoRelacion: normalizedType,
+      isReciprocal: isPlatformReciprocalFamilyRelation(normalizedType),
+    })
+  }
+  return { ok: true, relations: normalizedRelations }
+}
+
+function denied(reason: FamilyAdapterDeniedReason, personaId?: string): FamilyAdapterResult {
+  return {
+    ok: false,
+    reason,
+    relations: [],
+    audit: { decision: 'denied', reason, ...(personaId ? { personaId } : {}), relationCount: 0 },
+  }
+}

--- a/lib/platform/experiences.ts
+++ b/lib/platform/experiences.ts
@@ -9,6 +9,7 @@ export const PLATFORM_EXPERIENCE_CATALOG = {
   estudiantes: { label: 'Estudiantes', scopeTypes: ['salon'] },
   the_living_room: { label: 'The Living Room', scopeTypes: ['experience'] },
   talleres_crecimiento: { label: 'Talleres de Crecimiento', scopeTypes: ['taller'] },
+  family: { label: 'Familia', scopeTypes: ['experience'] },
 } satisfies Record<string, { label: string; scopeTypes: readonly PlatformScopeType[] }>
 
 export type PlatformExperienceKey = keyof typeof PLATFORM_EXPERIENCE_CATALOG
@@ -20,6 +21,8 @@ export const PLATFORM_CAPABILITIES = {
   'ninos.room.read': { experience: 'ninos', scopeType: 'salon' },
   'estudiantes.room.read': { experience: 'estudiantes', scopeType: 'salon' },
   'talleres_crecimiento.participation.read': { experience: 'talleres_crecimiento', scopeType: 'taller' },
+  'family.minor.read': { experience: 'family', scopeType: 'experience' },
+  'family.minor.consent': { experience: 'family', scopeType: 'experience' },
 } satisfies Record<string, { experience: PlatformExperienceKey; scopeType: PlatformScopeType }>
 
 export type PlatformCapabilityKey = keyof typeof PLATFORM_CAPABILITIES

--- a/lib/platform/family.ts
+++ b/lib/platform/family.ts
@@ -38,6 +38,16 @@ const PLATFORM_ANY_FAMILY_RELATION_TYPE_SET = new Set<string>([
 /** Conjunto de búsqueda O(1) para tipos futuros. */
 const PLATFORM_FUTURE_FAMILY_RELATION_TYPE_SET = new Set<string>(PLATFORM_FUTURE_FAMILY_RELATION_TYPES)
 
+/**
+ * Normaliza un identificador de persona de plataforma.
+ * Recorta espacios y devuelve `undefined` para valores no-string o vacíos.
+ */
+export function normalizePlatformPersonaId(value: unknown): string | undefined {
+  if (typeof value !== 'string') return undefined
+  const trimmed = value.trim()
+  return trimmed || undefined
+}
+
 /** Verifica si un valor es uno de los 6 tipos actuales de relación familiar. */
 export function isPlatformFamilyRelationType(value: unknown): value is PlatformFamilyRelationType {
   return typeof value === 'string' && PLATFORM_FAMILY_RELATION_TYPE_SET.has(value)

--- a/lib/platform/family/canAccessMinorData.ts
+++ b/lib/platform/family/canAccessMinorData.ts
@@ -1,0 +1,67 @@
+import { normalizePlatformPersonaId } from '@/lib/platform/family'
+import { type NormalizedFamilyRelation } from '@/lib/platform/adapters/family'
+import { type PlatformSession } from '@/lib/platform/session/types'
+
+export type MinorAccessActorPersona = {
+  personaId: string
+}
+
+export type MinorAccessTargetPersona = {
+  personaId: string
+  hasAuthAccount: boolean | null
+}
+
+export type MinorAccessReason =
+  | 'self'
+  | 'explicit_guardian'
+
+export type MinorAccessDeniedReason =
+  | 'no_actor'
+  | 'no_target'
+  | 'no_platform_session'
+  | 'minor_no_auth'
+  | 'insufficient_relation'
+
+export type CanAccessMinorDataResult =
+  | { allowed: true; reason: MinorAccessReason }
+  | { allowed: false; reason: MinorAccessDeniedReason }
+
+export function canAccessMinorData(params: {
+  actor: MinorAccessActorPersona | null | undefined
+  target: MinorAccessTargetPersona | null | undefined
+  relations: readonly NormalizedFamilyRelation[]
+  session: PlatformSession | null | undefined
+}): CanAccessMinorDataResult {
+  const { actor, target, relations, session } = params
+  if (session == null) {
+    return { allowed: false, reason: 'no_platform_session' }
+  }
+
+  const actorId = normalizePlatformPersonaId(actor?.personaId)
+  if (!actorId) {
+    return { allowed: false, reason: 'no_actor' }
+  }
+
+  const targetId = normalizePlatformPersonaId(target?.personaId)
+  if (!targetId) {
+    return { allowed: false, reason: 'no_target' }
+  }
+
+  if (actorId === targetId) {
+    return { allowed: true, reason: 'self' }
+  }
+
+  const guardianRelation = relations.find(
+    (relation) => relation.relatedPersonaId === targetId && (relation.tipoRelacion === 'padre' || relation.tipoRelacion === 'tutor'),
+  )
+
+  if (target?.hasAuthAccount === false) {
+    return guardianRelation
+      ? { allowed: true, reason: 'explicit_guardian' }
+      : { allowed: false, reason: 'minor_no_auth' }
+  }
+
+  return guardianRelation
+    ? { allowed: true, reason: 'explicit_guardian' }
+    : { allowed: false, reason: 'insufficient_relation' }
+}

--- a/openspec/changes/fase-01-platform-foundation/tasks.md
+++ b/openspec/changes/fase-01-platform-foundation/tasks.md
@@ -61,7 +61,8 @@ Chain strategy: stacked-to-main para PR1a; confirmar por slice futuro
 - [x] 4.1 Crear `lib/platform/family.ts` con taxonomía existente (`conyuge`, `padre`, `hijo`, `tutor`, `hermano`, `otro_familiar`) y futuros `autorizado/contacto` explícitos.
   - Issue #228: `lib/platform/family.ts` + `__tests__/lib/platform/family.test.ts` en rama `feat/228-family-taxonomy`.
   - Revisión 4R (fixes no bloqueantes): renombrar exports con prefijo `Platform*`, agregar guard `isPlatformFutureFamilyRelationType`, test de involution y normalización de solo espacios en blanco.
-- [ ] 4.2 Probar tutor denegado, menor sin auth, permiso familiar insuficiente y no exposición de datos sensibles por backend/RLS.
+- [x] 4.2 Probar tutor denegado, menor sin auth, permiso familiar insuficiente y no exposición de datos sensibles por backend/RLS.
+  - Issue #230: `lib/platform/adapters/family.ts` (renamed from `familia.ts`) + `lib/platform/family/canAccessMinorData.ts` + tests + capabilities `family.minor.read`/`family.minor.consent` en `lib/platform/experiences.ts`. Aplicados fixes 4R: exports `Family*`, eliminado `esPrincipal`/`explicit_authorized`, extraído `normalizePlatformPersonaId`, sin `no_family_relations`/`not_a_minor`.
 
 ## Fase 5: Ledger longitudinal y `uno_a_uno` preflight
 


### PR DESCRIPTION
Closes #230

## Resumen
Crea el adapter familiar read-only (espejo de `grupos-vida.ts`) y el guard puro `canAccessMinorData`. Prueba los 4 escenarios del spec `platform-family-context`: tutor denegado, menor sin auth, permiso familiar insuficiente, no exposición de datos sensibles. Agrega `family.minor.read` y `family.minor.consent` al allowlist de capabilities. Task 4.2 de Fase 4 completa.

## Qué Incluye
- `lib/platform/adapters/family.ts`: adapter read-only con `FamilyReadRepository` inyectable. Normaliza `tipo_relacion` desde perspectiva del actor (invierte si es `usuario2_id`; preserva si inversion devuelve `null`). Fail-closed en `session_required`, `adapter_read_failed`, `invalid_family_data`.
- `lib/platform/family/canAccessMinorData.ts`: guard puro, sin DB. Razones allow: `self`, `explicit_guardian`. Razones deny: `no_actor`, `no_target`, `no_platform_session`, `minor_no_auth`, `insufficient_relation`. Precedencia: session → actor → target → self → relation check.
- `lib/platform/family.ts` (modificado): exporta `normalizePlatformPersonaId` (helper compartido) + tests.
- `lib/platform/experiences.ts` (modificado): agrega `family` experience catalog + `family.minor.read` y `family.minor.consent` capabilities.
- Tests: 60/60 pasan (24 adapter + 24 guard + 12 helper).
- OpenSpec task 4.2 marcada completa.

## Motivación / Por Qué
Fase 4 task 4.2: probar que el sistema NO le da acceso indebido a nadie sobre datos familiares. La decisión arquitectónica clave de Fase 1 ("relaciones como contexto, no permisos amplios") se valida con tests de denegación. 4 spec scenarios cubiertos: tutor denegado operar salones, menor sin auth protegido, permiso familiar insuficiente, no exposición de datos sensibles.

## Migraciones / Base de Datos
- [x] No aplica

## Impacto y Riesgos
- Sin cambios de comportamiento: el guard y el adapter no son consumidos aún. La integración con rutas reales queda para Fases 4-7.
- 372 líneas, dentro del presupuesto de 400.
- Capabilities nuevas son definition-only (no wireadas en session builder).
- Real `FamilyReadRepository` impl con Supabase queda para Fase 5.

## Checklist Autor
- [x] Código formateado (Prettier/ESLint)
- [x] Sin `console.log` / debugger
- [x] Tipos TypeScript correctos
- [x] Sin PII ni datos sensibles
- [x] Documentación actualizada (`openspec/changes/fase-01-platform-foundation/tasks.md`)
- [x] Rebase con `main` limpio

## Checklist Revisor
- [x] Propósito claro
- [x] Nombres descriptivos (convención `Family*` / `Platform*` consistente)
- [x] Sin lógica duplicada (`normalizePlatformPersonaId` extraído)
- [x] Manejo adequado de errores (fail-closed paths)
- [x] Cambios acotados al alcance
- [x] Sin secretos / datos sensibles

## Pruebas Realizadas
- [x] `pnpm test -- __tests__/lib/platform --runInBand` — 9 suites / 133 tests
- [x] `npx eslint <changed files> --max-warnings 0`
- [x] `npx tsc --noEmit`
- [x] `pnpm test:ci` — 57 suites / 600 tests + 26 node tests
- [x] `git diff --check`

## Pendientes / Follow-up
- Fase 5 task 5.1: `lib/platform/preflight.ts` (bloqueo `uno_a_uno`).
- Fase 5 task 5.2: `lib/platform/participation.ts` (ledger longitudinal).
- Fase 6: `lib/platform/grants.ts` (auditoría + métricas).
- Real `FamilyReadRepository` impl con Supabase (Fase 5+).
- Sentry observability para denegaciones (Fase 6).
- SUGGESTIONs R2/R4 deferred: audit reason narrowing, `hasAuthAccount` comment, runtime null check tightening, `errorCategory` para `adapter_read_failed`.

## Notas Adicionales
Fresh 4R review encontró 5 warnings R2 y 1 critical R4 (no commits). Todos resueltos antes del commit: rename `familia` → `family` (English), drop `esPrincipal` y `explicit_authorized`, extraer `normalizePlatformPersonaId` a `lib/platform/family.ts`, quitar `no_family_relations` y `not_a_minor` del allowlist (consistente con non-goals).
