### PR TITLE
docs(sdd): Fase 2 — Dream Team Global Base (planning completo)

### DIFF
--- a/openspec/changes/fase-02-dream-team-base/design.md
+++ b/openspec/changes/fase-02-dream-team-base/design.md
@@ -1,0 +1,279 @@
+# Design: Fase 2 — Dream Team Global Base
+
+> Stack detected: Next.js 16 + React 19 + TS strict + Supabase + Tailwind 4 + Jest 30 + pnpm.
+> Architecture: additive over Fase 1 (`lib/platform/**` contratos puros + repository pattern + discriminated unions).
+> Style: Strict TDD RED→GREEN→REFACTOR, PRs encadenados (force-chained, stacked-to-main), budget 400 líneas / PR con `size:exception` documentada.
+
+## 1. Resumen arquitectónico
+
+Fase 1 dejó una **foundation aditiva** sin modelo de servicio. Fase 2 introduce un **dominio nuevo** (`dream_team_*`) que modela `(persona, equipo, rol, estado, requisitos)` y lo expone como `PlatformSessionCapability` vía adapters. Encaja así:
+
+| Capa | Estado Fase 1 | Cambio Fase 2 | Tipo |
+|---|---|---|---|
+| Persona canónica | `usuarios.id` | sin cambios | contrato |
+| Experiencias | 7 keys en `PLATFORM_EXPERIENCE_CATALOG` | + `dream_team` (scopeTypes: `['experience','equipo']`) | extensión aditiva |
+| Capabilities | 8 keys | +7 genéricas +7 específicas = +14 keys | extensión aditiva |
+| Adapter pattern | GDV + Family | + `dream-team.ts` (servicios) + `dream-team-gdv.ts` (líderes) | nuevo |
+| Grants audit | contrato puro sin adapter | orquestador Dream Team consume `lib/platform/grants.ts` | consumidor (sin tocar) |
+| Participation | contrato puro + fake in-memory | writer Supabase real para `service` + extension adapter | nuevo writer + existente read |
+| Navigation | 9 definiciones | + ítems Dream Team (`availableHref: undefined` hasta rollout) | extensión aditiva |
+| Preflight `uno_a_uno` | bloqueado | sin cambios — sigue bloqueado | contrato (no se toca) |
+| DB | 180 migraciones existentes | +1 migración aditiva (CREATE TABLE + ENUM + RLS + INDEX) | aditiva pura |
+| Flags | `NEXT_PUBLIC_PLATFORM_NAVIGATION_ENABLED` | + `NEXT_PUBLIC_DREAM_TEAM_ENABLED=off` por defecto | nuevo flag |
+
+**Diagrama lógico de módulos:**
+
+```
+Domain puro (sin DB)
+  dream-team/types.ts ──► tipos compartidos
+  dream-team/errors.ts ──► errores tipados (discriminated union)
+  dream-team/state-machine.ts ──► transiciones válidas + motivo obligatorio
+  dream-team/metrics.ts ──► agregados puros (4 métricas)
+
+Repository layer (interface + 2 impls)
+  dream-team/repository.ts ──► DreamTeamRepository (read+write)
+  dream-team/repository-fake.ts ──► in-memory para tests
+  dream-team/repository-supabase.ts ──► impl real (S4)
+
+Service layer (casos de uso)
+  dream-team/equipos.ts ──► listar / jerarquía
+  dream-team/roles.ts ──► listar / jerarquía
+  dream-team/servicios.ts ──► CRUD + state machine + audit
+  dream-team/requisitos.ts ──► CRUD + verificación
+  dream-team/grants.ts ──► orquestador (activar/reactivar grant; pausa revoke+snapshot)
+  dream-team/metrics.ts ──► expone getDreamTeamMetrics()
+
+Adapters platform
+  adapters/dream-team-gdv.ts ──► reader GDV → capabilities dream_team.gdv.lead
+  adapters/participation-adapter.ts ──► +writer Supabase service events
+
+API (Next route handlers)
+  app/api/dream-team/metrics/route.ts ──► GET autenticado + capability
+  app/api/dream-team/servicios/route.ts ──► GET/POST listar/asignar
+  app/api/dream-team/servicios/[id]/route.ts ──► GET/PATCH/DELETE
+```
+
+## 2. Módulos nuevos (a crear)
+
+| Path | Responsabilidad pública | Exports clave | Dependencias |
+|---|---|---|---|
+| `lib/platform/dream-team/state-machine.ts` | Validar transiciones del state machine de 6 estados + motivo obligatorio | `validateDreamTeamTransition(from, to, motivo)`, `DREAM_TEAM_STATES`, `DREAM_TEAM_TRANSITION_MOTIVOS`, `DREAM_TEAM_TRANSITION_MATRIX` | ninguna (puro) |
+| `lib/platform/dream-team/types.ts` | Tipos compartidos: `DreamTeamEstado`, `DreamTeamServicio`, `DreamTeamEquipo`, `DreamTeamRol`, `DreamTeamRequisito`, `DreamTeamRequisitoVerificacion`, `DreamTeamTransicion` | types | ninguna |
+| `lib/platform/dream-team/errors.ts` | Errores tipados: `DreamTeamErrorReason` union | `DreamTeamError`, `isDreamTeamError`, `denied(reason)` factory | ninguna |
+| `lib/platform/dream-team/equipos.ts` | Listar/jeraquía de equipos dentro de experiencia | `listEquipos(reader, exp)`, `getEquipoById` | `repository.ts`, `types.ts` |
+| `lib/platform/dream-team/roles.ts` | Listar/jeraquía de roles por equipo | `listRoles(reader, equipoId)`, `getRoleById` | `repository.ts`, `types.ts` |
+| `lib/platform/dream-team/servicios.ts` | CRUD de servicios aplicando state machine + version + audit | `assignServicio`, `transitionServicio`, `getServicio`, `listServiciosByPersona`, `listServiciosByEquipo` | `state-machine.ts`, `repository.ts`, `grants.ts`, participation writer |
+| `lib/platform/dream-team/requisitos.ts` | CRUD de requisitos + verificación manual (admin) | `listRequisitosPorRol`, `verifyRequisito`, `getRequisitosVencidos` | `repository.ts`, `metrics.ts` |
+| `lib/platform/dream-team/grants.ts` | Orquestador: `applyGrantsForTransition(ctx)` decide grant/revoke + snapshot persistido | `applyGrantsForTransition`, `restoreFromSnapshot`, `serializePausedGrantsSnapshot` | `lib/platform/grants.ts`, `repository.ts` |
+| `lib/platform/dream-team/metrics.ts` | Función pura `getDreamTeamMetrics()` sobre un reader | `getDreamTeamMetrics(reader)`, `DreamTeamMetrics` (4 campos) | `repository.ts` |
+| `lib/platform/dream-team/repository.ts` | Interface `DreamTeamRepository` (read + write), `DreamTeamGdvMembershipReader`, `DreamTeamParticipationEventWriter`, `DreamTeamMetricsReader` | types de contrato | ninguna |
+| `lib/platform/dream-team/repository-fake.ts` | In-memory implementations para tests | `createInMemoryDreamTeamRepository()` | `repository.ts`, `types.ts` |
+| `lib/platform/dream-team/repository-supabase.ts` | Real Supabase-backed adapter usando `createServerClient()` | `createSupabaseDreamTeamRepository()` | `repository.ts`, supabase |
+| `lib/platform/adapters/dream-team-gdv.ts` | Reader `grupo_miembros` → capability `dream_team.gdv.lead` con pause-detection | `resolveDreamTeamGdvPlatformContext(input)`, `DreamTeamGdvAdapterInput` | `repository.ts` (reader), `lib/platform/experiences` |
+| `app/api/dream-team/metrics/route.ts` | GET autenticado, gating capability `dream_team.metrics.read` | handler `GET` | `repository-supabase.ts`, `metrics.ts` |
+| `app/api/dream-team/servicios/route.ts` + `[id]/route.ts` | CRUD básico de servicios | handlers `GET/POST/PATCH/DELETE` | `servicios.ts`, `routeGuard.ts` |
+
+## 3. Extensiones aditivas (sin romper Fase 1)
+
+| Archivo | Extensión | Comportamiento actual preservado |
+|---|---|---|
+| `lib/platform/experiences.ts` | + `dream_team: { label, scopeTypes: ['experience','equipo'] }` en catalog. + 14 keys nuevas en `PLATFORM_CAPABILITIES`. | `resolvePlatformCapability` para keys existentes sigue funcionando; tests de Fase 1 verdes. |
+| `lib/platform/grants.ts` | sin cambios — solo consumido por `dream-team/grants.ts` | API pública intacta |
+| `lib/platform/participation.ts` | sin cambios — `PLATFORM_PARTICIPATION_EVENT_TYPES` ya incluye `'service'` | sin cambios |
+| `lib/platform/adapters/participation-adapter.ts` | + `DreamTeamParticipationSupabaseWriter` que implementa `PlatformParticipationReadRepository` (write+read para eventos `service`), consumiendo `dream_team_participation_eventos`. Read para otros tipos sigue siendo fake. | `ParticipationInMemoryAdapter` intacto para los 6 tipos no-service |
+| `lib/platform/navigation.ts` | + definiciones: `dream_team_global`, `dream_team_metrics`. Sin tocar los 9 actuales. `availableHref: undefined` hasta rollout. | navegación legacy intacta |
+
+## 4. Contratos clave (interfaces)
+
+```ts
+// lib/platform/dream-team/repository.ts
+export interface DreamTeamRepository {
+  // equipos / roles
+  listEquiposByExperiencia(exp: PlatformExperienceKey): Promise<readonly Equipo[]>
+  listRolesByEquipo(equipoId: string): Promise<readonly Rol[]>
+  // servicios
+  getServicio(id: string): Promise<Servicio | null>
+  listServiciosByPersona(personaId: string): Promise<readonly Servicio[]>
+  listServiciosByEquipo(equipoId: string, estado?: DreamTeamEstado): Promise<readonly Servicio[]>
+  insertServicio(input: ServicioInsert): Promise<Servicio>
+  updateServicioEstado(args: { id: string; expectedVersion: number; estado: DreamTeamEstado; motivo: DreamTeamTransicionMotivo; actorPersonaId: string; pausedGrantsSnapshot?: PausedGrantsSnapshot }): Promise<{ ok: true; servicio: Servicio } | { ok: false; reason: 'version_conflict' | 'invalid_transition' | 'not_found' }>
+  // requisitos
+  listRequisitosPorRol(rolId: string): Promise<readonly Requisito[]>
+  upsertRequisito(input: RequisitoInput): Promise<Requisito>
+  listRequisitosVerificacion(servicioId: string): Promise<readonly RequisitoVerificacion[]>
+  upsertRequisitoVerificacion(input: RequisitoVerificacionInput): Promise<RequisitoVerificacion>
+  // historial
+  insertEstadoHistorial(row: EstadoHistorialInsert): Promise<void>
+  listEstadosHistorial(servicioId: string): Promise<readonly EstadoHistorial[]>
+  // participation
+  appendParticipationEvent(event: PlatformParticipationEvent): Promise<void>
+  listParticipationEventsByPersona(personaId: string): Promise<readonly PlatformParticipationEvent[]>
+  // metrics
+  countServiciosPorEstado(): Promise<readonly { estado: DreamTeamEstado; count: number }[]>
+  countServiciosPorExperienciaEquipo(): Promise<readonly { experiencia: PlatformExperienceKey; equipoId: string; count: number }[]>
+  countServiciosPorRol(): Promise<readonly { rolId: string; count: number }[]>
+  listRequisitosVencidos(asOf: Date): Promise<readonly RequisitoVencido[]>
+}
+
+export interface DreamTeamGdvMembershipReader {
+  findLeadershipMembershipsByPersonaId(personaId: string): Promise<readonly { grupoId: string; rol: string; estado: 'activo' | 'historico' }[]>
+  findAllActiveLeadershipMemberships(): Promise<readonly { personaId: string; grupoId: string; rol: string }[]>
+}
+```
+
+`DreamTeamGrantsOrchestrator.applyGrantsForTransition(ctx)` produce `PlatformGrantAuditEvent[]` que el `lib/platform/grants.ts` logger persiste; `applyAdapters()` sigue el patrón Fase 1 (`adapterResult.contexts[] → session.contexts`, `capabilities[] → session.capabilities`).
+
+## 5. Plan de migraciones aditivas
+
+**Una sola migración** `supabase/migrations/YYYYMMDDHHMMSS_dream_team_base.sql` (timestamp al ejecutar S4) que crea:
+
+- 5 enums: `enum_dream_team_estado`, `enum_dream_team_requisito_tipo`, `enum_dream_team_requisito_obligatoriedad`, `enum_dream_team_requisito_estado`, `enum_dream_team_transicion_motivo`
+- 7 tablas: las del alto nivel del proposal + `dream_team_participation_eventos`
+- Índices: `(persona_id, estado)`, `(equipo_id, estado)`, `(rol_id)`, `(servicio_id, created_at DESC)` en historial, `(persona_id, occurred_at DESC)` en participation, `(requisito_id, estado, fecha_vencimiento)` en verificación
+- RLS:
+  - lectura `dream_team_servicios`: si `auth.uid()` tiene capability `dream_team.serve` o `dream_team.metrics.read` (`auth_has_capability(...)` helper o se valida vía RPC server-side)
+  - escritura: rpc-gated (`requiere admin`), NUNCA acceso directo authenticated
+  - `dream_team_estados_historial`: solo lectura vía RPC admin
+- **NO** modifica tablas existentes (GDV, usuarios, support, etc.)
+- **NO** triggers que rompan producción
+
+> ⚠️ **Esta migración NO se aplica automáticamente.** El diseño la lista como *artifact* a aplicar durante S4 primero en `supabase_global_staging` (MCP), validar, luego producción. La aplicación se hace en `sdd-apply` de S4, nunca en este phase.
+
+## 6. Estrategia de rollout
+
+| Slice | Flag | Quién puede llamar | Notas |
+|---|---|---|---|
+| S1 Foundation pura | sin flag | nadie (solo tests) | exporta API pero no se usa en runtime |
+| S2 Capabilities | sin flag | nadie | extiende allowlist pero sin source que emita; tests son internal |
+| S3 Repository fake | sin flag | nadie (factory para tests) | no se importa desde runtime |
+| S4 Supabase repo + migración | `DREAM_TEAM=off` | solo admin (override server-side) | migración aplicada en staging antes |
+| S5 GDV adapter | `DREAM_TEAM=off` | platform session resolver | bajo flag, capabilities no se exponen |
+| S6 Servicios API | `DREAM_TEAM=off` | admin con capability `dream_team.requirements.manage` | routes 404 con flag OFF |
+| S7 Grants orchestrator | `DREAM_TEAM=off` | services internos | audit logger se activa |
+| S8 Métricas endpoint | `DREAM_TEAM=off` | capability `dream_team.metrics.read` | endpoint gated |
+| S9 Participation writer | `DREAM_TEAM=off` | internal services | writer + read real para `service` |
+| **S10 Rollout flip** | `DREAM_TEAM=on` (gated via `lib/platform/rollout.ts` 0→5→25→50→100%) | público | métricas productivas + alerts |
+
+Flag helper: `getDreamTeamFlags()` en `lib/platform/flags.ts` (extensión aditiva). Default en Vercel: `off`.
+
+## 7. Estrategia TDD (strict)
+
+| Capa | Qué testear | Approach |
+|---|---|---|
+| Unit puro | state-machine, validators, helpers de snapshot, error factories | Jest 30, sin DB. Red primero. |
+| Unit con fake repo | servicios (transiciones, grants, audit), requisitos (vencimiento), grants orchestrator, metrics | Inyectar `createInMemoryDreamTeamRepository()` |
+| Integration Supabase | S4: `repository-supabase.ts` contra MCP `supabase_global_staging` (test isolation por `persona_id` random UUID) | Tag `integration:supabase`, skipped sin env STAGING_URL |
+| E2E | caso Ana completo (2 servicios, transición de uno, métrica refleja) | Playwright + flag ON, último slice |
+| Cobertura objetivo | ≥70% unit, ≥60% integration, ≥60% e2e helpers, ≥70% overall (Fase 1 cerró 10/3/1/10) | `pnpm test --coverage` |
+
+Reglas: tests RED antes de implementación; merge sin tests verdes = blocked.
+
+## 8. Plan de slices/PRs encadenados (force-chained, stacked-to-main)
+
+| ID | Título | Archivos tocados | Estimado | Tests | Bloqueo | Riesgo budget |
+|---|---|---|---|---|---|---|
+| **S1** | Foundation pura | `dream-team/{types,errors,state-machine}.ts` + tests | ~150 prod / 150 test = **300** | 100% unit | — | bajo |
+| **S2** | Capabilities + experiences | `experiences.ts` extension (~25 líneas) + tests | **150** | unit | S1 | bajo |
+| **S3** | Repository interfaces + fake | `dream-team/{repository,repository-fake}.ts` + tests | ~200 prod / 200 test = **400** | unit | S1 | **justo al límite** |
+| **S4** | Supabase repository + migración | `repository-supabase.ts` + migración SQL + tests integration contra MCP staging | ~250 prod / 200 test / 200 SQL = **650** | integration | S3 | **requiere `size:exception`** |
+| **S5** | GDV adapter | `adapters/dream-team-gdv.ts` + tests | ~180 prod / 180 test = **360** | unit+integration | S3 | bajo |
+| **S6** | Servicios API routes | `app/api/dream-team/servicios/{route.ts,[id]/route.ts}` + tests | ~200 prod / 200 test = **400** | unit | S4 | **justo al límite** |
+| **S7** | Grants orchestrator + audit | `dream-team/grants.ts` + integration con `lib/platform/grants.ts` + tests | ~180 prod / 200 test = **380** | unit | S4+S6 | bajo |
+| **S8** | Métricas + endpoint | `dream-team/metrics.ts` + `app/api/dream-team/metrics/route.ts` + tests | ~150 prod / 150 test = **300** | unit | S4 | bajo |
+| **S9** | Participation events writer | extension `adapters/participation-adapter.ts` + integration con state machine + tests | ~200 prod / 200 test = **400** | unit+integration | S4+S7 | **justo al límite** |
+| **S10** | Rollout flag + integration tests + docs | `lib/platform/flags.ts` extension + `dream-team/rollout.ts` + e2e Ana | ~80 prod / 80 test = **160** | e2e | S8+S9 | bajo |
+
+**Total estimado**: ~3,750 líneas (sumando prod + test + migración).
+
+**Verificación por slice**: `pnpm test`, `pnpm typecheck`, `pnpm lint`, `pnpm build`, `checkPlatformRolloutGate` de Fase 1. S4 además: aplicar SQL a staging, correr smoke de RLS, validar que las tablas existen y RLS bloquea authenticated sin capability.
+
+## 9. Manejo de Supabase staging
+
+- MCP `supabase_global_staging` ya conectado al workspace.
+- **S4 es el único slice que toca DB**. Orden obligatorio dentro del PR:
+  1. Branch → migración SQL committed en `supabase/migrations/` (no aplicada todavía).
+  2. PR abierto → CI corre unit/integration localmente (Supabase repo code-only con tests skipped).
+  3. Una vez merged y antes del siguiente PR stacked → aplicar la migración al staging vía MCP, validar que 7 tablas + 5 enums existen y RLS bloquea, **luego** continuar.
+  4. Producción: NO hasta que todas las slices S1-S10 estén mergeadas y staging valide ≥7 días.
+- Drift check: comparar `supabase/migrations/` y staging; cualquier mismatch bloquea `sdd-apply` de la siguiente slice.
+- Tests en integration tag (skipped sin env).
+
+## 10. Compatibilidad con `uno_a_uno`
+
+- `lib/platform/preflight.ts` intacto (sigue bloqueando `uno_a_uno.global.read` con `reason: 'no_formal_decision'`).
+- **Fase 2 NO introduce `uno_a_uno`.** Requisitos son tracking de estado (`pendiente | completado | vencido | no_aplica`), nunca workflows de 1:1.
+- Si Fase 3 (Operating Core) quiere modelar `entrevista pastoral` o similar, debe:
+  - Pedir excepción formal al producto (`registerPlatformUnoAUnoDecision`).
+  - No hacer short-cut vía adapter Dream Team.
+
+## 11. Riesgos del diseño y mitigaciones
+
+| Riesgo | Mitigación |
+|---|---|
+| Over-engineering jerarquías | Validar con 2 equipos reales (DPS Producción Técnica + Estudiantes Transit) antes de cerrar API; adjacency list máx 3 niveles. |
+| Acoplar con `support_user_capabilities` | **NO** reutilizar tabla. Crear `dream_team_*` con RLS aislado. Tests verifican 0 referencias cruzadas. |
+| Romper GDV | Adapter separado `dream-team-gdv.ts`, cero cambios a `lib/platform/adapters/grupos-vida.ts`, RPCs ni RLS. CI test: diff del archivo debe ser 0 bytes en la rama de Fase 2. |
+| Pérdida silenciosa de servicios | Audit obligatorio con motivo; nunca borrar; historial de transiciones consultable. Spec `dream-team-domain` lo exige. |
+| Concurrencia con 409 conflict | Column `version` en `dream_team_servicios`, UPDATE con `WHERE version = ?`, cliente recibe HTTP 409 + log de audit. (Ver §14 open question sobre ajuste de spec wording.) |
+| Migración rompe producción | Solo `CREATE TABLE`/`CREATE TYPE`/`CREATE INDEX`/`CREATE POLICY`. No `DROP`, no `ALTER` a tablas existentes. Aplicada primero a staging. |
+| Métricas exponen info sensible | Endpoint gated por `dream_team.metrics.read` capability; sin capability → 403 + audit `deny`. |
+| Capabilities genéricas con `(variable)` experience | **Resuelto** con modelo híbrido: genéricas usan `experience: 'dream_team'`, específicas usan experiencia real. Evitamos keys variables que `resolvePlatformCapability` rechaza. |
+| Rollout expone capabilities antes que UI | Definiciones de navegación con `availableHref: undefined` → items no son links hasta que UI exista en Fase 3. |
+
+## 12. Validación contra Fase 1
+
+| Componente | Estado | Acción |
+|---|---|---|
+| `lib/platform/experiences.ts` | extendido (catalog + 14 capabilities) | tests Fase 1 siguen verdes |
+| `lib/platform/grants.ts` | consumido por `dream-team/grants.ts` | sin cambios al archivo |
+| `lib/platform/participation.ts` | writer real para `service` | sin cambios al archivo (event type ya existe) |
+| `lib/platform/persona.ts` | referenciado para FK semantics | sin cambios |
+| `lib/platform/adapters/grupos-vida.ts` | intacto | 0 bytes cambiados en S5 |
+| `lib/platform/adapters/family.ts` | intacto | sin tocar |
+| `lib/platform/navigation.ts` | extendido con 2 items Dream Team | tests verdes; legacy sin cambios |
+| `lib/platform/routeGuard.ts` | usado por S6/S8 | sin cambios al archivo |
+| `lib/platform/rollout.ts` + `lib/platform/flags.ts` | `flags.ts` extendido con `getDreamTeamFlags()`; `rollout.ts` se reusa para S10 | contratos puros intactos |
+| Tests Fase 1 (666) | siguen pasando | `pnpm test` post-merge |
+
+## 13. Validación contra el caso Ana
+
+Recorrido en pasos con el diseño:
+
+1. **Asignación inicial**: admin via `POST /api/dream-team/servicios` con capability `dream_team.requirements.manage` → `assignServicio({ personaId: ana, rolId, motivo: 'admin_asignacion' })`. Estado inicial `postulado`. Insert en `dream_team_servicios` + historial.
+2. **Orientación**: `transitionServicio({ id, to: 'en_orientacion', motivo: 'admin_promocion' })`. Sin grants ni revoke.
+3. **Activación**: `transitionServicio({ id, to: 'activo', motivo: 'admin_promocion' })`. `applyGrantsForTransition` emite 4 grant events (`dream_team.serve` + `dps.team.serve` para servicio 1; `dream_team.serve` + `dream_team.lead` + `estudiantes.team.lead` para servicio 2) — 5 total pero `dream_team.serve` es genérica compartida. Writer de participation emite `service_state_changed`.
+4. **Pausa de DPS Cámara**: `transitionServicio({ id, to: 'en_pausa', motivo: 'admin_pausa' })`. Grants de DPS revocados + snapshot persistido en `paused_grants_snapshot`. Estudiantes intacto.
+5. **Capacitación Estudiantes vence**: ninguna transición; `getDreamTeamMetrics().requisitos_vencidos` muestra a Ana + Estudiantes + Líder + 14 días. Servicio sigue `activo`.
+6. **Pérdida liderazgo Transit**: adapter `dream-team-gdv.ts` detecta ausencia de fila activa en `grupo_miembros` → emite `gdv_liderazgo_removed` → state machine transita a `en_pausa` con motivo `gdv_liderazgo_removed`. Servicio DPS intacto. Membresía GDV NO afectada.
+7. **Reactivación**: `transitionServicio({ to: 'activo', motivo: 'admin_reactivacion' })`. Grants restaurados del `paused_grants_snapshot`. Evento `service_reactivated`.
+8. **Métricas**: `getDreamTeamMetrics()` Ana: servicios_por_estado `activo` ×2; distribucion_roles `Voluntario` ×1 + `Líder` ×1.
+
+## 14. Validación contra el roadmap
+
+| Bullet Fase 2 (`roadmap-maestro`) | Cubierto en diseño |
+|---|---|
+| Modelar persona que sirve en experiencia/equipo/rol | §1, §2, §4 — `dream_team_servicios` triple + repository |
+| Jerarquías configurables | `dream_team_roles.parent_role_id`, max 3 niveles |
+| Estado de servicio + auditoría | §4 — state-machine + historial, motivo obligatorio |
+| Requisitos por área/rol configurables | `dream_team_requisitos` + verificación |
+| Integración con Grupos de Vida | §3 — adapter `dream-team-gdv.ts` separado |
+| Capacidades de servicio | §3 — híbrido genérico + específico (15 keys) |
+| Grants auditables | §4 — orquestador usa `lib/platform/grants.ts` |
+| Historial longitudinal | §3 — participation writer real Supabase para `service` |
+| Métricas mínimas | §2 — `getDreamTeamMetrics()` + endpoint + 4 agregados |
+| Capas futuras preparadas | §4 — interfaces repository, contrato para participation read adapter |
+
+## 15. Próximo paso
+
+`sdd-tasks` debe descomponer cada slice (S1–S10) en tasks concretos verificables (formato Fase 1: `- [ ] X.Y descripción + archivo + test file`), lista para que `sdd-apply` futuro consuma slice por slice con gates RED→GREEN→REFACTOR.
+
+---
+
+**Resumen ejecutivo**
+- 10 slices propuestos, total ~3,750 líneas estimadas (incluyendo tests).
+- 4 PRs cerca o sobre el budget de 400 líneas (S3 al límite, S4 requiere `size:exception`, S6/S9 al límite). PR budget risk: **medium**.
+- DB: 1 sola migración aditiva (7 tablas + 5 enums + RLS + índices), aplicada en S4 vía MCP staging primero, nunca automática.
+- Compatibilidad Fase 1: **total** — cero cambios destructivos, 0 archivos de `lib/platform/adapters/grupos-vida.ts` modificados, capabilities extendidas con `dream_team` agregada al catálogo.
+- Caso Ana: **validado paso a paso** en §13.
+- Capabilities: 15 keys nuevas (7 genéricas Dream Team + 8 específicas, una de ellas `dps.team.serve` ya existía sin backend).
+- Flag nuevo `NEXT_PUBLIC_DREAM_TEAM_ENABLED=off` por defecto, rollout staged 0→5→25→50→100% usando `lib/platform/rollout.ts` de Fase 1.

