### PR TITLE
feat(platform): preflight bloqueante para uno_a_uno sin decisión formal

### DIFF
--- a/__tests__/lib/platform/preflight.test.ts
+++ b/__tests__/lib/platform/preflight.test.ts
@@ -1,0 +1,132 @@
+import {
+  PLATFORM_UNO_A_UNO_REQUIRED_STEPS,
+  registerPlatformUnoAUnoDecision,
+  runPlatformUnoAUnoPreflight,
+  _resetPlatformUnoAUnoPreflight,
+  type PlatformUnoAUnoPreflightResult,
+} from '@/lib/platform/preflight'
+
+describe('lib/platform/preflight', () => {
+  beforeEach(() => {
+    _resetPlatformUnoAUnoPreflight()
+  })
+
+  describe('runPlatformUnoAUnoPreflight', () => {
+    it('denies by default because no formal decision has been registered', () => {
+      const result = runPlatformUnoAUnoPreflight()
+
+      expect(result).toEqual({
+        ok: false,
+        reason: 'no_formal_decision',
+        missing: PLATFORM_UNO_A_UNO_REQUIRED_STEPS,
+      })
+    })
+
+    it('returns the registered baseline decision with evidence', () => {
+      const decision: PlatformUnoAUnoPreflightResult = {
+        ok: true,
+        decision: 'baseline',
+        evidence: {
+          migration_version: '20260629_001',
+          rls_verified: 'true',
+          rollback_script: 'supabase/migrations/20260629_001_uno_a_uno_baseline_rollback.sql',
+        },
+      }
+
+      registerPlatformUnoAUnoDecision(decision)
+
+      expect(runPlatformUnoAUnoPreflight()).toEqual(decision)
+    })
+
+    it('returns the registered archive decision with evidence', () => {
+      const decision: PlatformUnoAUnoPreflightResult = {
+        ok: true,
+        decision: 'archive',
+        evidence: {
+          archive_date: '2026-06-29',
+          backup_location: 's3://backups/global-connect/uno_a_uno/archive.tar.gz',
+        },
+      }
+
+      registerPlatformUnoAUnoDecision(decision)
+
+      expect(runPlatformUnoAUnoPreflight()).toEqual(decision)
+    })
+
+    it('returns the registered reintroduce decision with evidence', () => {
+      const decision: PlatformUnoAUnoPreflightResult = {
+        ok: true,
+        decision: 'reintroduce',
+        evidence: {
+          feature_issue: '#240',
+          rls_verified: 'true',
+          rollback_script: 'supabase/migrations/20260629_001_uno_a_uno_reintroduce_rollback.sql',
+        },
+      }
+
+      registerPlatformUnoAUnoDecision(decision)
+
+      expect(runPlatformUnoAUnoPreflight()).toEqual(decision)
+    })
+
+    it('returns the default denial after the registry is reset', () => {
+      registerPlatformUnoAUnoDecision({
+        ok: true,
+        decision: 'baseline',
+        evidence: {
+          migration_version: '20260629_001',
+          rls_verified: 'true',
+          rollback_script: 'supabase/migrations/20260629_001_uno_a_uno_baseline_rollback.sql',
+        },
+      })
+      _resetPlatformUnoAUnoPreflight()
+
+      const result = runPlatformUnoAUnoPreflight()
+
+      expect(result).toEqual({
+        ok: false,
+        reason: 'no_formal_decision',
+        missing: PLATFORM_UNO_A_UNO_REQUIRED_STEPS,
+      })
+    })
+  })
+
+  describe('type gate', () => {
+    it('blocks registration without the required baseline evidence fields', () => {
+      // @ts-expect-error evidence must contain migration_version, rls_verified, rollback_script
+      registerPlatformUnoAUnoDecision({ ok: true, decision: 'baseline', evidence: {} })
+      _resetPlatformUnoAUnoPreflight()
+
+      expect(runPlatformUnoAUnoPreflight().ok).toBe(false)
+    })
+
+    it('blocks registration without the required archive evidence fields', () => {
+      // @ts-expect-error evidence must contain archive_date, backup_location
+      registerPlatformUnoAUnoDecision({ ok: true, decision: 'archive', evidence: {} })
+      _resetPlatformUnoAUnoPreflight()
+
+      expect(runPlatformUnoAUnoPreflight().ok).toBe(false)
+    })
+
+    it('blocks registration without the required reintroduce evidence fields', () => {
+      // @ts-expect-error evidence must contain feature_issue, rls_verified, rollback_script
+      registerPlatformUnoAUnoDecision({ ok: true, decision: 'reintroduce', evidence: {} })
+      _resetPlatformUnoAUnoPreflight()
+
+      expect(runPlatformUnoAUnoPreflight().ok).toBe(false)
+    })
+
+    it('blocks registration of an explicit denial result', () => {
+      const denial = {
+        ok: false,
+        reason: 'no_formal_decision',
+        missing: ['baseline_migration'],
+      } as const
+      // @ts-expect-error only ok:true decisions can be registered
+      registerPlatformUnoAUnoDecision(denial)
+      _resetPlatformUnoAUnoPreflight()
+
+      expect(runPlatformUnoAUnoPreflight().ok).toBe(false)
+    })
+  })
+})

