### PR TITLE
fix(platform): routeGuard no redirige con flag OFF (fail-open)

### DIFF
--- a/__tests__/app/configuracion-pages.test.tsx
+++ b/__tests__/app/configuracion-pages.test.tsx
@@ -30,16 +30,17 @@ describe('configuracion pages render through the platform route guard without ch
     restoreEnv('NEXT_PUBLIC_PLATFORM_NAVIGATION_KILL_SWITCH', originalKillSwitch)
   })
 
-  it('redirects /configuracion/directores-generales to /dashboard when the platform flag is off', async () => {
+  it('renders /configuracion/directores-generales when the platform flag is off (pre-slice behavior preserved)', async () => {
     delete process.env.NEXT_PUBLIC_PLATFORM_NAVIGATION_ENABLED
-    getUserWithRoles.mockResolvedValue({ user: { id: 'auth-1' }, roles: ['admin'], platformSession: null })
+    getUserWithRoles.mockResolvedValue({ user: { id: 'auth-1' }, roles: ['admin', 'pastor', 'director-general'], platformSession: null })
     const { default: DirectoresGeneralesPage } = await import('@/app/(auth)/configuracion/directores-generales/page')
 
-    await expect(DirectoresGeneralesPage()).rejects.toThrow(/NEXT_REDIRECT:\/dashboard/)
+    await act(async () => { render(await DirectoresGeneralesPage()) })
+
+    expect(screen.getByText('Directores Generales')).toBeInTheDocument()
   })
 
   it.each([
-    ['feature flag is off', {}, null],
     ['kill switch is active', { enabled: 'true', killSwitch: 'true' }, null],
     ['platform session is missing', { enabled: 'true' }, null],
     ['platform session has no capabilities', { enabled: 'true' }, buildPlatformSession([])],

--- a/__tests__/app/support-pages.test.tsx
+++ b/__tests__/app/support-pages.test.tsx
@@ -478,7 +478,6 @@ describe('support capability configuration page platform route guard', () => {
   })
 
   it.each([
-    ['feature flag is off', {}, null],
     ['kill switch is active', { enabled: 'true', killSwitch: 'true' }, null],
     ['platform session is missing', { enabled: 'true' }, null],
     ['platform session has no capabilities', { enabled: 'true' }, buildSupportPlatformSession([])],
@@ -489,6 +488,20 @@ describe('support capability configuration page platform route guard', () => {
     getUserWithRoles.mockResolvedValue({ user: { id: 'auth-1' }, roles: ['director-general'], platformSession })
 
     await expect(SupportCapabilitiesPage()).rejects.toThrow(/NEXT_REDIRECT:\/dashboard/)
+  })
+
+  it('renders the support capability configuration when the platform flag is off (pre-slice behavior preserved)', async () => {
+    setSupportNavigationEnv({})
+    createSupabaseServerClient.mockResolvedValue(createSupportCapabilitiesPageSupabase(true))
+    getUserWithRoles.mockResolvedValue({
+      user: { id: 'auth-1' },
+      roles: ['director-general'],
+      platformSession: null,
+    })
+
+    await act(async () => { render(await SupportCapabilitiesPage()) })
+
+    expect(screen.getByRole('heading', { name: /Capacidades permitidas/i })).toBeInTheDocument()
   })
 
   it('renders the configuration UI when the platform flag is on and the required capability is present', async () => {

--- a/__tests__/lib/platform/routeGuard.test.ts
+++ b/__tests__/lib/platform/routeGuard.test.ts
@@ -46,8 +46,17 @@ describe('getPlatformNavigationFlags', () => {
 })
 
 describe('checkPlatformRouteAccess', () => {
+  it('allows access with reason when the feature flag is disabled to preserve pre-slice behavior', () => {
+    const result = checkPlatformRouteAccess({
+      flags: { enabled: false },
+      platformSession: basePlatformSession,
+      requiredCapability: 'support.manage',
+    })
+
+    expect(result).toEqual({ allowed: true, reason: 'feature_flag_disabled' })
+  })
+
   it.each([
-    ['feature flag is disabled', { enabled: false }, basePlatformSession, 'feature_flag_disabled'],
     ['kill switch is active', { enabled: true, killSwitch: true }, basePlatformSession, 'kill_switch_enabled'],
     ['no platformSession', { enabled: true }, null, 'platform_session_required'],
     ['empty capabilities', { enabled: true }, { ...basePlatformSession, capabilities: [] }, 'no_platform_grants'],

--- a/lib/platform/routeGuard.ts
+++ b/lib/platform/routeGuard.ts
@@ -9,7 +9,7 @@ export type PlatformRouteGuardReason =
   | 'missing_required_capability'
 
 export type PlatformRouteGuardResult =
-  | { allowed: true }
+  | { allowed: true; reason?: string }
   | { allowed: false; reason: PlatformRouteGuardReason }
 
 export type PlatformRouteGuardInput = {
@@ -26,11 +26,15 @@ export type PlatformRouteGuardInput = {
  * and decides what to do with a denial. Strict denial is out of scope for
  * Fase 1 task 3.3; add Sentry capture at the deny branches when Fase 2 enables
  * hard-deny.
+ *
+ * When the feature flag is disabled, the guard returns
+ * `{ allowed: true, reason: 'feature_flag_disabled' }` to ensure pre-slice
+ * behavior is preserved. The caller's role-based check remains the real gate.
  */
 export function checkPlatformRouteAccess(input: PlatformRouteGuardInput): PlatformRouteGuardResult {
   const flags = normalizeFlags(input.flags)
 
-  if (!flags.enabled) return { allowed: false, reason: 'feature_flag_disabled' }
+  if (!flags.enabled) return { allowed: true, reason: 'feature_flag_disabled' }
   if (flags.killSwitch) return { allowed: false, reason: 'kill_switch_enabled' }
   if (!input.platformSession) return { allowed: false, reason: 'platform_session_required' }
   if (input.requiredCapability.trim() === '') return { allowed: true }


### PR DESCRIPTION
Closes #242

## Resumen

Critical bugfix: `lib/platform/routeGuard.ts` retornaba `{ allowed: false, reason: 'feature_flag_disabled' }` cuando el flag estaba OFF. Las 3 páginas cableadas (`/configuracion`, `/configuracion/directores-generales`, `/configuracion/soporte`) hacían `if (!routeGuard.allowed) redirect('/dashboard')` → en Vercel con flag OFF los admins/pastors/director-general eran redirigidos fuera de esas páginas, contradiciendo el contrato "con flag off el comportamiento debe ser IDÉNTICO al pre-slice".

## El fix

`checkPlatformRouteAccess()` con `flags.enabled === false` ahora retorna `{ allowed: true, reason: 'feature_flag_disabled' }` (allow con reason para observabilidad). El role/capability legacy existente en cada página sigue siendo el verdadero gate. El platform guard solo actúa cuando flag está ON y la capability falta.

## Cambios

- `lib/platform/routeGuard.ts`: branch de `flags.enabled` cambia de deny a allow con reason. `PlatformRouteGuardResult` ahora permite `reason?: string` en la rama allowed. JSDoc documenta el contrato fail-open.
- `__tests__/lib/platform/routeGuard.test.ts`: nuevo test explícito "returns allow with reason when feature flag is disabled"; deny `it.each` ahora cubre solo los 4 deny reasons restantes.
- `__tests__/app/configuracion-pages.test.tsx`: el test standalone para `/configuracion/directores-generales` ahora asserte render con flag off (no redirect). El `it.each` de redirect de `/configuracion` ya no incluye "feature flag is off".
- `__tests__/app/support-pages.test.tsx`: el `it.each` de redirect de `/configuracion/soporte` ya no incluye "feature flag is off". Test positivo que renderiza la página con flag off (descubierto en full CI, no en focused verification — fix incluido en el mismo slice).

## Verificación

- Tests focused: 16/16 passing.
- Platform regression: 199/199 passing.
- Full CI: 62 suites / 665 tests + 26 node tests.
- `tsc --noEmit` clean, `eslint --max-warnings 0` clean.
- `git diff --check` clean.
- 35 insertions, 8 deletions = 43 changed lines, dentro del budget de 200.

## No tocado

- Las 3 páginas cableadas NO cambiaron: el código de las páginas ya hace `if (!routeGuard.allowed)` correctamente. Solo el guard retorna un valor diferente ahora.
- Legacy role checks en cada página siguen siendo el gate real.
- No Supabase remoto, no migraciones, no RLS.
- No otras rutas (`/dashboard`, etc.).
- No redesign de `routeGuard.ts`.
- No otros PRs mergeados.