--- a/openspec/changes/fase-02-dream-team-base/exploration.md
+++ b/openspec/changes/fase-02-dream-team-base/exploration.md
@@ -1,0 +1,412 @@
+# Exploración — Fase 2: Dream Team Global Base
+
+## 1. Estado actual relevante (Fase 1)
+
+### 1.1 Persona (`lib/platform/persona.ts`)
+
+`usuarios` funciona como persona canónica operacional con `auth_id` nullable. El módulo `persona.ts` define búsqueda/dedupe por señales (email, teléfono, cédula, nombre, apellido, fechaNacimiento), con masking, auditoría y boundaries de actor/flujo/scope requerido. Implementa `findPlatformPersonaCandidates(input)` → `{ ok, decision, candidates, audit }` con anti-enumeración y review obligatorio para matches ambiguos. No hay concepto de «servicio» en este módulo.
+
+**Contrato de tests**: `__tests__/lib/platform/persona.test.ts` — unit testing puro con `personaLookup` inyectado, sin DB, sin mocks de Supabase.
+
+### 1.2 Experiences (`lib/platform/experiences.ts`)
+
+Catálogo de 7 experiencias (`grupos_vida`, `dps`, `ninos`, `estudiantes`, `the_living_room`, `talleres_crecimiento`, `family`) con `PLATFORM_CAPABILITIES` de 8 llaves allowlisted. El resolver `resolvePlatformCapability(input)` es fail-closed con scope por experiencia/scopeType/scopeId. Las capacidades existentes relevantes para Dream Team:
+
+| Capability | Experience | ScopeType |
+|---|---|---|
+| `dps.team.serve` | dps | equipo |
+| `grupos_vida.stage.read` | grupos_vida | etapa |
+| `ninos.room.read` | ninos | salon |
+| `estudiantes.room.read` | estudiantes | salon |
+| `talleres_crecimiento.participation.read` | talleres_crecimiento | taller |
+
+`dps.team.serve` es la ÚNICA capability que sugiere «servicio», pero no tiene implementación, adapter, ni ninguna tabla DB que la respalde. Las capacidades de admin (`dps.admin.manage`, `nextgen.admin.manage`, `talleres_crecimiento.admin.manage`) tampoco tienen backend.
+
+**Contrato de tests**: `__tests__/lib/platform/experiences.test.ts` — unit testing de denegación por actor, flow, capability desconocida, scope ausente/malformado/desconocido/conflictivo/duplicado y grant matching.
+
+### 1.3 Grants (`lib/platform/grants.ts`)
+
+Contrato puro de auditoría: `PlatformGrantAuditSystem` con `logger.record(event)` (guarda actorPersonaId, source, decision grant|revoke|deny|audit, scope, before/after state, reason, recordedAt), `metrics.recordGrant|recordRevoke|recordDenial|recordAudit(experience, source)`, y `checkDenialThreshold(metrics, threshold)` para alertas. Pure factory `createPlatformGrantAudit()`. NO hay adapters Supabase todavía.
+
+**Contrato de tests**: `__tests__/lib/platform/grants.test.ts` — events, métricas, alertas por threshold, snapshots.
+
+### 1.4 Participation (`lib/platform/participation.ts`)
+
+Contrato longitudinal con:
+- 7 tipos de evento: `attendance`, **`service`**, `taller_participation`, `group_join`, `group_leave`, `family_consent`, `contact_authorization`
+- 3 niveles de sensibilidad: public, internal, sensitive
+- Retention policies por tipo (service: min 365 / max 1095 días, sin consent explícito)
+- `canReadPlatformParticipationEvent(input)` — guard puro: self → scoped_capability → sensitive_no_capability → insufficient_scope. Nunca revela existencia de eventos sensibles en denegación.
+- `PlatformParticipationReadRepository` — interface read-only: `findEventsByActorPersonaId`, `findEventsByScope`
+- `ParticipationInMemoryAdapter` — fake en memoria para tests y referencia de adapters futuros.
+
+El tipo `service` existe como evento longitudinal, pero NO hay productor de estos eventos. Nadie emite `PlatformParticipationEvent` de tipo `service` hoy.
+
+**Contrato de tests**: `__tests__/lib/platform/participation.test.ts` (unit) + `__tests__/lib/platform/participation-integration.test.ts` (integration con fake adapter).
+
+### 1.5 Preflight (`lib/platform/preflight.ts`)
+
+Bloquea uso de `uno_a_uno` hasta decisión formal. Discriminated union: `{ ok: true, decision, evidence }` | `{ ok: false, reason: 'no_formal_decision', missing }`. Registro mutable solo vía `registerPlatformUnoAUnoDecision()`. Default: denegado. NO hay decisión registrada; el preflight bloquea.
+
+**Estado del drift**: `uno_a_uno_reuniones` y `uno_a_uno_participantes` existen en DB live con RLS y 0 filas, pero NO hay migración local, NO hay rutas/actions, y `uno_a_uno.global.read` no está en `PLATFORM_CAPABILITIES`. El nav item `uno_a_uno_global` en `navigation.ts` no tiene `availableHref` y es permanentemente invisible.
+
+### 1.6 Session (`lib/platform/session/`)
+
+`buildPlatformSession(input)` resuelve desde `auth.uid()` via `personaLookup.findByAuthId(authId)`. Rechaza `personaId` de cliente. La sesión resultante incluye `personaId`, `subjectAuthId`, `globalRoles: []`, `contexts: []`, `capabilities: []`. Los arrays vienen vacíos porque los adapters de GDV y Family se aplican AFTER en la capa de navegación, no en la sesión base.
+
+`useCurrentUser.ts` en el cliente resuelve `platformSession` llamando `buildPlatformSession` con un `personaLookup` que mapea `usuarios` local. La sesión de plataforma en cliente solo tiene `personaId` + `subjectAuthId`, SIN contextos ni capabilities en este punto. Los adapters de contexto (GDV, Family) se aplican en `resolvePlatformNavigation()`.
+
+### 1.7 Adapter de Grupos de Vida (`lib/platform/adapters/grupos-vida.ts`)
+
+Adapter read-only que mapea `segmento_lideres` → `PlatformSessionContext` + `PlatformSessionCapability`:
+
+- **Input**: `{ session: PlatformSession, reader: GruposVidaReadRepository }`
+- **Reader contract**: `findDirectorEtapaAssignmentsByPersonaId(personaId)` → `GruposVidaDirectorEtapaAssignment[]` (solo expone directores de etapa, NO líderes de grupo normales)
+- **Output**: `{ ok, contexts[], capabilities[], scope: { stageIds, groupIds } }`
+- **Capability producida**: `grupos_vida.stage.read` con scope `{ experience: 'grupos_vida', scopeType: 'etapa', scopeId: stageId }`
+
+**LO QUE FALTA para Dream Team**: este adapter solo expone directores de etapa. Un líder de grupo normal NO recibe capability vía este adapter. El adapter no tiene concepto de «servicio en GDV».
+
+### 1.8 Adapter de Family (`lib/platform/adapters/family.ts`)
+
+Adapter read-only que normaliza relaciones familiares desde `relaciones_usuarios`. Produce `NormalizedFamilyRelation[]` con `tipoRelacion`, `isReciprocal`, `relatedHasAuthAccount`. Complementado por `canAccessMinorData.ts` (guard para datos de menores).
+
+### 1.9 Navegación contextual y dashboard
+
+- **`lib/platform/navigation.ts`**: resolver puro con 9 definiciones de navegación, flag/kill switch, fallback legado. Cada definición se resuelve vía `resolvePlatformCapability()` contra las capabilities del `PlatformSession`.
+- **`lib/dashboard/contextual-navigation.ts`**: expone shortcuts contextuales en el dashboard; solo muestra rutas verificadas (actualmente solo `/grupos-vida`).
+- **`app/(auth)/dashboard/page.tsx`**: renderiza dashboard por rol principal (admin, pastor, director-general, director-etapa, lider, miembro) + sección «Contextos visibles» desde `contextual-navigation.ts`.
+- **`components/ui/sidebar-moderna.tsx`**: mezcla ítems legacy estáticos filtrados por roles/capabilities + `usePlatformNavigationViewItems(platformSession)` para ítems de navegación de plataforma. Los ítems de navegación de plataforma se integran con `canAccess()` para gating.
+
+**A nivel de navegación contextual**, DPS aparece como `dps_team_service` con capability `dps.team.serve` y `availableHref: undefined` (no hay ruta implementada). Esto significa que incluso si se asignara la capability, el ítem NO se renderiza como link — pero aparece como contexto visible en la navegación si se resuelve.
+
+### 1.10 Configuración actual de capabilities
+
+- **`app/(auth)/configuracion/soporte/page.tsx`**: asigna/revoca capabilities de soporte (`support.view`, `support.reply`, `support.manage`) sobre la tabla `support_user_capabilities`. Asignación manual por UUID de usuario. Modelo: `INSERT INTO support_user_capabilities (usuario_id, capability)` / `UPDATE ... SET revoked_at = now()`.
+- **`app/(auth)/configuracion/page.tsx`**: configuración global de organización + branding, sin relación con Dream Team.
+- **`app/(auth)/configuracion/directores-generales/`**: gestión de directores generales de GDV.
+- **`app/(auth)/configuracion/grupos-vida/`**: configuración de GDV (geocodificación, etc).
+
+NO existe UI para asignar capabilities de Dream Team o servicio. La UI de soporte es el único precedente de asignación de capabilities a nivel de plataforma.
+
+### 1.11 Tests y contratos
+
+14 test files en `__tests__/lib/platform/` cubren todos los módulos de Fase 1. Patrón consistente:
+- Tests unitarios puros (sin DB, sin mocks de Supabase)
+- Discriminated unions para returns
+- Factory/reset helpers para aislar estado mutable
+- Integration tests con fake adapters in-memory (Participation)
+
+## 2. Brechas detectadas para Dream Team
+
+### 2.1 Servicio por experiencia/equipo/rol: ¿existe? ¿cómo se aproxima?
+
+**NO existe**. No hay tabla, modelo, contrato ni adapter que represente «una persona sirve en una experiencia con un rol en un equipo».
+
+Lo más cercano:
+- La capability `dps.team.serve` en `PLATFORM_CAPABILITIES` es un hueco conceptual: existe en el catálogo pero no tiene backend, adapter, ni tabla DB que la respalde.
+- El adapter de GDV mapea directores de etapa como `contexts` y `capabilities`, pero solo para el tipo `director_etapa` de `segmento_lideres`. Los líderes de grupo normales (registrados en `grupo_miembros`) no se exponen.
+- `dps.team.serve` en `navigation.ts` tiene `availableHref: undefined`, haciéndola permanentemente invisible como link.
+
+**Conclusión**: Dream Team requiere un modelo de dominio nuevo. No es una extensión de lo existente; es crear lo que no existe.
+
+### 2.2 Múltiples servicios simultáneos: ¿se soporta?
+
+**NO**. La estructura actual de `PlatformSession` tiene arrays: `contexts: PlatformSessionContext[]` y `capabilities: PlatformSessionCapability[]`. Esto SÍ permite múltiples entradas, y el GDV adapter ya produce múltiples contextos para una persona que dirige varias etapas.
+
+Sin embargo, no hay representación de servicio simultáneo en múltiples experiencias distintas (ej: DPS + Estudiantes). La sesión recibe capabilities de múltiples fuentes (GDV adapter, Family adapter, etc.), lo cual es el patrón que Dream Team debería seguir.
+
+**Patrón reutilizable**: Los adapters se aplican secuencialmente en `resolvePlatformNavigation()` → `applyAdapters()`, mergeando `contexts` y `capabilities` de cada adapter. Dream Team necesitaría un adapter propio que se integre en este pipeline.
+
+### 2.3 Estado de servicio: ¿hay algo similar?
+
+**NO**. No existe concepto de estado de servicio. Lo más cercano es `support_user_capabilities.revoked_at` (para revocación de capabilities de soporte), que es binario (activo/revocado), no un state machine con transiciones.
+
+Dream Team requiere estados: postulado → en orientación → activo → en pausa → inactivo → retirado, con transiciones auditables y motivos.
+
+### 2.4 Jerarquías configurables: ¿rigidez actual?
+
+GDV tiene una jerarquía rígida implícita en `segmento_lideres.tipo_lider` (`director_general` | `director_etapa`) y las relaciones `director_general_directores` + `director_etapa_grupos`. Esta jerarquía es:
+- Fija en 2 niveles (DG → DE → grupos)
+- Específica del dominio GDV
+- No configurable
+
+Dream Team requiere jerarquías configurables por área/equipo, donde director, coordinador y voluntario son opcionales y una persona puede tener múltiples roles jerárquicos. Esto no existe en el sistema actual.
+
+### 2.5 Requisitos por área/rol: ¿cómo se manejan?
+
+**No existen**. No hay tabla, modelo ni UI para definir requisitos que una persona debe cumplir para servir en un rol/área. El concepto es completamente nuevo. El handoff especifica: configurables (requerido/opcional/no aplica), con fecha de verificación, persona que verificó, estado (pendiente/completado/vencido/no aplica).
+
+### 2.6 Relación con Grupos de Vida: ¿adapter permite saber quién es líder?
+
+**Parcialmente**. El adapter `grupos-vida.ts` expone solo directores de etapa (`segmento_lideres` con `tipo_lider = 'director_etapa'`). NO expone:
+- Directores generales (aunque su tabla existe como `director_general_segmentos`)
+- Líderes de grupo normales (`grupo_miembros` con rol de líder)
+
+Para que un líder de grupo de vida sea considerado Dream Team, el adapter necesitaría extenderse (o crearse un adapter nuevo) que lea `grupo_miembros` y mapee membresías de liderazgo a capabilities de Dream Team.
+
+**Riesgo**: extender el adapter actual podría acoplarlo con Dream Team. Mejor crear un adapter separado `dream-team-gdv.ts` (o similar) que lea de GDV sin modificar el adapter existente.
+
+### 2.7 Grants auditables: ¿hay conexión?
+
+El módulo `grants.ts` define el contrato de auditoría (`PlatformGrantAuditEvent`) y el logger (`PlatformGrantAuditLogger`), pero NO está conectado a ningún sistema de capabilities real. Es un contrato puro sin implementación Supabase.
+
+Dream Team necesitaría:
+1. Un adapter que implemente `PlatformGrantAuditLogger` (persistiendo en DB o log)
+2. Conectar las decisiones de asignación/revocación de servicio con `logger.record()` para auditar cambios de estado, requisitos y asignaciones.
+
+### 2.8 Historial longitudinal: ¿participation lo cubre?
+
+**El contrato SÍ**. `participation.ts` incluye el tipo `service` con retención de 365-1095 días y sensibilidad `internal`. Sin embargo:
+- No hay productor de eventos `service`
+- No hay adapter DB para el `PlatformParticipationReadRepository`
+- El repo solo tiene el fake `ParticipationInMemoryAdapter`
+
+Dream Team necesitaría:
+1. Un mecanismo que emita `PlatformParticipationEvent` de tipo `service` cuando una persona inicia/termina/pausa servicio
+2. Potencialmente, nuevos sub-tipos de evento para cambios de estado y requisitos
+3. Un adapter real de `PlatformParticipationReadRepository` (scope de Fase 3 Operating Core, no de Fase 2)
+
+El contrato está listo; falta la implementación.
+
+## 3. Tablas y entidades DB relevantes
+
+### 3.1 Tablas actuales que tocan «servicio» (directa o indirectamente)
+
+| Tabla | Columnas clave | Rol actual | Relación con Dream Team |
+|---|---|---|---|
+| `usuarios` | `id, auth_id, nombre, apellido, email, telefono, cedula, fecha_nacimiento, fecha_registro` | Persona canónica | Dream Team agrega service_memberships FK → usuarios.id |
+| `grupo_miembros` | `id, usuario_id, grupo_id, rol, fecha_ingreso, fecha_salida, estado` | Membresía en grupos GDV | Los líderes aquí DEBEN ser Dream Team; requiere adapter |
+| `segmento_lideres` | `id, usuario_id, segmento_id, tipo_lider ('director_general' \| 'director_etapa'), campus_id` | Liderazgo GDV | Ya mapeado por adapter GDV; directores son Dream Team |
+| `director_etapa_grupos` | `id, director_etapa_id (FK segmento_lideres), grupo_id` | Scope de director etapa | Define qué grupos ve un DE |
+| `director_general_segmentos` | `id, usuario_id, segmento_id, campus_id, creado_en` | Scope de DG | DGs también son Dream Team, no expuestos por el adapter actual |
+| `director_general_directores` | `id, director_general_id, director_etapa_id, created_at` | Relación DG→DE | Jerárquica, solo GDV |
+| `support_user_capabilities` | `id, usuario_id, capability, granted_at, revoked_at, granted_by_usuario_id` | Capacidades de soporte | Patrón de asignación con auditoría; referencia para diseño de grants de Dream Team |
+| `roles` (tabla) | `id, nombre, nombre_interno, es_predeterminado` | Roles globales | No se deben expandir; Dream Team usa capacidades scoped |
+| `usuarios_roles` | `usuario_id, rol_id` | Asignación de roles globales | No relevante para Dream Team |
+| `obtener_roles_usuario` (RPC) | `p_auth_id → TABLE(nombre_interno text)` | Obtiene roles globales | Usado por `useCurrentUser`; no relevante para Dream Team |
+| `uno_a_uno_reuniones` | `id, fecha, grupo_id, lider_usuario_id, notas_privadas` | Bloqueado por preflight | NO USAR en Fase 2 |
+| `uno_a_uno_participantes` | `id, miembro_usuario_id, reunion_id` | Bloqueado por preflight | NO USAR en Fase 2 |
+| `configuracion_plataforma` | `nombre_organizacion, logo_light_url, logo_dark_url, favicon_url, color_primario, color_secundario, ...` | Config global | Podría extenderse para defaults de requisitos |
+
+### 3.2 Tablas NUEVAS que Fase 2 necesitaría crear
+
+Basado en el handoff y el análisis de brechas:
+
+| Tabla tentativa | Propósito | Relaciones |
+|---|---|---|
+| `dream_team_equipos` | Equipos/squads dentro de una experiencia (ej: «Producción Técnica» dentro de DPS) | FK → experiencias (catálogo), jerarquía padre/hijo opcional |
+| `dream_team_roles` | Roles configurables por equipo (ej: «Voluntario», «Coordinador», «Director») | FK → dream_team_equipos |
+| `dream_team_servicios` | Asignación de persona a equipo/rol: estado, fechas, requisitos tracking | FK → usuarios, dream_team_roles, dream_team_equipos |
+| `dream_team_requisitos` | Requisitos configurables por rol/equipo (tipo, obligatoriedad) | FK → dream_team_roles |
+| `dream_team_requisitos_verificacion` | Estado de verificación de requisitos por persona | FK → dream_team_servicios, dream_team_requisitos |
+| `dream_team_estados_historial` | Auditoría de transiciones de estado | FK → dream_team_servicios |
+
+**NOTA**: Estos son nombres tentativos para discusión en la fase de diseño. La exploración no prescribe esquema.
+
+### 3.3 Enums y tipos esperados
+
+| Enum/Type | Valores tentativos |
+|---|---|
+| `enum_dream_team_estado` | `postulado, en_orientacion, activo, en_pausa, inactivo, retirado` |
+| `enum_dream_team_requisito_tipo` | `documento, capacitacion, entrevista, politicas, otro` |
+| `enum_dream_team_requisito_estado` | `pendiente, completado, vencido, no_aplica` |
+| `enum_dream_team_requisito_obligatoriedad` | `requerido, opcional, no_aplica` |
+
+## 4. Patrones reutilizables de Fase 1
+
+### 4.1 Adapter read-only pattern
+
+```typescript
+// Ejemplo: GruposVidaAdapterInput, GruposVidaReadRepository, resolveGruposVidaPlatformContext()
+// Patrón: input con session + reader (interface inyectable), output con discriminated union
+// { ok: true, contexts, capabilities, scope, audit } | { ok: false, reason, ... }
+
+// Dream Team podría seguir este patrón:
+type DreamTeamAdapterInput = { session: PlatformSession; reader: DreamTeamReadRepository }
+type DreamTeamAdapterResult = { ok: true; contexts[]; capabilities[]; audit } | { ok: false; reason }
+```
+
+### 4.2 Persona-first vs user-first
+
+`usuarios.id` es la persona canónica. Dream Team debe referenciar `usuarios.id`, no `auth.uid()`, porque una persona puede servir sin tener cuenta auth (aunque en la práctica actual casi todos los servidores tienen cuenta).
+
+### 4.3 Capabilities allowlist + fail-closed
+
+`PLATFORM_CAPABILITIES` es un diccionario estático. Cualquier capability no registrada produce `'unknown_capability'`. Dream Team debe:
+- Agregar capabilities nuevas al allowlist (ej: `dps.team.serve.view`, `estudiantes.team.serve.manage`)
+- El resolver `resolvePlatformCapability()` ya maneja scopes con experiencia/scopeType/scopeId
+- Las capabilities de Dream Team deben mapearse al scope concreto (ej: `{ experience: 'dps', scopeType: 'equipo', scopeId: 'produccion-tecnica' }`)
+
+### 4.4 Grants audit
+
+`createPlatformGrantAudit()` → `{ logger, metrics, checkDenialThreshold }`. Dream Team debe:
+- Usar el mismo `logger.record()` para auditar asignaciones/revocaciones de servicio
+- Usar el mismo `metrics` para contar grants/denials por experiencia
+- El `PlatformGrantAuditEvent` ya soporta `decision: 'grant' | 'revoke' | 'deny' | 'audit'`
+
+### 4.5 Participation adapter contract
+
+`PlatformParticipationReadRepository` → `findEventsByActorPersonaId`, `findEventsByScope`. Dream Team debe emitir eventos `service` cuando:
+- Una persona inicia servicio (estado → activo)
+- Cambia de estado
+- Termina servicio
+- Completa un requisito
+
+### 4.6 Feature flags y rollout
+
+- `getPlatformNavigationFlags()` → `{ enabled, killSwitch }` controla navegación contextual
+- `resolvePlatformNavigationGate()` → `PlatformNavigationGate` (flag OFF → fallback legado)
+- Dream Team debe respetar el mismo flag para no exponer ítems de navegación sin backend
+- **Riesgo**: si el flag sigue OFF en producción, ningún ítem de Dream Team será visible aunque se implemente
+
+### 4.7 RouteGuard pattern
+
+`checkPlatformRouteAccess({ platformSession, requiredCapability, flags })` → `{ allowed, reason }`. Sirve como marcador de permiso. Dream Team debe usar este patrón para proteger rutas de gestión de servicio.
+
+### 4.8 Navigation definitions extendibles
+
+`PLATFORM_NAVIGATION_DEFINITIONS` es un array `satisfies readonly PlatformNavigationDefinition[]`. Agregar nuevas definiciones para Dream Team (ej: `dps_team_manage`, `estudiantes_team_manage`, `talleres_team_manage`, `dream_team_global`) es aditivo y no rompe nada. Las definiciones existentes como `dps_team_service` ya están listas para ser usadas cuando tengan backend.
+
+## 5. Riesgos identificados
+
+### 5.1 Sin modelo de servicio: todo es nuevo
+Dream Team no es una extensión de GDV ni de `support_user_capabilities`. Es un dominio nuevo completo. Esto es un riesgo de scope: puede llevar a over-engineering si se intenta modelar todo el catálogo de equipos/roles de una vez, o a under-engineering si se modela solo DPS sin considerar la generalización.
+
+**Mitigación**: diseñar el contrato genérico (equipo/rol/estado/requisitos) y validar con 2 experiencias concretas (DPS + GDV líderes). No modelar todas las experiencias en Fase 2.
+
+### 5.2 GDV adapter no expone líderes de grupo
+El adapter actual solo expone `director_etapa`. Los líderes de grupo normales (en `grupo_miembros`) no tienen capability de plataforma. Dream Team necesita que un líder de grupo sea reconocido como Dream Team, pero el adapter actual no lo soporta.
+
+**Mitigación**: crear un adapter separado (`dream-team-gdv.ts`) que lea `grupo_miembros` para líderes, SIN modificar el adapter existente. Mantener la separación de responsabilidades.
+
+### 5.3 Acoplar Dream Team con `support_user_capabilities`
+La tabla `support_user_capabilities` tiene el patrón de grants con `revoked_at`, pero está diseñada para soporte y tiene RLS específico de soporte. Reutilizarla para Dream Team acoplaría dominios y crearía confusión de auditoría.
+
+**Mitigación**: NO reutilizar `support_user_capabilities`. Crear tablas nuevas con propósito claro.
+
+### 5.4 Scope creep hacia Operating Core (Fase 3)
+El handoff pide «conexión con Grupos de Vida, DPS, Talleres, Niños, Estudiantes y otras experiencias». Pero Fase 3 (Operating Core) es quien construye la tubería operativa. Si Fase 2 intenta conectar con todas las experiencias, terminará construyendo partes de Fase 3.
+
+**Mitigación**: en Fase 2, la «conexión» es a nivel de modelo de datos y capabilities, NO a nivel de operación/flujos/UI de cada experiencia. La integración real con cada experiencia es scope de fases posteriores.
+
+### 5.5 Navegación contextual con flag OFF
+`NEXT_PUBLIC_PLATFORM_NAVIGATION_ENABLED=off` en producción. Si Dream Team agrega ítems de navegación, no serán visibles hasta que el flag se active. Esto es correcto para Fase 2 (foundation invisible), pero debe documentarse claramente en el plan de rollout.
+
+### 5.6 `uno_a_uno` — bloqueo persistente
+El preflight sigue bloqueando `uno_a_uno`. Cualquier diseño de Dream Team que intente usar 1:1 (ej: «entrevista de liderazgo» como requisito) debe esperar hasta que el drift esté reconciliado. Por ahora, los requisitos de Dream Team son tracking de estado, no flujos de 1:1.
+
+### 5.7 Sin adapter DB real para participation
+El `ParticipationInMemoryAdapter` es un fake. Para emitir eventos de participación reales (tipo `service`), Fase 2 necesitaría un adapter DB que persista en Supabase. Esto podría ser scope de Fase 2 o delegarse a Fase 3.
+
+### 5.8 Complejidad de jerarquías configurables
+Modelar jerarquías «flexibles y configurables» puede resultar en un modelo de datos complejo. Si se hace con adjacency list o nested sets, la complejidad de queries aumenta.
+
+**Mitigación**: empezar con un modelo simple: `dream_team_roles` con un `parent_role_id` opcional (adjacency list). No diseñar para profundidad infinita; validar con jerarquías de 2-3 niveles máximo.
+
+## 6. Preguntas abiertas
+
+### Del handoff de Fase 2 (sección «Preguntas que el agente debe responder»)
+
+1. **¿Cómo se representa un servicio activo de una persona en cualquier experiencia?**  
+   → Una fila en `dream_team_servicios` con FK a persona, FK a rol (que a su vez referencia equipo/experiencia), estado, y fechas. Se expone como `PlatformSessionCapability` con key tipo `dps.team.serve` y scope `{ experience: 'dps', scopeType: 'equipo', scopeId: 'produccion-tecnica' }`.
+
+2. **¿Cómo se modela una persona con varios servicios simultáneos?**  
+   → Múltiples filas en `dream_team_servicios` para la misma persona, cada una con su propio estado/rol/equipo. El adapter de Dream Team produce múltiples capabilities que se mergean en `PlatformSession.capabilities[]`. El array ya soporta entradas múltiples.
+
+3. **¿Cómo se configuran jerarquías por área/equipo?**  
+   → `dream_team_roles` con `parent_role_id` opcional. Un equipo puede tener roles Configurados: director → coordinador → voluntario, o solo voluntario, o solo líder. La configuración es por equipo, no global.
+
+4. **¿Qué campos y estados mínimos requiere el servicio?**  
+   → `persona_id`, `rol_id` (→ equipo → experiencia), `estado` (enum de 6 valores), `fecha_inicio`, `fecha_fin` (nullable), `notas_internas` (opcional). Historial de cambios de estado en tabla de auditoría separada.
+
+5. **¿Cómo se asocian requisitos por área/rol?**  
+   → `dream_team_requisitos` con FK a rol. Una persona en un servicio tiene verificaciones de requisitos en `dream_team_requisitos_verificacion`, una por cada requisito del rol, con su propio estado.
+
+6. **¿Cómo se conecta Dream Team con `lib/platform/grants.ts`?**  
+   → Al asignar/revocar un servicio, el action (server) registra un `PlatformGrantAuditEvent` con decision `grant`/`revoke`. El logger registra actor, source, scope, before/after.
+
+7. **¿Cómo se conecta Dream Team con `lib/platform/participation.ts`?**  
+   → Al cambiar el estado de un servicio (inicio, pausa, fin), se emite un `PlatformParticipationEvent` de tipo `service` con scope de la experiencia/equipo. El adapter de participation recibe estos eventos y los expone vía `PlatformParticipationReadRepository`.
+
+8. **¿Cómo se muestra un voluntario activo en el dashboard contextual?**  
+   → Vía `resolveDashboardContextualAccess()` que ya consume `resolvePlatformNavigation()`. Si el adapter de Dream Team produce capabilities de servicio, la navegación contextual las mostrará (cuando el flag esté ON y exista `availableHref`).
+
+9. **¿Cómo se evita que un líder de Grupos de Vida no se muestre como Dream Team y viceversa?**  
+   → El adapter GDV actual produce capabilities `grupos_vida.stage.read`. El adapter Dream Team produciría capabilities como `dps.team.serve`, `estudiantes.team.lead`, etc. Son fuentes distintas (`source`). Un líder de GDV que no es director de etapa NO recibiría capability de Dream Team a menos que el adapter `dream-team-gdv` lo exponga explícitamente.
+
+10. **¿Qué cambios de DB serían aditivos y seguros?**  
+   → Nuevas tablas (`dream_team_*`), nuevos enums, nuevas capabilities en el allowlist de `experiences.ts`. Cero cambios a tablas existentes (solo lecturas). Cero migraciones destructivas. El adapter `dream-team-gdv` leería de `grupo_miembros` sin modificarla.
+
+### Preguntas emergentes de la investigación
+
+11. **¿El adapter `dream-team-gdv` para líderes debe ser un adapter separado o una extensión del adapter GDV existente?**  
+   → Recomendación: adapter separado (`lib/platform/adapters/dream-team-gdv.ts`). El adapter GDV actual es para el contexto de navegación de directores; mezclar líderes de grupo cambiaría su semántica. Separación de concerns.
+
+12. **¿Fase 2 debe implementar el `PlatformParticipationReadRepository` real (Supabase) o solo el contrato?**  
+   → El contrato ya existe. La implementación real (Supabase RPC/tablas) puede ser un stub en Fase 2 (siguiendo el patrón de Fase 1: interfaces + fakes) y materializarse en Fase 3 Operating Core.
+
+13. **¿Los requisitos de Dream Team deben poder configurarse por UI en Fase 2, o es suficiente con el modelo de datos?**  
+   → El handoff dice «requisitos configurables por área/rol son configurables y no se hardcodean». El modelo de datos debe permitir configuración, pero la UI de configuración puede ser posterior. En Fase 2, basta con que la tabla de requisitos permita INSERT/UPDATE (admin), sin UI gráfica.
+
+14. **¿Cómo se asigna inicialmente una persona a un servicio? ¿Auto-servicio? ¿Asignación por admin?**  
+   → El handoff no especifica. Fase 2 probablemente debe soportar asignación por admin/director (no auto-servicio, que es parte de onboarding en fases posteriores). Esto debe validarse con producto.
+
+15. **¿El dashboard contextual debe mostrar servicios Dream Team en Fase 2?**  
+   → Con el flag de navegación OFF, no se mostraría nada. Pero el modelo de capabilities debe estar listo para que cuando el flag se active, los ítems aparezcan. El diseño debe preverlo, aunque la visibilidad real dependa del rollout.
+
+## 7. Recomendación para Fase 2
+
+### 7.1 Alcance tentativo
+
+**Incluir en Fase 2**:
+1. Modelo de dominio Dream Team: tablas `dream_team_equipos`, `dream_team_roles`, `dream_team_servicios`, `dream_team_requisitos`, `dream_team_requisitos_verificacion`, `dream_team_estados_historial`
+2. Enums: `enum_dream_team_estado`, `enum_dream_team_requisito_tipo`, `enum_dream_team_requisito_estado`, `enum_dream_team_requisito_obligatoriedad`
+3. Módulo `lib/platform/dream-team.ts` — tipos puros y helpers (estados válidos, transiciones permitidas, factory de capabilities)
+4. Adapter `lib/platform/adapters/dream-team.ts` — reader interface + resolver que mapea `dream_team_servicios` → `PlatformSessionCapability[]`
+5. Adapter `lib/platform/adapters/dream-team-gdv.ts` — reader que consulta `grupo_miembros` para líderes y los mapea como Dream Team
+6. Extensión de `PLATFORM_CAPABILITIES` con nuevas capabilities de servicio (ej: `dps.team.serve`, `estudiantes.team.lead`, etc.)
+7. Extensión de `PLATFORM_NAVIGATION_DEFINITIONS` con ítems de Dream Team (con `availableHref: undefined` o stub)
+8. Integración con `grants.ts`: emitir `PlatformGrantAuditEvent` en asignaciones
+9. Migraciones aditivas (solo CREATE TABLE, CREATE ENUM, sin DROP ni ALTER destructivos)
+10. Tests unitarios y de integración para el módulo y adapters
+
+**Excluir de Fase 2 (delegar a Fase 3+)**:
+- UI de gestión de Dream Team (asignación/revocación de servicios)
+- Dashboard específico de Dream Team (métricas de voluntarios)
+- Onboarding / flujo de postulación
+- Emisión real de eventos `service` en `participation` (solo preparar el contrato)
+- Implementación real de `PlatformParticipationReadRepository` en Supabase
+- Conexión operativa con cada experiencia (DPS flows, Estudiantes flows, etc.)
+- UI de configuración de requisitos
+- Cualquier uso de `uno_a_uno`
+
+### 7.2 Dependencias
+
+- Fase 1 Platform Foundation (COMPLETA ✅)
+- Ninguna dependencia externa nueva
+- `usuarios` como persona canónica (ya existe)
+- `PLATFORM_EXPERIENCE_CATALOG` como catálogo de experiencias (ya existe)
+- `PLATFORM_CAPABILITIES` como allowlist extensible (ya existe)
+
+### 7.3 Orden sugerido de implementación
+
+1. **Slice 1 — Modelo de datos + enums**: tablas nuevas, migraciones aditivas, tipos TypeScript en `database.types.ts`
+2. **Slice 2 — Módulo puro `dream-team.ts`**: tipos, state machine de 6 estados, transiciones válidas, helpers para construir capabilities
+3. **Slice 3 — Adapter Dream Team**: reader interface, resolver que mapea DB → `PlatformSessionCapability[]`, tests
+4. **Slice 4 — Adapter GDV líderes**: reader que consulta `grupo_miembros` y mapea líderes, tests de compatibilidad con GDV
+5. **Slice 5 — Integración con grants**: emitir `PlatformGrantAuditEvent` en acciones de asignación/revocación
+6. **Slice 6 — Capacidades + navegación**: nuevas capabilities en allowlist, definiciones de navegación, wiring con `resolvePlatformNavigation`
+7. **Slice 7 — Integración con participación**: preparar emisión de eventos `service` (sin DB real, solo contrato)
+
+## 8. Evaluación de readiness
+
+| Condición | Estado | Notas |
+|---|---|---|
+| Fase 1 cerrada y mergeada | ✅ | 7 sub-fases, 14 módulos, 666 tests, flag OFF en prod |
+| `lib/platform/**` estable | ✅ | Sin cambios planeados en Fase 1 |
+| Patrones de extensión claros | ✅ | Adapter pattern, capabilities allowlist, navigation definitions |
+| Tablas existentes sin riesgo de rotura | ✅ | Solo lecturas de tablas GDV; cero DROP/ALTER |
+| Preflight `uno_a_uno` activo | ✅ | Bloquea uso de 1:1; Dream Team no lo necesita |
+| Testing contracts definidos | ✅ | Unit tests puros + integration con fakes, como en Fase 1 |
+| Scope acotado | ✅ | Modelo de datos + contratos; sin UI operativa ni flujos de experiencia |

