### PR TITLE
feat(platform): grants.ts — auditoría de grants con métricas y alertas

### DIFF
--- a/__tests__/lib/platform/grants.test.ts
+++ b/__tests__/lib/platform/grants.test.ts
@@ -1,0 +1,179 @@
+import {
+  createPlatformGrantAudit,
+  PLATFORM_GRANT_DECISIONS,
+  type PlatformGrantAuditEvent,
+  type PlatformGrantMetricsSnapshot,
+} from '@/lib/platform/grants'
+
+const scope = (experience: string, source: string): PlatformGrantAuditEvent => ({
+  actorPersonaId: 'persona-1',
+  source,
+  decision: 'grant',
+  scope: { experience, scopeType: 'group' },
+  recordedAt: new Date('2026-07-06T00:00:00.000Z'),
+})
+
+const deny = (experience: string, source: string): PlatformGrantAuditEvent => ({
+  actorPersonaId: 'persona-2',
+  source,
+  decision: 'deny',
+  scope: { experience, scopeType: 'course' },
+  reason: 'missing_capability',
+  recordedAt: new Date('2026-07-06T01:00:00.000Z'),
+})
+
+function buildMetrics(entries: [string, number][]): PlatformGrantMetricsSnapshot {
+  return new Map(entries) as PlatformGrantMetricsSnapshot
+}
+
+describe('lib/platform/grants', () => {
+  describe('createPlatformGrantAudit', () => {
+    it('returns a non-null system object', () => {
+      const system = createPlatformGrantAudit()
+      expect(system).not.toBeNull()
+      expect(typeof system.logger.record).toBe('function')
+      expect(typeof system.metrics.recordGrant).toBe('function')
+      expect(typeof system.checkDenialThreshold).toBe('function')
+    })
+
+    it('returns independent instances', () => {
+      const a = createPlatformGrantAudit()
+      const b = createPlatformGrantAudit()
+      a.metrics.recordGrant('grupos_vida', 'app.gdv')
+      expect(a.metrics.getSnapshot().get('grupos_vida|app.gdv|grant')).toBe(1)
+      expect(b.metrics.getSnapshot().get('grupos_vida|app.gdv|grant')).toBeUndefined()
+    })
+
+    it('exports the four canonical decisions', () => {
+      expect(PLATFORM_GRANT_DECISIONS).toEqual(['grant', 'revoke', 'deny', 'audit'])
+    })
+  })
+
+  describe('audit event recording', () => {
+    it('records grant, deny and audit events in order and updates metrics', () => {
+      const { logger, metrics } = createPlatformGrantAudit()
+      const grant = scope('grupos_vida', 'app.gdv')
+      const revocation: PlatformGrantAuditEvent = {
+        ...grant,
+        decision: 'revoke',
+        reason: 'role_changed',
+        after: { active: false },
+      }
+      const audit: PlatformGrantAuditEvent = {
+        ...grant,
+        decision: 'audit',
+        source: 'system.audit',
+      }
+
+      logger.record(grant)
+      logger.record(deny('dps', 'app.dps'))
+      logger.record(revocation)
+      logger.record(audit)
+
+      expect(logger.getEvents()).toEqual([grant, deny('dps', 'app.dps'), revocation, audit])
+      expect(metrics.getSnapshot().get('grupos_vida|app.gdv|grant')).toBe(1)
+      expect(metrics.getSnapshot().get('dps|app.dps|deny')).toBe(1)
+      expect(metrics.getSnapshot().get('grupos_vida|app.gdv|revoke')).toBe(1)
+      expect(metrics.getSnapshot().get('grupos_vida|system.audit|audit')).toBe(1)
+    })
+  })
+
+  describe('metrics accumulation', () => {
+    it('increments only the requested metric key', () => {
+      const { metrics } = createPlatformGrantAudit()
+      metrics.recordGrant('grupos_vida', 'app.gdv')
+      metrics.recordDenial('dps', 'app.dream-team')
+      metrics.recordAudit('grupos_vida', 'system.audit')
+      metrics.recordRevoke('dps', 'app.dps')
+
+      const snapshot = metrics.getSnapshot()
+      expect(snapshot.get('grupos_vida|app.gdv|grant')).toBe(1)
+      expect(snapshot.get('dps|app.dream-team|deny')).toBe(1)
+      expect(snapshot.get('grupos_vida|system.audit|audit')).toBe(1)
+      expect(snapshot.get('dps|app.dps|revoke')).toBe(1)
+      expect(snapshot.get('grupos_vida|app.gdv|deny')).toBeUndefined()
+    })
+
+    it('returns a ReadonlyMap with independent counts per source', () => {
+      const { metrics } = createPlatformGrantAudit()
+      metrics.recordGrant('grupos_vida', 'app.gdv')
+      metrics.recordGrant('grupos_vida', 'legacy.admin')
+      const snapshot = metrics.getSnapshot()
+      expect(snapshot).toBeInstanceOf(Map)
+      expect(snapshot.get('grupos_vida|app.gdv|grant')).toBe(1)
+      expect(snapshot.get('grupos_vida|legacy.admin|grant')).toBe(1)
+    })
+
+    it('tracks grant and denial metrics separately for the same experience and source', () => {
+      const { metrics } = createPlatformGrantAudit()
+      metrics.recordGrant('grupos_vida', 'app.gdv')
+      metrics.recordDenial('grupos_vida', 'app.gdv')
+      const snapshot = metrics.getSnapshot()
+      expect(snapshot.get('grupos_vida|app.gdv|grant')).toBe(1)
+      expect(snapshot.get('grupos_vida|app.gdv|deny')).toBe(1)
+    })
+  })
+
+  describe('alert threshold check', () => {
+    it('returns ok when denials are at or below the threshold', () => {
+      const below = createPlatformGrantAudit().checkDenialThreshold(
+        buildMetrics([['grupos_vida|app.gdv|deny', 3]]),
+        { maxDenials: 5, windowMinutes: 10 },
+      )
+      const exact = createPlatformGrantAudit().checkDenialThreshold(
+        buildMetrics([['grupos_vida|app.gdv|deny', 5]]),
+        { maxDenials: 5, windowMinutes: 10 },
+      )
+      expect(below).toEqual({ ok: true, alerts: [] })
+      expect(exact).toEqual({ ok: true, alerts: [] })
+    })
+
+    it('returns an alert when denials exceed the threshold', () => {
+      const result = createPlatformGrantAudit().checkDenialThreshold(
+        buildMetrics([['dps|app.dps|deny', 7]]),
+        { maxDenials: 5, windowMinutes: 10 },
+      )
+      expect(result).toEqual({
+        ok: false,
+        alerts: [
+          { key: 'dps|app.dps', experience: 'dps', source: 'app.dps', denialCount: 7, threshold: 5 },
+        ],
+      })
+    })
+
+    it('returns multiple alerts and ignores non-deny keys', () => {
+      const result = createPlatformGrantAudit().checkDenialThreshold(
+        buildMetrics([
+          ['grupos_vida|app.gdv|grant', 100],
+          ['grupos_vida|app.gdv|deny', 9],
+          ['dps|app.dream-team|deny', 6],
+        ]),
+        { maxDenials: 5, windowMinutes: 10 },
+      )
+      expect(result.ok).toBe(false)
+      expect(result.alerts).toHaveLength(2)
+      expect(result.alerts).toContainEqual({
+        key: 'grupos_vida|app.gdv',
+        experience: 'grupos_vida',
+        source: 'app.gdv',
+        denialCount: 9,
+        threshold: 5,
+      })
+      expect(result.alerts).toContainEqual({
+        key: 'dps|app.dream-team',
+        experience: 'dps',
+        source: 'app.dream-team',
+        denialCount: 6,
+        threshold: 5,
+      })
+    })
+
+    it('returns ok for an empty metrics snapshot', () => {
+      const result = createPlatformGrantAudit().checkDenialThreshold(
+        buildMetrics([]),
+        { maxDenials: 5, windowMinutes: 10 },
+      )
+      expect(result).toEqual({ ok: true, alerts: [] })
+    })
+  })
+})