--- a/lib/platform/preflight.ts
+++ b/lib/platform/preflight.ts
@@ -1,0 +1,68 @@
+export type PlatformUnoAUnoDecision = 'baseline' | 'archive' | 'reintroduce'
+
+export type PlatformUnoAUnoPreflightMissing =
+  | 'baseline_migration'
+  | 'schema_types_match'
+  | 'live_tables_expected'
+  | 'rls_verification'
+  | 'rollback_strategy'
+
+export const PLATFORM_UNO_A_UNO_REQUIRED_STEPS: readonly PlatformUnoAUnoPreflightMissing[] = [
+  'baseline_migration',
+  'schema_types_match',
+  'live_tables_expected',
+  'rls_verification',
+  'rollback_strategy',
+]
+
+export type PlatformUnoAUnoBaselineEvidence = {
+  migration_version: string
+  rls_verified: string
+  rollback_script: string
+}
+
+export type PlatformUnoAUnoArchiveEvidence = {
+  archive_date: string
+  backup_location: string
+}
+
+export type PlatformUnoAUnoReintroduceEvidence = {
+  feature_issue: string
+  rls_verified: string
+  rollback_script: string
+}
+
+export type PlatformUnoAUnoPreflightResult =
+  | { ok: true; decision: 'baseline'; evidence: PlatformUnoAUnoBaselineEvidence }
+  | { ok: true; decision: 'archive'; evidence: PlatformUnoAUnoArchiveEvidence }
+  | { ok: true; decision: 'reintroduce'; evidence: PlatformUnoAUnoReintroduceEvidence }
+  | { ok: false; reason: 'no_formal_decision'; missing: PlatformUnoAUnoPreflightMissing[] }
+
+export type PlatformUnoAUnoRegisteredDecision = Extract<
+  PlatformUnoAUnoPreflightResult,
+  { ok: true }
+>
+
+// Module-level registry (mutable ONLY via explicit registration in a future commit)
+let registeredDecision: PlatformUnoAUnoRegisteredDecision | null = null
+
+export function registerPlatformUnoAUnoDecision(
+  decision: PlatformUnoAUnoRegisteredDecision,
+): void {
+  registeredDecision = decision
+}
+
+/** Exported for test isolation only; not part of the public API contract */
+export function _resetPlatformUnoAUnoPreflight(): void {
+  registeredDecision = null
+}
+
+export function runPlatformUnoAUnoPreflight(): PlatformUnoAUnoPreflightResult {
+  if (registeredDecision) return registeredDecision
+
+  return {
+    ok: false,
+    reason: 'no_formal_decision',
+    missing: [...PLATFORM_UNO_A_UNO_REQUIRED_STEPS],
+  }
+}

--- a/openspec/changes/fase-01-platform-foundation/tasks.md
+++ b/openspec/changes/fase-01-platform-foundation/tasks.md
@@ -66,7 +66,8 @@ Chain strategy: stacked-to-main para PR1a; confirmar por slice futuro
 
 ## Fase 5: Ledger longitudinal y `uno_a_uno` preflight
 
-- [ ] 5.1 Crear `lib/platform/preflight.ts` para bloquear `uno_a_uno` sin baseline/archive/reintroducción formal; test de falla pre-implementación.
+- [x] 5.1 Crear `lib/platform/preflight.ts` para bloquear `uno_a_uno` sin baseline/archive/reintroducción formal; test de falla pre-implementación.
+  - Issue #232: `lib/platform/preflight.ts` + `__tests__/lib/platform/preflight.test.ts`. Preflight puro discriminated-union, sin DB ni imports de `@/lib/supabase/*`; registro mutable solo vía `registerPlatformUnoAUnoDecision`; denegación por defecto con `reason: 'no_formal_decision'` y `PLATFORM_UNO_A_UNO_REQUIRED_STEPS`. R2 aplicado: nombres con prefijo `Platform*`, evidencia discriminada por decisión (`PlatformUnoAUnoBaselineEvidence`, `PlatformUnoAUnoArchiveEvidence`, `PlatformUnoAUnoReintroduceEvidence`) y `PlatformUnoAUnoRegisteredDecision` estrechado a `ok: true`.
 - [ ] 5.2 Crear `lib/platform/participation.ts` con clasificación de sensibilidad, retención, actor/fuente y boundaries de lectura.
 - [ ] 5.3 Probar lectura autorizada, denegación fuera de scope, evento sin permisos y no revelación de existencia de datos sensibles.
 