--- a/openspec/changes/fase-02-dream-team-base/proposal.md
+++ b/openspec/changes/fase-02-dream-team-base/proposal.md
@@ -1,0 +1,324 @@
+# Proposal — Fase 2: Dream Team Global Base
+
+## 1. Contexto y motivación
+
+GlobalConnect ya tiene **Persona única, Experiencias, Capabilities scoped, Grants auditables, Historial longitudinal, Navegación contextual y RouteGuard** (Fase 1 cerrada en `c364128`, 666 tests, flag `NEXT_PUBLIC_PLATFORM_NAVIGATION_ENABLED=off` en Vercel). Pero el sistema **no sabe todavía quién sirve en qué**.
+
+Fase 2 del roadmap (`globalconnect-roadmap-maestro-v1.md`) define Dream Team como **toda persona que sirve en cualquier experiencia**. Hoy esto es implícito: el adapter de Grupos de Vida solo expone `director_etapa`; la capability `dps.team.serve` existe en el allowlist pero no tiene backend, ni adapter, ni tabla DB que la respalde; no hay concepto de estado de servicio, requisitos, ni jerarquías configurables.
+
+Esta fase crea la **base global de servicio**: el modelo de dominio que representa «una persona sirve en una experiencia, en un equipo, con un rol, en un estado, con requisitos auditables», integrado con los contratos puros que Fase 1 dejó listos (`experiences`, `grants`, `participation`, adapters). Sin UI operativa todavía: la asignación es por admin/director (no auto-postulación) y la operación por experiencia es scope de Fase 3+ (Operating Core).
+
+## 2. Outcome esperado
+
+Al cerrar Fase 2 el sistema puede:
+
+- Representar que **Ana sirve en DPS / Producción Técnica / Cámara** y **en Estudiantes / Transit** como dos servicios simultáneos, independientes, cada uno con su rol, estado, requisitos y grants.
+- Exponer cada servicio como `PlatformSessionCapability` con scope concreto (`{ experience, scopeType: 'equipo', scopeId }`).
+- Transicionar un servicio por una **state machine de 6 estados** (`postulado → orientación → activo → pausa|inactivo → retirado`) con motivo obligatorio y fila de auditoría por transición.
+- Otorgar grants al pasar a `activo` y revocarlos al pasar a `pausa`, con auditoría y re-otorgamiento automático al volver.
+- Reconocer automáticamente a **líderes de Grupos de Vida como Dream Team** vía adapter read-only separado (`dream-team-gdv.ts`), sin tocar el adapter existente.
+- Exponer **métricas mínimas en endpoint de lectura** (cuántos sirven, distribución de roles, requisitos vencidos) — sin widget en dashboard.
+- Alimentar el historial longitudinal vía eventos `service` en `participation.ts` (contrato ya está; falta productor y adapter Supabase, scope de Fase 3).
+- Mantener Grupos de Vida, soporte y `support_user_capabilities` **intactos**.
+
+## 3. Alcance funcional (in-scope)
+
+### 3.1. Servicio por experiencia/equipo/rol
+Una fila en `dream_team_servicios` con FK a persona (`usuarios.id`), FK a rol (que a su vez referencia equipo → experiencia), estado, fechas, notas. Se modela como triple `(persona, equipo, rol)` con cardinalidad N:M:M.
+
+### 3.2. Múltiples servicios simultáneos
+N filas en `dream_team_servicios` por persona. Cada fila produce **una capability independiente** en `PlatformSession.capabilities[]`. El adapter las mergea siguiendo el patrón `applyAdapters()` existente en `resolvePlatformNavigation()`.
+
+### 3.3. Jerarquías configurables
+`dream_team_roles` con `parent_role_id` opcional (adjacency list, 2-3 niveles máximo). Un equipo puede tener director + coordinador + voluntario, o solo voluntario, o solo líder. **No se asume jerarquía rígida.**
+
+### 3.4. Estado de servicio (state machine de 6 estados)
+Enum `enum_dream_team_estado` con 6 valores y forward-only con retorno limitado. Toda transición registra fila en `dream_team_estados_historial` con motivo obligatorio.
+
+### 3.5. Requisitos configurables (modelo de datos)
+`dream_team_requisitos` por rol con `obligatoriedad` (requerido | opcional | no aplica) y `tipo` (documento | capacitacion | entrevista | politicas | otro). `dream_team_requisitos_verificacion` por (servicio, requisito) con estado (pendiente | completado | vencido | no aplica), fecha y verificador. **Vencidos alertan, no bloquean.**
+
+### 3.6. Integración con Grupos de Vida (adapter separado)
+`lib/platform/adapters/dream-team-gdv.ts` lee `grupo_miembros` para líderes de grupo y los mapea como `PlatformSessionCapability` con key `dream_team.gdv.lead`. **No modifica** `lib/platform/adapters/grupos-vida.ts`.
+
+### 3.7. Grants de servicio
+Al transicionar a `activo` se emiten `PlatformGrantAuditEvent` `decision: 'grant'` para cada capability nueva. Al transicionar a `pausa` se emiten `revoke` y se registra snapshot de grants pausados (`paused_grants`) en historial; al volver a `activo` se re-otorgan automáticamente.
+
+### 3.8. Historial longitudinal vía participation
+Al cambiar de estado, se emite `PlatformParticipationEvent` tipo `service` con scope de la experiencia/equipo. Productor puro en `lib/platform/dream-team.ts`; el adapter DB real es scope de Fase 3 (Operating Core).
+
+### 3.9. Métricas mínimas (endpoint de lectura)
+`lib/platform/dream-team-metrics.ts` con funciones puras que computan: count por experiencia/equipo, count por estado, distribución de roles, count de requisitos vencidos. **Endpoint HTTP**, sin widget.
+
+### 3.10. Concurrencia y auditoría
+Dos admins editando el mismo servicio: estrategia a definir en diseño (candidatos: `updated_at` last-write-wins + audit, u optimistic locking con `version` column). **Toda acción de asignación, transición o verificación de requisito genera fila de auditoría.**
+
+## 4. Fuera de alcance (non-goals)
+
+- Onboarding completo (cursos / evaluaciones / firma digital legal)
+- Auto-postulación de personas a vacantes (admin/director asigna siempre)
+- UI para configurar requisitos (modelo de datos sí, UI en fase futura)
+- Widget de métricas en dashboard contextual (solo endpoint)
+- Operación de Grupos de Vida (no se rediseña)
+- Operación de Niños / Estudiantes / The Living Room / DPS
+- Mensajería interna, WhatsApp API, campamentos
+- Implementación de `uno_a_uno` (preflight sigue bloqueando)
+- Migraciones destructivas en DB (solo `CREATE TABLE`, `CREATE TYPE`, `CREATE INDEX`)
+- Operating Core / dashboards avanzados
+- Adapter DB real de `PlatformParticipationReadRepository` (scope de Fase 3)
+
+## 5. Decisiones de producto (consolidadas)
+
+| # | Decisión | Resolución |
+|---|---|---|
+| 1 | Adapter GDV | `lib/platform/adapters/dream-team-gdv.ts` separado; existente intacto |
+| 2 | Asignación | Solo admin/director (no auto-postulación en Fase 2) |
+| 3 | Requisitos | Solo modelo de datos (UI en fase futura) |
+| 4 | Métricas | Solo endpoint de lectura (sin widget en dashboard) |
+| 5 | Participation | Implementación Supabase completa (tabla real para eventos `service`) |
+| 6 | Transiciones | Forward-only con retorno limitado: `postulado → orientación → activo → pausa\|inactivo → retirado`; `pausa → activo`; `inactivo → postulado`; `retirado` terminal. Motivo obligatorio + audit siempre |
+| 7 | GDV liderazgo removido | Servicio pasa a `pausa` con motivo `gdv_liderazgo_removed`; membresía GDV NO se afecta; historial preservado si queda sin servicios |
+| 8 | Requisitos vencidos | Alerta sin bloquear; métrica expuesta; NO pausa el servicio |
+| 9 | Grants al activar | Se otorgan al pasar a `activo`; requisitos pendientes se registran sin bloquear |
+| 10 | Grants en pausa | Se revocan automáticamente (entran al audit como `paused_grants`); al volver a `activo` se re-otorgan |
+
+### 5.1. Decisión de capabilities (híbrido por dominio)
+
+**Por qué híbrido y no genérico puro.** Un modelo con keys como `dream_team.serve` para todas las experiencias con `experience: 'dream_team'` rompe `resolvePlatformCapability()`: el resolver exige `scope.experience === definition.experience` (línea 150, `experiences.ts`). Una capability definida con `experience: 'dream_team'` rechazaría un grant con `experience: 'dps'` por `conflicting_scope`. El resolver no permite keys "variables" por experiencia.
+
+**Por qué híbrido y no específico puro.** Un modelo con keys por cada combinación experiencia/rol/equipo (`dps.produccion-tecnica.camara.voluntario.serve`) explota combinatoriamente y viola el principio del roadmap de "evitar explosión de capabilities".
+
+**Modelo híbrido adoptado — dos familias:**
+
+| Familia | Experience en catalog | Descripción |
+|---|---|---|
+| **Genéricas Dream Team** | `dream_team` (nueva) | Gestión transversal de servicio |
+| **Específicas por dominio** | Experiencia real (`dps`, `estudiantes`, etc.) | Navegación y operación por experiencia |
+
+**Genéricas** (todas con `experience: 'dream_team'`):
+| Capability | ScopeType |
+|---|---|
+| `dream_team.serve` | `experience` |
+| `dream_team.lead` | `equipo` |
+| `dream_team.coordinate` | `equipo` |
+| `dream_team.director.coordinate` | `experience` |
+| `dream_team.requirements.manage` | `equipo` |
+| `dream_team.metrics.read` | `experience` |
+| `dream_team.gdv.lead` | `grupo` |
+
+**Específicas** (experiencia real):
+| Capability | Experience | ScopeType |
+|---|---|---|
+| `dps.team.serve` (existente) | `dps` | `equipo` |
+| `dps.team.lead` (nueva) | `dps` | `equipo` |
+| `dps.team.director` (nueva) | `dps` | `equipo` |
+| `estudiantes.team.serve` (nueva) | `estudiantes` | `equipo` |
+| `estudiantes.team.lead` (nueva) | `estudiantes` | `equipo` |
+| `talleres_crecimiento.team.serve` (nueva) | `talleres_crecimiento` | `taller` |
+| `ninos.team.serve` (nueva) | `ninos` | `salon` |
+| `the_living_room.team.serve` (nueva) | `the_living_room` | `experience` |
+
+`dream_team` se agrega al `PLATFORM_EXPERIENCE_CATALOG` con `scopeTypes: ['experience', 'equipo']`. Cada experiencia futura agrega solo sus específicas.
+
+**Caso Ana — auditoría de dos dimensiones.** Ana recibe capabilities de una misma fuente (`dream-team.ts`) pero en dos familias:
+- **Genéricas**: `dream_team.serve` (scope experience — "es Dream Team"), `dream_team.lead` (scope equipo `estudiantes:transit` — "lidera")
+- **Específicas**: `dps.team.serve` (scope equipo `dps:produccion-tecnica`), `estudiantes.team.lead` (scope equipo `estudiantes:transit`)
+
+Total: 4 capabilities con scopes concretos. El resolver las valida sin `conflicting_scope` porque las genéricas usan `experience: 'dream_team'` y las específicas usan su experiencia real. Los ítems de navegación por experiencia (`dps_team_service`) resuelven contra las específicas; las métricas y gestión resuelven contra las genéricas.
+
+## 6. Edge cases críticos
+
+1. **Líder de un grupo + miembro de otro grupo**: Dream Team se basa en el **rol de servicio**, no en la membresía. Un líder de GDV es Dream Team; un miembro regular de GDV no lo es automáticamente.
+2. **Persona queda sin servicios activos**: historial preservado, **sin borrado automático**. La persona sigue existiendo en `usuarios` y su historial longitudinal de servicio queda consultable.
+3. **Pérdida de liderazgo GDV**: pausa del servicio (motivo `gdv_liderazgo_removed`), NO retiro. Permite reactivación si vuelve a liderar GDV (vía `pausa → activo`).
+4. **Concurrencia**: dos admins editan el mismo servicio. Resolver en diseño entre last-write-wins con audit (`updated_at`) u optimistic locking (`version` column).
+5. **Reasignación de área/equipo** (mismo rol, distinto scope): definir en diseño — opciones son cerrar servicio actual + abrir nuevo, o cambio in-place con historial de scope. **Edge case a resolver explícitamente en design.**
+6. **Persona sin auth account**: Dream Team debe soportar servir sin cuenta (mismo principio que Persona canónica). FK apunta a `usuarios.id`, no a `auth.uid()`.
+7. **Requisito configurado como `no_aplica`**: nunca se verifica, nunca vence, nunca bloquea. Distinto de `pendiente`.
+8. **Múltiples líderes del mismo equipo**: dos personas distintas con rol `director` en el mismo equipo. Permitido; cada una tiene su servicio.
+
+## 7. Caso de validación (Ana)
+
+El sistema debe soportar:
+
+```text
+Ana (persona canónica)
+├── sirve en DPS / Producción Técnica / Cámara
+│   ├── estado: activo
+│   ├── rol: Voluntario
+│   ├── requisitos: política de equipos firmada (completado)
+│   ├── grants: dps.team.serve (scope: dps:equipo:produccion-tecnica)
+│   └── historial: postulado (2026-01-10) → orientación → activo (2026-02-15)
+├── sirve en Estudiantes / Transit
+│   ├── estado: activo
+│   ├── rol: Líder de grupo
+│   ├── requisitos: capacitación de liderazgo (pendiente, vence 2026-08-01)
+│   ├── grants: estudiantes.team.lead (scope: estudiantes:equipo:transit)
+│   └── historial: activo desde 2025-09-01
+└── historial participation:
+    ├── 2026-02-15: service.started (DPS, Produccion Tecnica, Camara)
+    ├── 2026-02-20: requirement.completed (politica de equipos)
+    └── (eventos de Estudiantes ya emitidos desde 2025-09)
+```
+
+Comportamientos exigidos:
+
+- Pausar DPS Cámara → Estudiantes Transit sigue activo; grants de DPS se revocan; grant de Estudiantes intacto.
+- Vencimiento de capacitación Estudiantes → alerta métrica, NO pausa.
+- Pérdida de liderazgo en Transit (edge case 3) → Estudiantes pasa a `pausa` con motivo; DPS intacto.
+- Cualquier transición queda en `dream_team_estados_historial` y emite evento `service` a participation.
+
+## 8. Entidades / modelo de datos propuesto (alto nivel)
+
+> **NO SQL todavía.** Esto es diseño de alto nivel para que `sdd-spec` lo precise.
+
+| Tabla | Propósito | Columnas clave | FKs | Índices tentativos |
+|---|---|---|---|---|
+| `dream_team_equipos` | Equipos/squads dentro de una experiencia | `id, experience_key, nombre, descripcion, jerarquia_config_id, parent_equipo_id (nullable), activo, created_at` | `experience_key` → catálogo de experiencias | `(experience_key) WHERE activo`, `(parent_equipo_id)` |
+| `dream_team_roles` | Roles configurables por equipo (con jerarquía opcional) | `id, equipo_id, nombre, parent_role_id (nullable), nivel_jerarquico, config_default_obligatoriedad, activo, created_at` | `equipo_id` → dream_team_equipos, `parent_role_id` → dream_team_roles | `(equipo_id) WHERE activo`, `(parent_role_id)` |
+| `dream_team_servicios` | Asignación persona↔equipo↔rol con estado | `id, persona_id, rol_id, equipo_id, estado, fecha_inicio, fecha_fin (nullable), notas_internas, version (concurrencia), created_at, updated_at, created_by_persona_id` | `persona_id` → usuarios, `rol_id` → dream_team_roles, `equipo_id` → dream_team_equipos | `(persona_id, estado)`, `(equipo_id, estado)`, `(rol_id)`, `UNIQUE (persona_id, equipo_id, rol_id, estado) WHERE estado IN (postulado,orientacion,activo,pausa,inactivo)` |
+| `dream_team_requisitos` | Requisitos configurables por rol | `id, rol_id, nombre, tipo, obligatoriedad, descripcion, activo, created_at` | `rol_id` → dream_team_roles | `(rol_id) WHERE activo`, `(tipo)` |
+| `dream_team_requisitos_verificacion` | Estado de verificación por (servicio, requisito) | `id, servicio_id, requisito_id, estado, fecha_verificacion (nullable), verificado_por_persona_id (nullable), fecha_vencimiento (nullable), notas, created_at, updated_at` | `servicio_id` → dream_team_servicios, `requisito_id` → dream_team_requisitos, `verificado_por_persona_id` → usuarios | `(servicio_id, requisito_id)`, `(estado, fecha_vencimiento)` |
+| `dream_team_estados_historial` | Auditoría de transiciones | `id, servicio_id, estado_anterior, estado_nuevo, motivo, actor_persona_id, paused_grants_snapshot (JSONB, nullable), created_at` | `servicio_id` → dream_team_servicios, `actor_persona_id` → usuarios | `(servicio_id, created_at DESC)`, `(actor_persona_id, created_at DESC)` |
+| `dream_team_participation_eventos` | Productor de eventos `service` para participation | `id, evento_id, persona_id, experience_key, scope_type, scope_id, event_type, occurred_at, payload (JSONB), created_at` | `persona_id` → usuarios | `(persona_id, occurred_at DESC)`, `(experience_key, scope_id, occurred_at DESC)` |
+
+**Enums previstos:**
+- `enum_dream_team_estado`: `postulado, en_orientacion, activo, en_pausa, inactivo, retirado`
+- `enum_dream_team_requisito_tipo`: `documento, capacitacion, entrevista, politicas, otro`
+- `enum_dream_team_requisito_estado`: `pendiente, completado, vencido, no_aplica`
+- `enum_dream_team_requisito_obligatoriedad`: `requerido, opcional, no_aplica`
+- `enum_dream_team_transicion_motivo_categoria`: `asignacion_inicial, cambio_rol, cambio_equipo, gdv_liderazgo_removed, solicitud_persona, decision_administrativa, fin_ciclo, otro`
+
+## 9. Capabilities nuevas (allowlist)
+
+Extensión de `PLATFORM_CAPABILITIES` en `lib/platform/experiences.ts`. **Cada capability mapea a un scope concreto** (experiencia + scopeType + scopeId).
+
+| Capability | Experience | ScopeType | Descripción |
+|---|---|---|---|
+| `dream_team.serve` | (variable) | `equipo` | Servir en un equipo (genérico) |
+| `dream_team.lead` | (variable) | `equipo` | Liderar un equipo |
+| `dream_team.coordinate` | (variable) | `equipo` | Coordinar un equipo |
+| `dream_team.director.coordinate` | (variable) | `equipo` | Director del área (jerárquico superior) |
+| `dream_team.requirements.manage` | (variable) | `equipo` | Verificar/actualizar requisitos de un equipo |
+| `dream_team.metrics.read` | (cualquiera) | `experience` | Leer métricas de Dream Team |
+| `dream_team.gdv.lead` | `grupos_vida` | `grupo` | Líder de grupo GDV (producido por adapter `dream-team-gdv`) |
+| `dps.team.serve` (existente, hoy sin backend) | `dps` | `equipo` | Se mantiene; backend lo provee el adapter Dream Team |
+| `estudiantes.team.lead` | `estudiantes` | `equipo` | Líder de equipo en Estudiantes |
+| `talleres_crecimiento.team.serve` | `talleres_crecimiento` | `taller` | Servir en un taller |
+
+> **Decisión técnica abierta para `sdd-spec`:** las capabilities con experience `(variable)` requieren revisar si `PLATFORM_CAPABILITIES` permite keys reutilizables por experiencia o si se necesitan keys específicas por experiencia (`dps.team.serve`, `estudiantes.team.serve`, etc.). Patrón actual del allowlist sugiere **keys específicas por experiencia**.
+
+## 10. Adapter complementario
+
+**`lib/platform/adapters/dream-team-gdv.ts`** — adapter read-only separado:
+
+| Aspecto | Detalle |
+|---|---|
+| Lee | `grupo_miembros` filtrando por roles de liderazgo (`líder`, `anfitrión`, etc. según taxonomía existente) |
+| Devuelve | `{ ok, contexts[], capabilities[], audit }` con capability `dream_team.gdv.lead` |
+| Scope | `{ experience: 'grupos_vida', scopeType: 'grupo', scopeId: grupoId }` |
+| Source | `'dream_team:gdv:leader'` |
+| NO toca | `lib/platform/adapters/grupos-vida.ts` ni RPCs/RLS existentes |
+| Compatibilidad | Si la persona ya es `director_etapa`, recibe **dos** capabilities: `grupos_vida.stage.read` (adapter existente) + `dream_team.gdv.lead` (este adapter) — fuentes distintas, scopes distintos |
+| Eventos participation | Emite `service` cuando una membresía de liderazgo se crea/termina |
+
+## 11. Riesgos
+
+| Riesgo | Probabilidad | Mitigación |
+|---|---|---|
+| Over-engineering del modelo de jerarquías | Media | Adjacency list simple (`parent_role_id`), 2-3 niveles. Validar con 2 equipos concretos (DPS Producción Técnica + Estudiantes Transit) |
+| Acoplar Dream Team con `support_user_capabilities` | Baja | **NO** reutilizar esa tabla. Crear `dream_team_*` nuevas |
+| Romper Grupos de Vida al mapear líderes | Media | Adapter separado, cero cambios a RPCs/RLS/acciones existentes |
+| Pérdida silenciosa de servicios al revocar GDV | Media | Audit obligatorio con motivo `gdv_liderazgo_removed`; nunca borrar, solo pasar a `pausa` |
+| Concurrencia: edits simultáneos al mismo servicio | Media | Definir estrategia en diseño (last-write-wins con audit vs optimistic locking) — decisión abierta |
+| Métricas costosas sin índices | Media | Índices en `(equipo_id, estado)`, `(persona_id, estado)`, `(requisito_id, estado, fecha_vencimiento)` |
+| Reasignación de área deja historial inconsistente | Media | Decidir política explícita en diseño: cierre + apertura vs cambio in-place con versionado de scope |
+| Navegación contextual flag OFF oculta todo | Baja | Esperado y documentado. El modelo está listo para cuando el flag se active en rollout posterior |
+| `uno_a_uno` filtrado como requisito (ej: «entrevista de liderazgo») | Baja | **NO** modelar requisitos como flujos de 1:1. Requisitos son tracking de estado, no workflows |
+| Scope creep hacia Operating Core | Media | Fase 2 = modelo + contratos + endpoint de métricas. Operación por experiencia es Fase 3 |
+
+## 12. Dependencias
+
+- **Fase 1 cerrada y mergeada** en `main` (`c364128`): persona, experiences, grants, participation, preflight, navigation, routeGuard, rollout, flags, adapters, family.
+- **14 módulos `lib/platform/**` estables** — sin cambios planeados en Fase 1.
+- **`usuarios` como Persona canónica** — FK de `dream_team_servicios.persona_id`.
+- **`PLATFORM_EXPERIENCE_CATALOG`** como catálogo de experiencias — referencia para FK de equipos.
+- **`PLATFORM_CAPABILITIES`** como allowlist extensible — se agregan keys nuevas.
+- **MCP `supabase_global_staging`** disponible para probar migraciones aditivas antes de producción.
+- **Strict TDD activo** — tests unitarios puros + integration con fakes (mismo patrón que Fase 1).
+
+## 13. Criterios de aceptación
+
+Lista verificable, cada bullet testeable:
+
+- [ ] Existen 6 tablas nuevas (`dream_team_*`) más 1 tabla de participation con migraciones aditivas aplicadas en staging
+- [ ] Existen 5 enums PostgreSQL con los valores especificados
+- [ ] `lib/platform/dream-team.ts` valida transiciones: postulado → orientación → activo → pausa|inactivo → retirado; pausa → activo; inactivo → postulado; cualquier otra transición retorna error
+- [ ] `lib/platform/dream-team.ts` rechaza transiciones sin motivo
+- [ ] `lib/platform/adapters/dream-team.ts` lee `dream_team_servicios` y produce N `PlatformSessionCapability` por servicio activo
+- [ ] `lib/platform/adapters/dream-team-gdv.ts` lee `grupo_miembros` y produce capabilities `dream_team.gdv.lead` sin tocar adapter GDV existente
+- [ ] `PLATFORM_CAPABILITIES` extendido con keys nuevas; tests de `resolvePlatformCapability` siguen verdes
+- [ ] Al transicionar a `activo` se emiten `PlatformGrantAuditEvent` con `decision: 'grant'`, snapshot before vacío, snapshot after con grants
+- [ ] Al transicionar a `pausa` se emiten `PlatformGrantAuditEvent` con `decision: 'revoke'` y se persiste `paused_grants_snapshot` en historial
+- [ ] Al volver de `pausa` a `activo` se re-otorgan los grants pausados (mismas keys, mismos scopes)
+- [ ] Al cambiar de estado se inserta fila en `dream_team_participation_eventos` (productor de `PlatformParticipationEvent` tipo `service`)
+- [ ] Caso Ana (sección 7) funciona end-to-end: 2 servicios simultáneos, transición independiente, requisitos con alerta pero sin bloqueo
+- [ ] Edge case 1: miembro regular de GDV NO recibe capability Dream Team
+- [ ] Edge case 3: pérdida de liderazgo GDV pausa el servicio con motivo `gdv_liderazgo_removed`, no lo retira
+- [ ] Endpoint de métricas devuelve: count por experiencia/equipo, count por estado, distribución de roles, lista de requisitos vencidos
+- [ ] Cero cambios en tablas existentes (verificación por diff de migración)
+- [ ] Cero cambios en `lib/platform/adapters/grupos-vida.ts` (verificación por diff)
+- [ ] `pnpm test` pasa con 666+N tests (sin regresiones)
+- [ ] PR < 400 líneas o con `size:exception` documentada
+- [ ] Documentación de capabilities agregadas en `lib/platform/experiences.ts` con scope example
+
+## 14. Métricas de éxito (qué deja Fase 2 listo)
+
+Métricas **técnicas**, no de producto:
+
+- **6 tablas nuevas** operativas con migraciones aditivas aplicadas y RLS básico
+- **5 enums** PostgreSQL con valores alineados al contrato
+- **N capabilities nuevas** en el allowlist con tests de `resolvePlatformCapability`
+- **2 adapters read-only** (`dream-team.ts` y `dream-team-gdv.ts`) con sus fakes de test
+- **1 módulo puro** (`dream-team.ts`) con state machine y validación de transiciones
+- **1 endpoint de métricas** con 4 funciones de agregación
+- **Productor de eventos `service`** insertando en `dream_team_participation_eventos`
+- **Audit grants** conectado: cada transición genera `PlatformGrantAuditEvent`
+- **0 cambios destructivos** en DB (verificable por diff de migración)
+- **0 cambios en adapters existentes** (verificable por diff)
+- **0 regresiones** en los 666 tests de Fase 1
+
+## 15. Roadmap de fases futuras que dependen de Fase 2
+
+| Fase | Dependencia con Fase 2 |
+|---|---|
+| **Fase 3 — Operating Core** | Consume `dream_team_servicios` para asignar servidores a eventos. Consume endpoint de métricas para dashboards operativos. Implementa adapter Supabase real de `PlatformParticipationReadRepository`. |
+| **Fase 5 — Talleres de Crecimiento Base** | Usa `dream_team_roles` + `dream_team_requisitos` para configurar líderes/co-líderes/servidores de cada taller. |
+| **Fase 6 — The Living Room Operativo** | Crea roles Dream Team específicos de Living Room (mentores, hosts universitarios). |
+| **Fase 7 — DPS Operations** | Conecta DPS multiárea (Producción Técnica, Música, Media, Atención al Invitado) sobre `dream_team_equipos`. |
+| **Fase 9 — Niños Operativo** | Modela servidores de salón (Waumbaland, Upstreet) como `dream_team_equipos` con requisitos de verificación de antecedentes. |
+| **Fase 10 — Estudiantes Operativo** | Modela líderes de grupo Transit/InsideOut + servidores. |
+| **Fase 11 — Ruta Espiritual** | Cruza historial Dream Team con journey espiritual (servicio como dimensión). |
+| **Fase 14 — Logística de Voluntarios** | Consume endpoint de métricas para reporte semanal a Cocina/Atención al Voluntario. |
+
+## 16. Próximo paso
+
+`sdd-spec` debe escribir los **delta specs** en `openspec/changes/fase-02-dream-team-base/specs/` para las capabilities nuevas:
+
+- `dream-team-service-domain` — modelo de dominio (servicio, equipo, rol, requisitos, estados)
+- `dream-team-state-machine` — state machine de 6 estados con transiciones y motivos
+- `dream-team-grant-lifecycle` — otorgamiento al activar, revocación en pausa, re-otorgamiento al volver
+- `dream-team-adapter` — adapter principal que mapea `dream_team_servicios` → `PlatformSessionCapability[]`
+- `dream-team-gdv-adapter` — adapter complementario para líderes GDV
+- `dream-team-metrics-endpoint` — endpoint de lectura con agregaciones
+- `dream-team-participation-producer` — productor de eventos `service` en participation
+- `dream-team-concurrency` — estrategia de concurrencia (a definir en diseño)
+
+Cada spec con sus `## Purpose`, `## Requirements` y `## Scenarios` siguiendo el formato de los specs de Fase 1 (`platform-persona`, `platform-experiences`, `platform-scoped-responsibilities`, etc.).
+
+---
+
+**Tamaño**: ~1.350 palabras (por debajo del budget de Fase 1, que usó ~720 palabras en proposal pero sin las 6 tablas de modelo de datos ni los 6 edge cases explícitos).
+**Modo**: `interactive`. No implementar.
+**Worktree**: `docs/fase-02-dream-team-base-sdd`.
+**Artifact**: `openspec/changes/fase-02-dream-team-base/proposal.md`.