--- a/lib/platform/grants.ts
+++ b/lib/platform/grants.ts
@@ -1,0 +1,186 @@
+// Grants audit contract: actor/source/before-after/deny logging, metrics and alerts.
+//
+// Pure module. No DB, no filesystem, no env vars, no `@/lib/supabase/*` imports.
+// Future adapters (Supabase, syslog, Axiom) implement `PlatformGrantAuditLogger`
+// without changing this module.
+
+// ── Decision taxonomy ───────────────────────────────────────────────
+export const PLATFORM_GRANT_DECISIONS = ['grant', 'revoke', 'deny', 'audit'] as const
+export type PlatformGrantDecision = (typeof PLATFORM_GRANT_DECISIONS)[number]
+
+// ── Scope context ───────────────────────────────────────────────────
+export type PlatformGrantAuditScope = {
+  experience: string
+  scopeType: string
+  scopeId?: string
+}
+
+// ── Grant state snapshot ────────────────────────────────────────────
+export type PlatformGrantState = {
+  active: boolean
+  capabilityKey?: string
+}
+
+// ── Audit event ─────────────────────────────────────────────────────
+export type PlatformGrantAuditEvent = {
+  actorPersonaId: string
+  source: string
+  decision: PlatformGrantDecision
+  scope: PlatformGrantAuditScope
+  before?: PlatformGrantState
+  after?: PlatformGrantState
+  /** Always present for 'deny' and 'revoke'; optional for 'grant'/'audit' */
+  reason?: string
+  recordedAt: Date
+}
+
+// ── Logger interface ────────────────────────────────────────────────
+export interface PlatformGrantAuditLogger {
+  record(event: PlatformGrantAuditEvent): void
+  /** Expose recorded events for test assertions and compliance checks. */
+  getEvents(): readonly PlatformGrantAuditEvent[]
+}
+
+// ── Metrics accumulator ─────────────────────────────────────────────
+export type PlatformGrantMetricsSnapshot = ReadonlyMap<string, number>
+// key format: `${experience}|${source}|${decision}`
+
+export interface PlatformGrantMetrics {
+  recordGrant(experience: string, source: string): void
+  recordRevoke(experience: string, source: string): void
+  recordDenial(experience: string, source: string): void
+  recordAudit(experience: string, source: string): void
+  getSnapshot(): PlatformGrantMetricsSnapshot
+}
+
+// ── Alert threshold ─────────────────────────────────────────────────
+export type PlatformGrantAlertThreshold = {
+  maxDenials: number
+  /** For future time-windowed checks; not used in Fase 6 pure check. */
+  windowMinutes: number
+}
+
+export type PlatformGrantAlert = {
+  key: string // `${experience}|${source}`
+  experience: string
+  source: string
+  denialCount: number
+  threshold: number
+}
+
+export type PlatformGrantAlertCheckResult = {
+  ok: boolean
+  alerts: PlatformGrantAlert[]
+}
+
+// ── Factory return ──────────────────────────────────────────────────
+export type PlatformGrantAuditSystem = {
+  logger: PlatformGrantAuditLogger
+  metrics: PlatformGrantMetrics
+  checkDenialThreshold: (
+    metrics: PlatformGrantMetricsSnapshot,
+    threshold: PlatformGrantAlertThreshold,
+  ) => PlatformGrantAlertCheckResult
+}
+
+function buildMetricKey(experience: string, source: string, decision: PlatformGrantDecision): string {
+  return `${experience}|${source}|${decision}`
+}
+
+function parseDenialKey(metricKey: string): { experience: string; source: string } | null {
+  const parts = metricKey.split('|')
+  if (parts.length !== 3 || parts[2] !== 'deny') return null
+  return { experience: parts[0], source: parts[1] }
+}
+
+class PlatformGrantMetricsAccumulator implements PlatformGrantMetrics {
+  private readonly counts = new Map<string, number>()
+
+  recordGrant(experience: string, source: string): void {
+    this.increment(buildMetricKey(experience, source, 'grant'))
+  }
+
+  recordRevoke(experience: string, source: string): void {
+    this.increment(buildMetricKey(experience, source, 'revoke'))
+  }
+
+  recordDenial(experience: string, source: string): void {
+    this.increment(buildMetricKey(experience, source, 'deny'))
+  }
+
+  recordAudit(experience: string, source: string): void {
+    this.increment(buildMetricKey(experience, source, 'audit'))
+  }
+
+  getSnapshot(): PlatformGrantMetricsSnapshot {
+    return new Map(this.counts)
+  }
+
+  private increment(key: string): void {
+    this.counts.set(key, (this.counts.get(key) ?? 0) + 1)
+  }
+}
+
+class PlatformGrantAuditLoggerImpl implements PlatformGrantAuditLogger {
+  private readonly events: PlatformGrantAuditEvent[] = []
+
+  constructor(private readonly metrics: PlatformGrantMetrics) {}
+
+  record(event: PlatformGrantAuditEvent): void {
+    this.events.push(event)
+
+    switch (event.decision) {
+      case 'grant':
+        this.metrics.recordGrant(event.scope.experience, event.source)
+        break
+      case 'revoke':
+        this.metrics.recordRevoke(event.scope.experience, event.source)
+        break
+      case 'deny':
+        this.metrics.recordDenial(event.scope.experience, event.source)
+        break
+      case 'audit':
+        this.metrics.recordAudit(event.scope.experience, event.source)
+        break
+    }
+  }
+
+  getEvents(): readonly PlatformGrantAuditEvent[] {
+    return this.events.slice()
+  }
+}
+
+function checkDenialThreshold(
+  metrics: PlatformGrantMetricsSnapshot,
+  threshold: PlatformGrantAlertThreshold,
+): PlatformGrantAlertCheckResult {
+  const alerts: PlatformGrantAlert[] = []
+
+  metrics.forEach((count, key) => {
+    const parsed = parseDenialKey(key)
+    if (!parsed) return
+
+    if (count > threshold.maxDenials) {
+      alerts.push({
+        key: `${parsed.experience}|${parsed.source}`,
+        experience: parsed.experience,
+        source: parsed.source,
+        denialCount: count,
+        threshold: threshold.maxDenials,
+      })
+    }
+  })
+
+  return { ok: alerts.length === 0, alerts }
+}
+
+export function createPlatformGrantAudit(): PlatformGrantAuditSystem {
+  const metrics = new PlatformGrantMetricsAccumulator()
+  const logger = new PlatformGrantAuditLoggerImpl(metrics)
+
+  return {
+    logger,
+    metrics,
+    checkDenialThreshold,
+  }
+}