### PR DESCRIPTION
Closes #232

## Resumen
Crea `lib/platform/preflight.ts` con `runPlatformUnoAUnoPreflight()` que por defecto deniega cualquier uso de `uno_a_uno` con `reason: 'no_formal_decision'` y lista los 5 criterios formales faltantes (baseline_migration, schema_types_match, live_tables_expected, rls_verification, rollback_strategy). Task 5.1 de Fase 5 completa.

## Qué Incluye
- Módulo puro, zero imports, sin DB/filesystem/env.
- `PlatformUnoAUnoDecision` (literal union: baseline | archive | reintroduce).
- `evidence` discriminated por decisión: `PlatformUnoAUnoBaselineEvidence` (migration_version, rls_verified, rollback_script), `PlatformUnoAUnoArchiveEvidence` (archive_date, backup_location), `PlatformUnoAUnoReintroduceEvidence` (feature_issue, rls_verified, rollback_script). El gate NO se puede abrir con `evidence: {}` — el type system lo impide.
- `registerPlatformUnoAUnoDecision(decision: PlatformUnoAUnoRegisteredDecision)` solo acepta `ok: true` variants. Intentos de registrar denials son type error.
- `PLATFORM_UNO_A_UNO_REQUIRED_STEPS` constant exportada.
- Tests: 9 focused (5 behavior + 4 type-gate via `@ts-expect-error`).

## Motivación / Por Qué
Las tablas `uno_a_uno_reuniones` y `uno_a_uno_participantes` existen en DB live + `database.types.ts` con RLS pero sin migración local, sin rutas/actions, y sin capability catalog entry. Este drift es una bomba sin desactivar: cualquier PR futuro podría usar estas tablas sin pasar por un guard. Task 5.1 pone un fusible explícito: el preflight deniega por defecto hasta que se tome una decisión formal (baseline migration, archive del drift, o reintroducción explícita) con la evidencia completa.

## Migraciones / Base de Datos
- [x] No aplica

## Impacto y Riesgos
- Sin cambios de comportamiento en producción: el módulo no es consumido por ningún código runtime actual.
- 202 líneas, dentro del presupuesto de 400.
- No se migra, usa, ni reconcilia `uno_a_uno` — solo se documenta el riesgo y se provee el guard.

## Checklist Autor
- [x] Código formateado (Prettier/ESLint)
- [x] Sin `console.log` / debugger
- [x] Tipos TypeScript correctos
- [x] Sin PII ni datos sensibles
- [x] Documentación actualizada (`openspec/changes/fase-01-platform-foundation/tasks.md`)
- [x] Rebase con `main` limpio

## Checklist Revisor
- [x] Propósito claro
- [x] Nombres descriptivos (convención `Platform*` consistente con `lib/platform/`)
- [x] Sin lógica duplicada (`PLATFORM_UNO_A_UNO_REQUIRED_STEPS` extraído)
- [x] Manejo adequado de errores (fail-closed default; type system previene bypass con `{}`)
- [x] Cambios acotados al alcance
- [x] Sin secretos / datos sensibles

## Pruebas Realizadas
- [x] `pnpm test -- __tests__/lib/platform/preflight.test.ts --runInBand` — 9/9
- [x] `npx eslint <changed files> --max-warnings 0`
- [x] `npx tsc --noEmit`
- [x] `pnpm test:ci` — 58 suites / 609 tests + 26 node tests
- [x] `git diff --check`

## Pendientes / Follow-up
- Task 5.2: `lib/platform/participation.ts` (modelo de eventos longitudinales con sensibilidad/retention/actor/fuente).
- Task 5.3: tests de denegación de participation (lectura autorizada, fuera de scope, sin permisos, no revelación de existencia).
- Cuando se decida el futuro de `uno_a_uno` (baseline/archive/reintroduce), un futuro commit llama `registerPlatformUnoAUnoDecision` con la evidencia correspondiente.
- Sentry observability para denegaciones de participation (Fase 6).

## Notas Adicionales
Fresh 4R review encontró 1 CRITICAL R2 (evidence contract opaque, gate could be bypassed with `{}`), 2 WARNINGs R2 (naming convention, duplicated array), y 1 SUGGESTION R2 (silent ignore de denials). Todos resueltos: discriminated evidence types por decisión, Platform* prefix consistente, constant extraído, input type narrowed. R1/R3/R4 PASS sin bloqueantes.