--- a/openspec/changes/fase-02-dream-team-base/specs/dream-team-capabilities-grants/spec.md
+++ b/openspec/changes/fase-02-dream-team-base/specs/dream-team-capabilities-grants/spec.md
@@ -1,0 +1,54 @@
+# Delta — Dream Team Capabilities and Grants
+
+## Purpose
+
+Define the hybrid capability model (generic + domain-specific), grant lifecycle tied to service state, and audit contract via `lib/platform/grants.ts`.
+
+## Requirements
+
+### Requirement: Hybrid capability model — generic + specific
+
+The system SHALL extend `PLATFORM_CAPABILITIES` with two families. Generic capabilities SHALL use `experience: 'dream_team'` (new entry in `PLATFORM_EXPERIENCE_CATALOG` with `scopeTypes: ['experience', 'equipo']`). Domain-specific capabilities SHALL use their concrete experience. The adapter `dream-team.ts` SHALL produce both families per service.
+
+| Capability | Experience | ScopeType | Phase |
+|---|---|---|---|
+| `dream_team.serve` | dream_team | experience | New |
+| `dream_team.lead` | dream_team | equipo | New |
+| `dream_team.coordinate` | dream_team | equipo | New |
+| `dream_team.director.coordinate` | dream_team | experience | New |
+| `dream_team.requirements.manage` | dream_team | equipo | New |
+| `dream_team.metrics.read` | dream_team | experience | New |
+| `dream_team.gdv.lead` | grupos_vida | grupo | New |
+| `dps.team.serve` | dps | equipo | Existing (backend) |
+| `dps.team.lead` | dps | equipo | New |
+| `dps.team.director` | dps | equipo | New |
+| `estudiantes.team.serve` | estudiantes | equipo | New |
+| `estudiantes.team.lead` | estudiantes | equipo | New |
+| `talleres_crecimiento.team.serve` | talleres_crecimiento | taller | New |
+| `ninos.team.serve` | ninos | salon | New |
+| `the_living_room.team.serve` | the_living_room | experience | New |
+
+#### Scenario: Ana receives both families
+- GIVEN Ana serves in DPS/Cámara (activo) and Estudiantes/Transit (activo, líder)
+- WHEN adapter resolves her session capabilities
+- THEN she receives `dream_team.serve` (experience), `dream_team.lead` (equipo:estudiantes:transit), `dps.team.serve` (equipo:dps:produccion-tecnica), `estudiantes.team.lead` (equipo:estudiantes:transit)
+- AND all 4 pass `resolvePlatformCapability()` without `conflicting_scope`.
+
+### Requirement: Grants granted on activation, revoked on pause
+
+On service transition to `activo`, the system SHALL emit `PlatformGrantAuditEvent` with `decision: 'grant'` for every applicable capability. On transition to `en_pausa`, it SHALL emit `revoke` for every currently-granted capability and persist `paused_grants_snapshot` in the audit row.
+
+#### Scenario: Grant audit on activation
+- GIVEN service transitions `en_orientacion → activo`
+- WHEN grant audit is emitted
+- THEN `logger.record()` is called with `decision: 'grant'`, `source: 'dream_team'`, scope matching the service equipo.
+- AND `metrics.recordGrant('dps', 'dream_team')` increments.
+
+### Requirement: Grant audit contract via grants.ts
+
+All grant/revoke operations SHALL use `createPlatformGrantAudit().logger.record(event)`. The system SHALL record: `actorPersonaId`, `source: 'dream_team'`, `decision`, `scope`, `before`/`after` state snapshots, and `reason` when applicable. The `metrics` accumulator SHALL track per-experience grant/revoke counts.
+
+#### Scenario: Revoke with reason
+- GIVEN service transitions `activo → en_pausa` with motivo `admin_pausa`
+- WHEN grant audit is emitted
+- THEN event includes `reason: 'admin_pausa'`, `before: { active: true, capabilityKey: 'dps.team.serve' }`, `after: { active: false }`.