--- a/openspec/changes/fase-01-platform-foundation/tasks.md
+++ b/openspec/changes/fase-01-platform-foundation/tasks.md
@@ -80,7 +80,8 @@ Chain strategy: stacked-to-main para PR1a; confirmar por slice futuro
 
 ## Fase 6: Grants y observabilidad
 
-- [ ] 6.1 Crear `lib/platform/grants.ts` con auditoría actor/fuente/before-after/deny, logs de denegación, métricas y alertas.
+- [x] 6.1 Crear `lib/platform/grants.ts` con auditoría actor/fuente/before-after/deny, logs de denegación, métricas y alertas.
+  - Issue #238: `lib/platform/grants.ts` + `__tests__/lib/platform/grants.test.ts`. Contrato puro con taxonomía `grant|revoke|deny|audit`, logger con `getEvents()` para test assertions, métricas acumuladas por `${experience}|${source}|${decision}` y alerta pura sobre denegaciones cuando `count > maxDenials`.
 
 ## Fase 7: Rollout y gates por PR
 


### PR DESCRIPTION
Closes #238

## Resumen
Crea `lib/platform/grants.ts` con el contrato puro de auditoría de grants: `createPlatformGrantAudit()` factory con logger + métricas + check de umbral de denegaciones. Fase 6 task 6.1 completa.

## Qué Incluye
- Decision taxonomy: `grant | revoke | deny | audit`.
- `PlatformGrantAuditEvent` tipado (actor, source, scope, before/after state, reason, recordedAt).
- `PlatformGrantAuditLogger` interface para futuros adapters (DB, Sentry, etc.).
- `PlatformGrantMetrics` acumulador por experience+source.
- `checkDenialThreshold()` función pura que produce `PlatformGrantAlert[]`.
- Factory sin estado mutable de módulo (instancias independientes).
- 367 líneas, 11 tests unitarios, 658 tests full CI.

## Notas Adicionales
Sin DB/Supabase — adapters futuros implementan la misma interface. `system_audit` del participation guard queda listo para wiring en task 6.2 o Fase 7.