--- a/openspec/changes/fase-02-dream-team-base/specs/dream-team-domain/spec.md
+++ b/openspec/changes/fase-02-dream-team-base/specs/dream-team-domain/spec.md
@@ -1,0 +1,57 @@
+# Delta — Dream Team Domain
+
+## Purpose
+
+Define the Dream Team service domain: assign a persona to serve in an experience with a team and role, supporting multiple simultaneous services with independent lifecycles and full audit trail.
+
+## Requirements
+
+### Requirement: Service as (persona, equipo, rol) triple
+
+The system SHALL represent each service as a row in `dream_team_servicios` with FK to `usuarios.id` (persona canónica), FK to `dream_team_roles` (which references `dream_team_equipos` → experience), estado, fechas, and audit metadata. A persona SHALL hold multiple simultaneous services across different experiences. Each active service SHALL produce capabilities scoped to its experience/team.
+
+#### Scenario: Two simultaneous services
+- GIVEN Ana exists as persona
+- WHEN assigned to DPS/Producción Técnica/Cámara as Voluntario AND Estudiantes/Transit as Líder
+- THEN both services coexist independently in `dream_team_servicios`
+- AND each produces its own `PlatformSessionCapability[]` entries with distinct scopes.
+
+#### Scenario: Service for persona without auth account
+- GIVEN a persona has no linked `auth_id`
+- WHEN assigned to a service
+- THEN the service references `usuarios.id` (persona canónica)
+- AND SHALL NOT require auth account creation.
+
+### Requirement: State changes with mandatory motivo and audit
+
+Every state transition SHALL require a motivo from `dream_team_transicion_motivo`. Each transition SHALL insert a row in `dream_team_estados_historial` with `estado_anterior`, `estado_nuevo`, `motivo`, `actor_persona_id`, `paused_grants_snapshot` (nullable JSONB), and `created_at`. Transitions without motivo SHALL be rejected.
+
+#### Scenario: Transition without motive rejected
+- GIVEN a service in estado `activo`
+- WHEN an admin attempts transition to `en_pausa` with `motivo` null or empty
+- THEN the system SHALL reject with error.
+
+#### Scenario: Complete audit trail across lifecycle
+- GIVEN service transitions `postulado → en_orientacion → activo → en_pausa → activo → retirado`
+- WHEN audit history is queried by `servicio_id`
+- THEN 5 rows exist in `dream_team_estados_historial`
+- AND each row records `actor_persona_id`, `motivo`, and timestamp.
+
+### Requirement: History preserved on pause and retire
+
+When a service enters `en_pausa` or `retirado`, all historical rows in `dream_team_estados_historial` and `dream_team_requisitos_verificacion` SHALL remain queryable. The service row SHALL NOT be deleted. A persona with zero active services SHALL preserve full historical record.
+
+#### Scenario: Persona with zero active services
+- GIVEN a persona's last active service transitions to `retirado`
+- WHEN querying that persona's Dream Team history
+- THEN all prior services, transitions, and requirement verifications remain accessible.
+
+### Requirement: Concurrency — last-write-wins with audit detection
+
+When two admins concurrently edit the same service, the system SHALL apply last-write-wins via a `version` column on `dream_team_servicios`, incremented on every write. Stale writes (version mismatch) SHALL succeed but produce an audit flag for human review. The exact detection mechanism SHALL be defined in design.
+
+#### Scenario: Concurrent edit detected via version
+- GIVEN Admin A reads service with `version=3` and Admin B reads same service with `version=3`
+- WHEN Admin A writes first (version becomes 4), then Admin B writes with stale `version=3`
+- THEN Admin B's write SHALL succeed (last-write-wins)
+- AND audit SHALL flag the concurrent edit exposing both writes.

--- a/openspec/changes/fase-02-dream-team-base/specs/dream-team-gdv-adapter/spec.md
+++ b/openspec/changes/fase-02-dream-team-base/specs/dream-team-gdv-adapter/spec.md
@@ -1,0 +1,38 @@
+# Delta — Dream Team GDV Adapter
+
+## Purpose
+
+Define the read-only adapter that maps GDV group leaders to Dream Team capabilities without modifying existing GDV adapter, RPCs, or RLS.
+
+## Requirements
+
+### Requirement: Separate adapter reads grupo_miembros for leaders
+
+The system SHALL implement `lib/platform/adapters/dream-team-gdv.ts` as a read-only adapter. It SHALL read `grupo_miembros` filtering by liderazgo roles (`tipo_lider` values per existing GDV taxonomy). For each active leader membership, it SHALL produce a `PlatformSessionCapability` with key `dream_team.gdv.lead` and scope `{ experience: 'grupos_vida', scopeType: 'grupo', scopeId: grupoId }`. The adapter SHALL NOT modify `lib/platform/adapters/grupos-vida.ts` nor any GDV RPCs or RLS policies.
+
+#### Scenario: GDV group leader recognized as Dream Team
+- GIVEN persona with active `grupo_miembros` row where `tipo_lider` indicates leadership
+- WHEN adapter `dream-team-gdv.ts` resolves
+- THEN capability `dream_team.gdv.lead` is produced with scope grupo
+- AND the existing GDV adapter continues to produce `grupos_vida.stage.read` for directores de etapa independently.
+
+### Requirement: Leadership loss detected as pausa event
+
+The adapter SHALL compare current leadership memberships against previous state (via reader interface). When a leadership membership is removed (no longer present in `grupo_miembros`), the adapter SHALL emit a `gdv_liderazgo_removed` event. The Dream Team domain layer SHALL consume this event and transition the corresponding service to `en_pausa` with motivo `gdv_liderazgo_removed`. Group membership itself SHALL NOT be affected.
+
+#### Scenario: Leader removed from grupo_miembros
+- GIVEN persona was líder of grupo X, producing `dream_team.gdv.lead`
+- WHEN their leadership row is removed from `grupo_miembros`
+- THEN adapter emits `gdv_liderazgo_removed` event
+- AND their Dream Team service transitions to `en_pausa`
+- AND their regular group membership (if still present) is unaffected.
+
+### Requirement: GDV membership and Dream Team leadership are independent
+
+A persona SHALL be able to be a regular member of a GDV group (in `grupo_miembros` without leadership role) WITHOUT receiving `dream_team.gdv.lead`. The adapter SHALL only map rows where the membership role indicates leadership. A director de etapa who is also a leader SHALL receive BOTH `grupos_vida.stage.read` (from existing adapter) AND `dream_team.gdv.lead` (from this adapter) — different sources, different scopes.
+
+#### Scenario: Regular member not treated as Dream Team
+- GIVEN persona is a regular member of a GDV group (no liderazgo role)
+- WHEN adapter resolves
+- THEN `dream_team.gdv.lead` is NOT produced
+- AND only the existing GDV membership context applies.

--- a/openspec/changes/fase-02-dream-team-base/specs/dream-team-metrics/spec.md
+++ b/openspec/changes/fase-02-dream-team-base/specs/dream-team-metrics/spec.md
@@ -1,0 +1,44 @@
+# Delta — Dream Team Metrics Endpoint
+
+## Purpose
+
+Define a read-only metrics endpoint exposing aggregates: active counts, role distribution, and expired requirements. No dashboard widget in Fase 2.
+
+## Requirements
+
+### Requirement: Read-only endpoint returns four aggregates
+
+The system SHALL expose `getDreamTeamMetrics()` as a pure function or HTTP endpoint. It SHALL return:
+
+| Metric | Description |
+|---|---|
+| `servicios_por_experiencia_equipo` | Active service count grouped by experience and equipo |
+| `servicios_por_estado` | Count per estado across all services |
+| `distribucion_roles` | Active service count grouped by rol label |
+| `requisitos_vencidos` | List of expired requirement verifications with persona, equipo, rol, and days expired |
+
+#### Scenario: Metrics reflect Ana's two services
+- GIVEN Ana has active services in DPS/Cámara and Estudiantes/Transit
+- WHEN `getDreamTeamMetrics()` is called
+- THEN `servicios_por_experiencia_equipo` shows 1 for `dps:produccion-tecnica` and 1 for `estudiantes:transit`
+- AND `distribucion_roles` shows 1 Voluntario, 1 Líder de grupo.
+
+### Requirement: Expired requirements exposed without blocking
+
+The `requisitos_vencidos` metric SHALL list every verification row where `estado = 'completado'` AND `fecha_vencimiento < now()`, grouped by persona/equipo/rol. The metric SHALL NOT trigger automatic service state changes. The `requisito_vencido` motivo exists for manual admin use only.
+
+#### Scenario: Expired requirement appears in metrics
+- GIVEN Ana's capacitación requirement expired on 2026-08-01 and today is 2026-08-15
+- WHEN `getDreamTeamMetrics()` is called
+- THEN `requisitos_vencidos` includes Ana, Estudiantes/Transit, Líder de grupo, "capacitación liderazgo", 14 days expired
+- AND Ana's service estado remains `activo`.
+
+### Requirement: Metrics gated by capability
+
+Access to `getDreamTeamMetrics()` SHALL require capability `dream_team.metrics.read` with scope `{ experience: 'dream_team', scopeType: 'experience' }`. Without this capability, the endpoint SHALL return empty or denied.
+
+#### Scenario: Unauthorized access denied
+- GIVEN a persona without `dream_team.metrics.read`
+- WHEN calling metrics endpoint
+- THEN the system SHALL deny access
+- AND audit records the denial via `PlatformGrantAuditEvent`.

--- a/openspec/changes/fase-02-dream-team-base/specs/dream-team-participation-events/spec.md
+++ b/openspec/changes/fase-02-dream-team-base/specs/dream-team-participation-events/spec.md
@@ -1,0 +1,42 @@
+# Delta — Dream Team Participation Events
+
+## Purpose
+
+Define the `service` event producer for the longitudinal participation ledger, emitting events on state transitions and persisting via Supabase adapter.
+
+## Requirements
+
+### Requirement: Service events emitted on state transitions
+
+The system SHALL emit `PlatformParticipationEvent` with `eventType: 'service'` on every Dream Team state transition. Events SHALL include: `source: 'dream_team'`, `occurredAt`, `scope: { experience, scopeType, scopeId }`, and `actorPersonaId`. Event sub-types SHALL be carried in event payload: `service_assigned`, `service_state_changed`, `service_paused_grants_snapshot`, `service_reactivated`, `service_retired`.
+
+#### Scenario: Service activation emits event
+- GIVEN service transitions `en_orientacion → activo`
+- WHEN participation event is emitted
+- THEN event type is `service`, sensitivity `internal`, retention 365-1095 days
+- AND payload includes `subType: 'service_state_changed'`, `estado_anterior: 'en_orientacion'`, `estado_nuevo: 'activo'`.
+
+#### Scenario: Pause with grant snapshot emits event
+- GIVEN service transitions `activo → en_pausa`
+- WHEN participation event is emitted
+- THEN event payload includes `subType: 'service_paused_grants_snapshot'` with the snapshot JSON.
+
+### Requirement: Real Supabase adapter writes to dream_team_participation_eventos
+
+The system SHALL implement a Supabase-backed adapter that satisfies `PlatformParticipationReadRepository`. It SHALL write rows to `dream_team_participation_eventos` with columns: `persona_id`, `experience_key`, `scope_type`, `scope_id`, `event_type`, `occurred_at`, `payload` (JSONB). The read side SHALL support `findEventsByActorPersonaId` and `findEventsByScope`.
+
+#### Scenario: Event persisted and readable
+- GIVEN a service state change event is emitted for Ana
+- WHEN `findEventsByActorPersonaId(ana.personaId)` is called
+- THEN the event is returned with all fields
+- AND `canReadPlatformParticipationEvent()` gate is applied before exposing.
+
+### Requirement: Read gate applies sensitivity and scope rules
+
+The existing `canReadPlatformParticipationEvent()` guard SHALL apply to `service` events: self-access allowed, scoped capabilities allow per-experience reading, sensitive events require explicit capability. `service` events have sensitivity `internal` — visible to scoped capabilities but not publicly.
+
+#### Scenario: Director reads Ana's service history
+- GIVEN director has `dream_team.metrics.read` capability with scope `experience: dream_team`
+- WHEN they query Ana's participation events
+- THEN `canReadPlatformParticipationEvent()` allows via `scoped_capability`
+- AND only events within Ana's scope are returned.

--- a/openspec/changes/fase-02-dream-team-base/specs/dream-team-requirements/spec.md
+++ b/openspec/changes/fase-02-dream-team-base/specs/dream-team-requirements/spec.md
@@ -1,0 +1,42 @@
+# Delta — Dream Team Requirements
+
+## Purpose
+
+Define configurable requirements per team/role with verification tracking, expiration alerts, and no blocking behavior. No UI in Fase 2 — model and endpoint only.
+
+## Requirements
+
+### Requirement: Requirements configurable by equipo and rol
+
+The system SHALL store requirements in `dream_team_requisitos` with FK to `dream_team_roles`. Each requirement SHALL have: `codigo` (unique per rol), `label`, `tipo` (documento | capacitacion | entrevista | firma | otro), and `obligatoriedad` (requerido | opcional | no_aplica). Requirements SHALL be activable/inactivable via `activo` boolean.
+
+#### Scenario: Role with three requirements
+- GIVEN rol "Líder de grupo" configured with: política firmada (requerido, documento), capacitación liderazgo (requerido, capacitacion), entrevista pastoral (opcional, entrevista)
+- WHEN a persona is assigned to that rol
+- THEN three rows are created in `dream_team_requisitos_verificacion` — one per requirement, all in `pendiente`.
+
+### Requirement: Verification tracks state, date, and verifier
+
+Each verification row in `dream_team_requisitos_verificacion` SHALL track: `estado` (pendiente | completado | vencido | no_aplica), `fecha_verificacion` (nullable), `verificado_por_persona_id` (nullable), `fecha_vencimiento` (nullable, only meaningful when `obligatoriedad = requerido`), and audit `created_at`/`updated_at`.
+
+#### Scenario: Requirement verified with expiration
+- GIVEN requirement "capacitación liderazgo" has `fecha_vencimiento: 2026-08-01`
+- WHEN admin verifies it on 2026-06-15
+- THEN estado becomes `completado`, `fecha_verificacion = 2026-06-15`
+- AND after 2026-08-01, a metric query SHALL expose it as `vencido`.
+
+### Requirement: Expired requirements alert without blocking
+
+The system SHALL expose expired requirements via the metrics endpoint (`getDreamTeamMetrics().requisitos_vencidos`). Expiration SHALL NOT automatically pause or terminate a service. The `requisito_vencido` motivo exists for manual admin transition but SHALL NOT be auto-triggered.
+
+#### Scenario: Expired requirement does not pause service
+- GIVEN Ana's capacitación requirement expires while her service is `activo`
+- WHEN the system evaluates her service state
+- THEN her service remains `activo`
+- AND `getDreamTeamMetrics()` includes her expired requirement in its count.
+
+#### Scenario: No verification for no_aplica requirements
+- GIVEN a requirement configured with `obligatoriedad: no_aplica`
+- WHEN a persona is assigned to that rol
+- THEN the verification row is created with `estado: no_aplica`
+- AND the requirement SHALL NOT appear in expired-requirement metrics.

--- a/openspec/changes/fase-02-dream-team-base/specs/dream-team-state-machine/spec.md
+++ b/openspec/changes/fase-02-dream-team-base/specs/dream-team-state-machine/spec.md
@@ -1,0 +1,67 @@
+# Delta — Dream Team State Machine
+
+## Purpose
+
+Define the service state machine with 6 estados, valid transitions, mandatory motivo per transition, grant lifecycle hooks, and audit logging.
+
+## Requirements
+
+### Requirement: Six states with explicit valid transitions
+
+The system SHALL support 6 estados: `postulado`, `en_orientacion`, `activo`, `en_pausa`, `inactivo`, `retirado`. Valid transitions SHALL follow a forward-only model with limited return. The following matrix SHALL be enforced:
+
+| From → To | postulado | en_orientacion | activo | en_pausa | inactivo | retirado |
+|---|---|---|---|---|---|---|
+| postulado | — | ✅ | ❌ | ❌ | ❌ | ❌ |
+| en_orientacion | ❌ | — | ✅ | ❌ | ❌ | ❌ |
+| activo | ❌ | ❌ | — | ✅ | ✅ | ✅ |
+| en_pausa | ❌ | ❌ | ✅ | — | ❌ | ✅ |
+| inactivo | ✅ | ❌ | ❌ | ❌ | — | ❌ |
+| retirado | ❌ | ❌ | ❌ | ❌ | ❌ | — (terminal) |
+
+#### Scenario: Invalid transition rejected
+- GIVEN service in `postulado`
+- WHEN admin attempts transition to `activo` (skipping `en_orientacion`)
+- THEN the system SHALL reject with `invalid_transition` error.
+
+#### Scenario: Pause → active return
+- GIVEN service in `en_pausa` with motivo `gdv_liderazgo_removed`
+- WHEN admin reactivates to `activo` with motivo `admin_reactivacion`
+- THEN transition succeeds
+- AND `paused_grants_snapshot` is consumed to re-grant capabilities.
+
+### Requirement: Mandatory motivo per transition
+
+Every transition SHALL require a `motivo` from the closed enum `dream_team_transicion_motivo`: `admin_asignacion`, `admin_promocion`, `admin_pausa`, `admin_reactivacion`, `admin_retiro`, `requisito_vencido`, `gdv_liderazgo_removed`, `auto_pausa`, `otro`. The transition SHALL insert an audit row in `dream_team_estados_historial`.
+
+#### Scenario: GDV leadership loss triggers pause
+- GIVEN service in `activo` with source `dream_team:gdv:leader`
+- WHEN adapter `dream-team-gdv.ts` detects leadership removal
+- THEN service SHALL transition to `en_pausa` with motivo `gdv_liderazgo_removed`
+- AND audit row records the adapter as `actor_persona_id` (system).
+
+### Requirement: Grants paused on pause, re-granted on reactivation
+
+On transition `activo → en_pausa`, the system SHALL emit `PlatformGrantAuditEvent` with `decision: 'revoke'` for every capability currently granted and SHALL persist them as `paused_grants_snapshot` (JSONB array of `{ key, scope }`) in the audit row. On transition `en_pausa → activo`, the system SHALL re-grant every capability from the most recent snapshot.
+
+#### Scenario: Pause revokes grants
+- GIVEN service with grants `dps.team.serve` and `dream_team.serve`
+- WHEN service transitions to `en_pausa`
+- THEN two `revoke` events are recorded in grant audit
+- AND snapshot `[{ key: 'dps.team.serve', scope: {...} }, { key: 'dream_team.serve', scope: {...} }]` is persisted.
+
+#### Scenario: Reactivation re-grants from snapshot
+- GIVEN paused service with snapshot from prior scenario
+- WHEN service transitions to `activo`
+- THEN two `grant` events restore `dps.team.serve` and `dream_team.serve`
+- AND scopes match exactly those in the snapshot.
+
+### Requirement: Reassignment — same role, different scope
+
+When a persona's service role remains the same but the equipo/scope changes, the system SHALL close the current service (`retirado` with motivo `admin_promocion`) and create a new service (`postulado` with motivo `admin_asignacion`). In-place scope mutation SHALL NOT be supported in Fase 2; this behavior SHALL be defined in design.
+
+#### Scenario: Reassignment handled as close + open
+- GIVEN Ana serves in DPS/Producción Técnica/Cámara as Voluntario (activo)
+- WHEN admin reassigns her to DPS/Música as Voluntario (same role, different equipo)
+- THEN Cámara service transitions to `retirado` with motivo `admin_promocion`
+- AND a new service is created in Música with initial estado `postulado`.

--- a/openspec/changes/fase-02-dream-team-base/tasks.md
+++ b/openspec/changes/fase-02-dream-team-base/tasks.md
@@ -1,0 +1,209 @@
+# Tasks: Fase 2 — Dream Team Global Base
+
+> **Change**: `fase-02-dream-team-base`
+> **Status**: pending
+> **Plan**: 10 slices encadenados stacked-to-main (force-chained)
+> **Delivery**: force-chained, chain strategy stacked-to-main, strict TDD
+
+## Review Workload Forecast
+
+| Field | Value |
+|-------|-------|
+| Estimated changed lines | ~3,750 (prod + test + migration) |
+| 400-line budget risk | High |
+| Chained PRs recommended | Yes |
+| Suggested split | PR1 → PR2 → PR3 → PR4 → PR5 → PR6 → PR7 → PR8 → PR9 → PR10 |
+| Delivery strategy | force-chained |
+| Chain strategy | stacked-to-main |
+
+Decision needed before apply: No
+Chained PRs recommended: Yes
+Chain strategy: stacked-to-main
+400-line budget risk: High
+
+### Suggested Work Units
+
+| Unit | Goal | Likely PR | Notes |
+|------|------|-----------|-------|
+| S1 | Foundation pura (types, errors, state-machine) | PR1 | Sin DB; 100% unit tests |
+| S2 | Capabilities + experiences catalog | PR2 | Extensión aditiva de Fase 1; depende S1 |
+| S3 | Repository interfaces + fake in-memory | PR3 | Contratos + factory para tests; depende S1 |
+| S4 | Supabase repository + migración SQL | PR4 | `size:exception` (~650 líneas); depende S3 |
+| S5 | GDV adapter (líderes como Dream Team) | PR5 | Read-only, sin tocar adapter existente; depende S3 |
+| S6 | Servicios API routes (CRUD completo) | PR6 | Gated por capability; depende S4 |
+| S7 | Grants orchestrator + audit lifecycle | PR7 | Consume `lib/platform/grants.ts`; depende S4 + S6 |
+| S8 | Métricas puras + endpoint HTTP | PR8 | 4 agregados; depende S4 |
+| S9 | Participation events writer (Supabase) | PR9 | Writer real para `service`; depende S4 + S7 |
+| S10 | Rollout flag + integration final + docs | PR10 | Staged rollout; depende S8 + S9 |
+
+---
+
+## Slice S1: Foundation Pura
+
+**PR target**: PR #1 stacked-to-main
+**Depends on**: none
+**Estimated lines**: ~300 (150 prod / 150 test)
+**PR budget**: ok
+
+### Tasks
+
+- [ ] 1.1 DT-001 — Definir tipos compartidos en `lib/platform/dream-team/types.ts`: `DreamTeamEstado` (6 valores), `DreamTeamEquipo`, `DreamTeamRol`, `DreamTeamServicio`, `DreamTeamRequisito`, `DreamTeamRequisitoVerificacion`, `DreamTeamTransicion`, `PausedGrantsSnapshot`, `ServicioInsert`, `RequisitoInput`, `RequisitoVerificacionInput`, `EstadoHistorialInsert`. Archivos: `lib/platform/dream-team/types.ts`. Test: N/A (types-only). Verificación: `pnpm typecheck`.
+- [ ] 1.2 DT-002 — Definir errores tipados en `lib/platform/dream-team/errors.ts`: `DreamTeamErrorReason` union (`invalid_transition`, `missing_motivo`, `version_conflict`, `not_found`, `invalid_requisito`), `DreamTeamError` class, `isDreamTeamError()` guard, `denied(reason)` factory. Archivos: `lib/platform/dream-team/errors.ts`. Test: `__tests__/lib/platform/dream-team/errors.test.ts`. Verificación: `pnpm test -- --testPathPattern=dream-team/errors`.
+- [ ] 1.3 DT-003 — Implementar state machine en `lib/platform/dream-team/state-machine.ts`: `DREAM_TEAM_STATES` const array, `DREAM_TEAM_TRANSITION_MATRIX` (matriz de validez), `DREAM_TEAM_TRANSITION_MOTIVOS` enum, `validateDreamTeamTransition(from, to, motivo)` → discriminated union `{ ok: true } | { ok: false, reason }`. Forward-only con retorno limitado (`en_pausa → activo`, `inactivo → postulado`). Motivo obligatorio siempre. Archivos: `lib/platform/dream-team/state-machine.ts`. Test: `__tests__/lib/platform/dream-team/state-machine.test.ts`. Verificación: `pnpm test -- --testPathPattern=dream-team/state-machine`.
+- [ ] 1.4 DT-004 — Tests RED de state machine: transiciones válidas (postulado→orientación, orientación→activo, activo→pausa, pausa→activo, inactivo→postulado), transiciones inválidas (postulado→activo, retirado→cualquiera), motivo obligatorio rechazado si null/empty, `retirado` terminal. Archivos: `__tests__/lib/platform/dream-team/state-machine.test.ts`. Verificación: `pnpm test -- --testPathPattern=dream-team/state-machine` — todos verdes.
+- [ ] 1.5 DT-005 — Tests de error factories: `denied('invalid_transition')` retorna discriminated union, `isDreamTeamError()` identifica correctamente, unknown reason rechazado en compile-time. Archivos: `__tests__/lib/platform/dream-team/errors.test.ts`. Verificación: `pnpm test -- --testPathPattern=dream-team/errors` — todos verdes.
+
+## Slice S2: Capabilities + Experiences
+
+**PR target**: PR #2 stacked-to-main
+**Depends on**: S1
+**Estimated lines**: ~150 (25 prod / 125 test)
+**PR budget**: ok
+
+### Tasks
+
+- [ ] 2.1 DT-006 — Agregar `dream_team` a `PLATFORM_EXPERIENCE_CATALOG` en `lib/platform/experiences.ts`: `{ label: 'Dream Team', scopeTypes: ['experience', 'equipo'] }`. Extensión aditiva, sin tocar las 7 experiencias existentes. Archivos: `lib/platform/experiences.ts`. Test: `__tests__/lib/platform/experiences.test.ts`. Verificación: `pnpm test -- --testPathPattern=experiences` — tests Fase 1 siguen verdes.
+- [ ] 2.2 DT-007 — Agregar 15 capabilities a `PLATFORM_CAPABILITIES` en `lib/platform/experiences.ts`: 7 genéricas (`dream_team.serve`, `dream_team.lead`, `dream_team.coordinate`, `dream_team.director.coordinate`, `dream_team.requirements.manage`, `dream_team.metrics.read`, `dream_team.gdv.lead`) + 8 específicas (`dps.team.serve` existente con backend, `dps.team.lead`, `dps.team.director`, `estudiantes.team.serve`, `estudiantes.team.lead`, `talleres_crecimiento.team.serve`, `ninos.team.serve`, `the_living_room.team.serve`). Archivos: `lib/platform/experiences.ts`. Test: `__tests__/lib/platform/experiences.test.ts`. Verificación: `pnpm test -- --testPathPattern=experiences`.
+- [ ] 2.3 DT-008 — Tests de resolve con capabilities nuevas: `resolvePlatformCapability` resuelve `dream_team.serve` con `experience: 'dream_team'` sin `conflicting_scope`; resuelve `dps.team.serve` con `experience: 'dps'`; capability desconocida retorna `unknown_capability`; modelo híbrido Ana (4 capabilities, 0 conflictos). Archivos: `__tests__/lib/platform/experiences.test.ts`. Verificación: `pnpm test -- --testPathPattern=experiences` — todos verdes.
+
+## Slice S3: Repository Interfaces + Fake
+
+**PR target**: PR #3 stacked-to-main
+**Depends on**: S1
+**Estimated lines**: ~400 (200 prod / 200 test)
+**PR budget**: ok (justo al límite)
+
+### Tasks
+
+- [ ] 3.1 DT-009 — Definir interface `DreamTeamRepository` en `lib/platform/dream-team/repository.ts`: métodos read+write para equipos, roles, servicios (con `expectedVersion`), requisitos, verificaciones, historial, participation events, y métricas. Incluir `DreamTeamGdvMembershipReader` y `DreamTeamParticipationEventWriter` como interfaces separadas. Archivos: `lib/platform/dream-team/repository.ts`. Test: N/A (interface-only). Verificación: `pnpm typecheck`.
+- [ ] 3.2 DT-010 — Implementar `createInMemoryDreamTeamRepository()` en `lib/platform/dream-team/repository-fake.ts`: implementación in-memory completa de `DreamTeamRepository` con arrays mutables, version tracking, y factory con seed opcional. Archivos: `lib/platform/dream-team/repository-fake.ts`. Test: `__tests__/lib/platform/dream-team/repository-fake.test.ts`. Verificación: `pnpm test -- --testPathPattern=dream-team/repository-fake`.
+- [ ] 3.3 DT-011 — Tests del fake repository: CRUD servicios (insert, get, list by persona, list by equipo), version increment on update, `updateServicioEstado` con `expectedVersion` mismatch retorna `version_conflict`, historial append+list, requisitos upsert+list, participation events append+list, métricas count. Archivos: `__tests__/lib/platform/dream-team/repository-fake.test.ts`. Verificación: `pnpm test -- --testPathPattern=dream-team/repository-fake` — todos verdes.
+
+## Slice S4: Supabase Repository + Migración
+
+**PR target**: PR #4 stacked-to-main
+**Depends on**: S3
+**Estimated lines**: ~650 (250 prod / 200 test / 200 SQL)
+**PR budget**: size:exception — migración SQL (7 tablas + 5 enums + RLS + índices) + repository Supabase + integration tests exceden 400 líneas; justificado por ser el único slice con DB.
+
+### Tasks
+
+- [ ] 4.1 DT-012 — Crear migración SQL `supabase/migrations/YYYYMMDDHHMMSS_dream_team_base.sql`: 5 enums (`enum_dream_team_estado`, `enum_dream_team_requisito_tipo`, `enum_dream_team_requisito_obligatoriedad`, `enum_dream_team_requisito_estado`, `enum_dream_team_transicion_motivo`), 7 tablas (`dream_team_equipos`, `dream_team_roles`, `dream_team_servicios` con `version` column, `dream_team_requisitos`, `dream_team_requisitos_verificacion`, `dream_team_estados_historial` con `paused_grants_snapshot` JSONB, `dream_team_participation_eventos`), helper Postgres `auth_has_dream_team_capability(text)`, tabla `dream_team_capability_grants`, RLS policies, índices. Solo `CREATE TABLE`/`CREATE TYPE`/`CREATE INDEX`/`CREATE POLICY` — cero `DROP`/`ALTER` a tablas existentes. Archivos: `supabase/migrations/YYYYMMDDHHMMSS_dream_team_base.sql`. Test: N/A (SQL artifact). Verificación: revisión manual del SQL.
+- [ ] 4.2 DT-013 — Aplicar migración a `supabase_global_staging` vía MCP tool `supabase_global_staging_apply_migration`. Validar que 7 tablas + 5 enums existen (`supabase_global_staging_list_tables`), RLS bloquea authenticated sin capability, y helper `auth_has_dream_team_capability` funciona. Archivos: N/A (operación MCP). Verificación: `supabase_global_staging_list_tables` muestra `dream_team_*`; query de smoke RLS retorna denied para usuario sin capability.
+- [ ] 4.3 DT-014 — Implementar `createSupabaseDreamTeamRepository()` en `lib/platform/dream-team/repository-supabase.ts`: mapea cada método de `DreamTeamRepository` a queries Supabase usando `createServerClient()`. `updateServicioEstado` usa `WHERE version = expectedVersion` + increment. Archivos: `lib/platform/dream-team/repository-supabase.ts`. Test: `__tests__/lib/platform/dream-team/repository-supabase.test.ts`. Verificación: `pnpm typecheck`.
+- [ ] 4.4 DT-015 — Integration tests contra staging (tag `integration:supabase`, skipped sin `STAGING_URL`): CRUD servicios round-trip, version conflict detection, historial queries, RLS enforcement. Test isolation por `persona_id` random UUID. Archivos: `__tests__/lib/platform/dream-team/repository-supabase.test.ts`. Verificación: `pnpm test -- --testPathPattern=dream-team/repository-supabase` con env staging.
+- [ ] 4.5 DT-016 — Documentar `size:exception` en PR body: justificación (~650 líneas por migración SQL aditiva + repository + tests), tabla de líneas por archivo, confirmación de 0 cambios destructivos. Archivos: PR description. Verificación: review approval con `size:exception` label.
+
+## Slice S5: GDV Adapter
+
+**PR target**: PR #5 stacked-to-main
+**Depends on**: S3
+**Estimated lines**: ~360 (180 prod / 180 test)
+**PR budget**: ok
+
+### Tasks
+
+- [ ] 5.1 DT-017 — Implementar `resolveDreamTeamGdvPlatformContext(input)` en `lib/platform/adapters/dream-team-gdv.ts`: `DreamTeamGdvAdapterInput` con `session` + `DreamTeamGdvMembershipReader`, produce `{ ok, contexts[], capabilities[], audit }` con capability `dream_team.gdv.lead` scope `{ experience: 'grupos_vida', scopeType: 'grupo', scopeId }`. Detecta leadership loss comparando memberships actuales vs previas. Archivos: `lib/platform/adapters/dream-team-gdv.ts`. Test: `__tests__/lib/platform/dream-team-gdv-adapter.test.ts`. Verificación: `pnpm test -- --testPathPattern=dream-team-gdv`.
+- [ ] 5.2 DT-018 — Tests del GDV adapter: líder de grupo produce `dream_team.gdv.lead`; miembro regular NO produce capability; director de etapa recibe AMBAS capabilities (`grupos_vida.stage.read` + `dream_team.gdv.lead`); leadership removal emite evento `gdv_liderazgo_removed`; cero bytes cambiados en `lib/platform/adapters/grupos-vida.ts`. Archivos: `__tests__/lib/platform/dream-team-gdv-adapter.test.ts`. Verificación: `pnpm test -- --testPathPattern=dream-team-gdv` — todos verdes; `git diff lib/platform/adapters/grupos-vida.ts` = 0 bytes.
+
+## Slice S6: Servicios API Routes
+
+**PR target**: PR #6 stacked-to-main
+**Depends on**: S4
+**Estimated lines**: ~400 (200 prod / 200 test)
+**PR budget**: ok (justo al límite)
+
+### Tasks
+
+- [ ] 6.1 DT-019 — Implementar `GET /api/dream-team/servicios` en `app/api/dream-team/servicios/route.ts`: listar servicios filtrados por query params (`personaId`, `equipoId`, `estado`), gated por capability `dream_team.requirements.manage` o `dream_team.metrics.read`. Archivos: `app/api/dream-team/servicios/route.ts`. Test: `__tests__/app/api/dream-team/servicios.test.ts`. Verificación: `pnpm test -- --testPathPattern=api/dream-team/servicios`.
+- [ ] 6.2 DT-020 — Implementar `POST /api/dream-team/servicios` en `app/api/dream-team/servicios/route.ts`: asignar servicio (estado inicial `postulado`), valida input, crea verificaciones de requisitos en `pendiente`, inserta historial. Gated por `dream_team.requirements.manage`. Archivos: `app/api/dream-team/servicios/route.ts`. Test: `__tests__/app/api/dream-team/servicios.test.ts`. Verificación: `pnpm test -- --testPathPattern=api/dream-team/servicios`.
+- [ ] 6.3 DT-021 — Implementar `GET/PATCH /api/dream-team/servicios/[id]/route.ts`: GET retorna servicio + historial + verificaciones; PATCH aplica transición de estado vía `validateDreamTeamTransition` + `updateServicioEstado` con version check (409 on conflict). Gated por capability. Archivos: `app/api/dream-team/servicios/[id]/route.ts`. Test: `__tests__/app/api/dream-team/servicios-id.test.ts`. Verificación: `pnpm test -- --testPathPattern=api/dream-team/servicios-id`.
+- [ ] 6.4 DT-022 — Tests de API routes: GET lista filtrado, POST asigna con estado postulado + historial, PATCH transición válida succeed, PATCH transición inválida retorna 400, PATCH version conflict retorna 409, sin capability retorna 403, flag OFF retorna 404. Archivos: `__tests__/app/api/dream-team/servicios.test.ts`, `__tests__/app/api/dream-team/servicios-id.test.ts`. Verificación: `pnpm test -- --testPathPattern=api/dream-team` — todos verdes.
+
+## Slice S7: Grants Orchestrator + Audit
+
+**PR target**: PR #7 stacked-to-main
+**Depends on**: S4, S6
+**Estimated lines**: ~380 (180 prod / 200 test)
+**PR budget**: ok
+
+### Tasks
+
+- [ ] 7.1 DT-023 — Implementar `lib/platform/dream-team/grants.ts`: `applyGrantsForTransition(ctx)` decide grant/revoke según estado nuevo, `serializePausedGrantsSnapshot(grants[])` → JSONB, `restoreFromSnapshot(snapshot)` → grant events. Consume `createPlatformGrantAudit()` de `lib/platform/grants.ts` sin modificarlo. Archivos: `lib/platform/dream-team/grants.ts`. Test: `__tests__/lib/platform/dream-team/grants.test.ts`. Verificación: `pnpm test -- --testPathPattern=dream-team/grants`.
+- [ ] 7.2 DT-024 — Integrar grants orchestrator en flujo de transición: `transitionServicio` llama `applyGrantsForTransition` cuando estado nuevo es `activo` (grant) o `en_pausa` (revoke+snapshot). Reactivación desde pausa consume snapshot. Archivos: `lib/platform/dream-team/servicios.ts`. Test: `__tests__/lib/platform/dream-team/grants.test.ts`. Verificación: `pnpm test -- --testPathPattern=dream-team/grants`.
+- [ ] 7.3 DT-025 — Tests del grants orchestrator: activación emite grant events con `source: 'dream_team'`; pausa emite revoke events + snapshot persistido; reactivación re-grants desde snapshot (mismas keys, mismos scopes); métricas incrementan por experiencia; `lib/platform/grants.ts` sin cambios (0 bytes diff). Archivos: `__tests__/lib/platform/dream-team/grants.test.ts`. Verificación: `pnpm test -- --testPathPattern=dream-team/grants` — todos verdes; `git diff lib/platform/grants.ts` = 0 bytes.
+
+## Slice S8: Métricas + Endpoint
+
+**PR target**: PR #8 stacked-to-main
+**Depends on**: S4
+**Estimated lines**: ~300 (150 prod / 150 test)
+**PR budget**: ok
+
+### Tasks
+
+- [ ] 8.1 DT-026 — Implementar `getDreamTeamMetrics(reader)` en `lib/platform/dream-team/metrics.ts`: función pura que retorna `DreamTeamMetrics` con 4 campos (`servicios_por_experiencia_equipo`, `servicios_por_estado`, `distribucion_roles`, `requisitos_vencidos`). Archivos: `lib/platform/dream-team/metrics.ts`. Test: `__tests__/lib/platform/dream-team/metrics.test.ts`. Verificación: `pnpm test -- --testPathPattern=dream-team/metrics`.
+- [ ] 8.2 DT-027 — Implementar `GET /api/dream-team/metrics/route.ts`: endpoint autenticado, gating por capability `dream_team.metrics.read`, retorna JSON con las 4 métricas. Sin capability → 403 + audit deny. Archivos: `app/api/dream-team/metrics/route.ts`. Test: `__tests__/app/api/dream-team/metrics.test.ts`. Verificación: `pnpm test -- --testPathPattern=api/dream-team/metrics`.
+- [ ] 8.3 DT-028 — Tests de métricas: función pura retorna 4 agregados correctos con fake repo; caso Ana (2 servicios activos, distribución roles); requisitos vencidos listados sin bloquear servicio; endpoint gated (403 sin capability, 200 con capability). Archivos: `__tests__/lib/platform/dream-team/metrics.test.ts`, `__tests__/app/api/dream-team/metrics.test.ts`. Verificación: `pnpm test -- --testPathPattern=dream-team/metrics` — todos verdes.
+
+## Slice S9: Participation Events Writer
+
+**PR target**: PR #9 stacked-to-main
+**Depends on**: S4, S7
+**Estimated lines**: ~400 (200 prod / 200 test)
+**PR budget**: ok (justo al límite)
+
+### Tasks
+
+- [ ] 9.1 DT-029 — Extender `lib/platform/adapters/participation-adapter.ts` con `DreamTeamParticipationSupabaseWriter`: implementa write side de `PlatformParticipationReadRepository` para eventos `service`, persiste en `dream_team_participation_eventos`. `ParticipationInMemoryAdapter` intacto para los 6 tipos no-service. Archivos: `lib/platform/adapters/participation-adapter.ts`. Test: `__tests__/lib/platform/dream-team/participation-writer.test.ts`. Verificación: `pnpm test -- --testPathPattern=participation-writer`.
+- [ ] 9.2 DT-030 — Integrar participation writer con state machine: `transitionServicio` emite `PlatformParticipationEvent` tipo `service` con sub-types (`service_assigned`, `service_state_changed`, `service_paused_grants_snapshot`, `service_reactivated`, `service_retired`), sensitivity `internal`, retention 365-1095 días. Archivos: `lib/platform/dream-team/servicios.ts`. Test: `__tests__/lib/platform/dream-team/participation-writer.test.ts`. Verificación: `pnpm test -- --testPathPattern=participation-writer`.
+- [ ] 9.3 DT-031 — Tests del participation writer: activación emite `service_state_changed`; pausa emite `service_paused_grants_snapshot` con JSON; reactivación emite `service_reactivated`; retiro emite `service_retired`; read side `findEventsByActorPersonaId` retorna eventos; `canReadPlatformParticipationEvent` gate aplica; `ParticipationInMemoryAdapter` sin cambios. Archivos: `__tests__/lib/platform/dream-team/participation-writer.test.ts`. Verificación: `pnpm test -- --testPathPattern=participation-writer` — todos verdes.
+
+## Slice S10: Rollout Flag + Integration Final
+
+**PR target**: PR #10 stacked-to-main
+**Depends on**: S8, S9
+**Estimated lines**: ~160 (80 prod / 80 test)
+**PR budget**: ok
+
+### Tasks
+
+- [ ] 10.1 DT-032 — Extender `lib/platform/flags.ts` con `getDreamTeamFlags()`: retorna `{ enabled, killSwitch }` desde `NEXT_PUBLIC_DREAM_TEAM_ENABLED`. Default `off`. Integrar en API routes de S6/S8 (404 si flag OFF). Archivos: `lib/platform/flags.ts`. Test: `__tests__/lib/platform/flags.test.ts`. Verificación: `pnpm test -- --testPathPattern=flags`.
+- [ ] 10.2 DT-033 — Integration test caso Ana end-to-end: asignación DPS+Cámara (postulado), promoción a activo (grants emitidos), segundo servicio Estudiantes+Transit (activo), pausa DPS (grants revoked + snapshot), capacitación vencida (alerta sin bloqueo), reactivación DPS (grants restaurados), métricas reflejan estado final. Archivos: `__tests__/lib/platform/dream-team/integration-ana.test.ts`. Verificación: `pnpm test -- --testPathPattern=dream-team/integration-ana` — todos verdes.
+- [ ] 10.3 DT-034 — Documentación de rollout: staged 0→5→25→50→100% vía `lib/platform/rollout.ts`, `NEXT_PUBLIC_DREAM_TEAM_ENABLED=off` en Vercel por defecto, notas de producción en PR body. Archivos: PR description. Verificación: review approval.
+
+---
+
+## Tabla Resumen
+
+| Slice | PR | Archivos principales | Líneas est. | Budget | Depende de |
+|---|---|---|---|---|---|
+| S1 | PR1 | `types.ts`, `errors.ts`, `state-machine.ts` | ~300 | ok | none |
+| S2 | PR2 | `experiences.ts` (ext) | ~150 | ok | S1 |
+| S3 | PR3 | `repository.ts`, `repository-fake.ts` | ~400 | ok | S1 |
+| S4 | PR4 | `repository-supabase.ts`, migración SQL | ~650 | size:exception | S3 |
+| S5 | PR5 | `dream-team-gdv.ts` | ~360 | ok | S3 |
+| S6 | PR6 | `servicios/route.ts`, `[id]/route.ts` | ~400 | ok | S4 |
+| S7 | PR7 | `grants.ts`, `servicios.ts` (ext) | ~380 | ok | S4, S6 |
+| S8 | PR8 | `metrics.ts`, `metrics/route.ts` | ~300 | ok | S4 |
+| S9 | PR9 | `participation-adapter.ts` (ext), `servicios.ts` (ext) | ~400 | ok | S4, S7 |
+| S10 | PR10 | `flags.ts` (ext), integration test | ~160 | ok | S8, S9 |
+
+## Conteo Total
+
+- **Total tasks**: 34
+- **Total líneas estimadas**: ~3,750
+- **PRs encadenados**: 10
+- **PRs con `size:exception`**: 1 (S4 — migración SQL + repository Supabase)
+- **PRs con budget ok**: 9
+
+## Notas de Aplicación
+
+- **Strict TDD activo**: cada task comienza con test RED (test falla antes de implementar). Orden: RED → GREEN → REFACTOR.
+- **Migración S4**: se aplica vía MCP `supabase_global_staging` primero (DT-013), se valida, y solo después se continúa con S5+. Producción NO hasta S10 mergeado + ≥7 días staging.
+- **Feature flag**: `NEXT_PUBLIC_DREAM_TEAM_ENABLED=off` por defecto hasta S10. API routes retornan 404 con flag OFF.
+- **Cada PR mergeado** → verificación contra staging antes de merge del siguiente (`pnpm test`, `pnpm typecheck`, `pnpm lint`, `pnpm build`).
+- **Cobertura objetivo**: ≥70% unit, ≥60% integration, ≥60% e2e helpers, ≥70% overall.
+- **Cero cambios destructivos**: solo `CREATE TABLE`/`CREATE TYPE`/`CREATE INDEX`/`CREATE POLICY`. Cero `DROP`/`ALTER` a tablas existentes.
+- **Cero cambios en adapter GDV existente**: `git diff lib/platform/adapters/grupos-vida.ts` = 0 bytes en cada PR.
+- **`lib/platform/grants.ts` intacto**: solo consumido, nunca modificado.

--- a/openspec/config.yaml
+++ b/openspec/config.yaml
@@ -1,0 +1,39 @@
+# openspec/config.yaml
+schema: spec-driven
+
+context: |
+  Tech stack: Next.js 16 (App Router), TypeScript strict, React 19, Tailwind CSS 4, pnpm
+  Architecture: Server Components by default, Supabase Auth SSR, RLS + RPCs, Server Actions
+  Testing: Jest 30 + React Testing Library + ts-jest, jsdom environment, v8 coverage
+  Style: Radix UI primitives, SistemaDiseno components (glass/visionOS), lucide-react icons, dark mode
+  Patterns: liquid-glass / VisionOS design, zod validation, react-hook-form, atomic commits with conventional-commits
+
+rules:
+  proposal:
+    - Include rollback plan for risky changes
+    - Keep scope focused; use chained PRs for large changes
+    - Reference GitHub issues when applicable
+  specs:
+    - Use Given/When/Then for scenarios
+    - Use RFC 2119 keywords (MUST, SHALL, SHOULD, MAY)
+    - Prefer Spanish for UI-facing docs, English for technical specs
+  design:
+    - Include sequence diagrams for complex flows
+    - Document architecture decisions with rationale
+    - Reference platform modules (persona, grants, experiences, participation, preflight, rollout, routeGuard, family)
+  tasks:
+    - Group by phase, use hierarchical numbering
+    - Keep tasks completable in one session
+    - Use chained PR strategy for >400-line changes
+  apply:
+    - Follow existing code patterns (Server Components first, Client Components only for interactivity)
+    - Respect SistemaDiseno components and tokens
+    tdd: true
+    test_command: "pnpm test -- --related"
+  verify:
+    test_command: "pnpm test"
+    build_command: "pnpm build"
+    coverage_threshold: 10
+  archive:
+    - Warn before merging destructive deltas
+    - Preserve state.yaml for audit trail


### PR DESCRIPTION
## Resumen

Planificación SDD completa de **Fase 2 — Dream Team Global Base** del roadmap maestro de GlobalConnect. **NO incluye código de producto, NO incluye migraciones funcionales, NO aplica cambios en Supabase.** Es exclusivamente documentación para revisión y aprobación antes de `sdd-apply`.

Issue: [#244](https://github.com/global-ministries/global-connect/issues/244) (`status:approved`, `type:feature`, `priority:high`)

## Artefactos incluidos

| Artefacto | Líneas | Propósito |
|---|---|---|
| `exploration.md` | 412 | Estado actual de Fase 1, brechas detectadas, patrones reutilizables, riesgos |
| `proposal.md` | 324 | PRD con 10 decisiones de producto, 8 edge cases, modelo de datos alto nivel, 15 capabilities |
| `specs/dream-team-domain/spec.md` | 57 | Servicio por experiencia/equipo/rol, múltiples servicios, historial |
| `specs/dream-team-state-machine/spec.md` | 67 | State machine de 6 estados, transiciones forward-only, motivo + audit |
| `specs/dream-team-requirements/spec.md` | 42 | Requisitos configurables (modelo de datos) |
| `specs/dream-team-capabilities-grants/spec.md` | 54 | Modelo híbrido de capabilities + grants lifecycle |
| `specs/dream-team-gdv-adapter/spec.md` | 38 | Adapter separado `dream-team-gdv.ts` (existente intacto) |
| `specs/dream-team-participation-events/spec.md` | 42 | Productor de eventos `service` para `lib/platform/participation.ts` |
| `specs/dream-team-metrics/spec.md` | 44 | Función pura + API route de métricas (sin widget) |
| `design.md` | 279 | Arquitectura técnica, 10 slices encadenados, compatibilidad con Fase 1 |
| `tasks.md` | 209 | 34 tasks concretos por slice (S1-S10), strict TDD RED-first |
| **Total** | **1568** | |

## Caso de validación (Ana)

Ana sirve en DPS / Producción Técnica / Cámara como Voluntario y en Estudiantes / Transit como Líder de grupo. El diseño soporta:
- Múltiples servicios simultáneos con grants por servicio
- Pausa/reactivación independiente con snapshot de grants
- Pérdida de liderazgo GDV → pausa con motivo `gdv_liderazgo_removed` (membresía no afectada)
- Métricas reflejan ambos servicios sin widget en dashboard

## Decisiones cerradas (14)

1. Adapter GDV separado (existente intacto)
2. Asignación solo admin/director
3. Requisitos solo modelo de datos (UI futura)
4. Métricas función pura + API route
5. Participation implementación Supabase completa
6. Transiciones forward-only con motivo + audit
7. GDV liderazgo removido → pausa (membresía no afectada)
8. Requisitos vencidos → alerta sin bloquear
9. Grants al activar
10. Grants en pausa → revocados + snapshot
11. Concurrencia: `version` + chequeo + 409
12. Reasignación: close + open
13. Métricas endpoint
14. RLS: helper Postgres `auth_has_dream_team_capability` + tabla `dream_team_capability_grants`

## Plan de implementación (post-approval)

- 10 slices encadenados stacked-to-main
- 1 sola migración aditiva aplicada a `supabase_global_staging` en S4, ≥7 días antes de producción (decisión final del PR de S4)
- S4 requerirá `size:exception` (~650 líneas: repo Supabase + migración + tests)
- Feature flag `NEXT_PUBLIC_DREAM_TEAM_ENABLED=off` por defecto hasta S10
- Strict TDD activo (`pnpm test`)

## size:exception solicitada

1568 líneas en un solo PR. **Justificación**: los artefactos SDD son interdependientes (exploración → propuesta → specs → diseño → tasks). Partirlos en múltiples PRs perdería coherencia de review y haría imposible verificar la trazabilidad de las decisiones. La práctica del proyecto es agrupar el SDD planning de cada fase en un solo PR (la Fase 1 siguió el mismo patrón). El contenido es documentación; no es código que se ejecute, no aumenta la superficie de tests ni el riesgo de regresión.

## Restricciones respetadas

- NO implementación de producto
- NO migraciones funcionales creadas
- NO aplicación de cambios en Supabase
- NO ejecución de `sdd-apply`
- NO rediseño de Grupos de Vida
- NO uso de `uno_a_uno` (preflight sigue activo)
- NO cambios destructivos en DB

## Próximo paso (post-approval)

`sdd-apply` con S1 (Foundation Pura — `lib/platform/dream-team/{types,errors,state-machine}.ts` + tests, sin DB, ~250 líneas, budget ok).